### PR TITLE
Add deterministic fingerprint and encryption tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ SeedPass allows you to manage multiple seed profiles (previously referred to as 
 
 **Note:** The term "seed profile" is used to represent different sets of seeds you can manage within SeedPass. This provides an intuitive way to handle multiple identities or sets of passwords.
 
+## Running Tests
+
+SeedPass includes a small suite of unit tests. After activating your virtual environment and installing dependencies, run the tests with **pytest**:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
 ## Security Considerations
 
 **Important:** The password you use to encrypt your parent seed is also required to decrypt the seed index data retrieved from Nostr. **It is imperative to remember this password** and be sure to use it with the same seed, as losing it means you won't be able to access your stored index. Secure your 12-word seed **and** your master password.

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,3 +8,5 @@ mnemonic
 aiohttp
 bcrypt
 bip85
+pytest>=7.0
+

--- a/src/tests/test_fingerprint_encryption.py
+++ b/src/tests/test_fingerprint_encryption.py
@@ -1,0 +1,38 @@
+import hashlib
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from cryptography.fernet import Fernet
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.fingerprint import generate_fingerprint
+from password_manager.encryption import EncryptionManager
+
+
+def test_generate_fingerprint_deterministic():
+    seed = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    expected = (
+        hashlib.sha256(seed.strip().lower().encode("utf-8")).hexdigest()[:16].upper()
+    )
+    fp1 = generate_fingerprint(seed)
+    fp2 = generate_fingerprint(seed.upper())
+    assert fp1 == expected
+    assert fp1 == fp2
+
+
+def test_encryption_round_trip():
+    with TemporaryDirectory() as tmpdir:
+        key = Fernet.generate_key()
+        manager = EncryptionManager(key, Path(tmpdir))
+        data = b"secret data"
+        rel_path = Path("testfile.enc")
+        manager.encrypt_and_save_file(data, rel_path)
+        decrypted = manager.decrypt_file(rel_path)
+        assert decrypted == data
+
+        # parent seed round trip
+        seed = "correct horse battery staple"
+        manager.encrypt_parent_seed(seed)
+        assert manager.decrypt_parent_seed() == seed


### PR DESCRIPTION
## Summary
- add new unit tests covering fingerprint generation and encryption round trips
- update documentation with testing instructions
- add pytest to requirements for running the test suite

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68607b7cdfa8832bbad2129aa3837046