### PR TITLE
Add relay management settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,15 @@ wss://nostr.oxtr.dev
 wss://relay.primal.net
 ```
 
-You can update the relay list or change the PIN through the **Settings** menu:
+You can manage the relay list or change the PIN through the **Settings** menu:
 
 1. From the main menu, choose option `13` (**Settings**).
-2. Select `1` to enter a comma-separated list of relay URLs.
-3. Choose `2` to change the settings PIN.
-4. Select `3` to go back to the main menu.
+2. Select `1` to view your current relays.
+3. Choose `2` to add a new relay URL.
+4. Select `3` to remove a relay by number.
+5. Choose `4` to reset to the default relay list.
+6. Select `5` to change the settings PIN.
+7. Choose `6` to return to the main menu.
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- expand Settings menu to manage Nostr relays
- allow users to view, add, remove, and reset relays
- persist relay changes via ConfigManager
- document new Settings menu workflow

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68615dc39148832b938c8f42c00a3ccf