### PR TITLE
Enforce relay presence and backup index

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -296,6 +296,10 @@ def handle_add_relay(password_manager: PasswordManager) -> None:
         cfg_mgr.set_relays(relays)
         _reload_relays(password_manager, relays)
         print(colored("Relay added.", "green"))
+        try:
+            handle_post_to_nostr(password_manager)
+        except Exception as backup_error:
+            logging.error(f"Failed to backup index to Nostr: {backup_error}")
     except Exception as e:
         logging.error(f"Error adding relay: {e}")
         print(colored(f"Error: {e}", "red"))
@@ -318,6 +322,14 @@ def handle_remove_relay(password_manager: PasswordManager) -> None:
         choice = input("Select relay number to remove: ").strip()
         if not choice.isdigit() or not (1 <= int(choice) <= len(relays)):
             print(colored("Invalid selection.", "red"))
+            return
+        if len(relays) == 1:
+            print(
+                colored(
+                    "At least one relay must be configured. Add another before removing this one.",
+                    "red",
+                )
+            )
             return
         relays.pop(int(choice) - 1)
         cfg_mgr.set_relays(relays)

--- a/src/password_manager/config_manager.py
+++ b/src/password_manager/config_manager.py
@@ -68,6 +68,8 @@ class ConfigManager:
 
     def set_relays(self, relays: List[str], require_pin: bool = True) -> None:
         """Update relay list and save."""
+        if not relays:
+            raise ValueError("At least one Nostr relay must be configured")
         config = self.load_config(require_pin=require_pin)
         config["relays"] = relays
         self.save_config(config)

--- a/src/tests/test_config_manager.py
+++ b/src/tests/test_config_manager.py
@@ -2,6 +2,7 @@ import bcrypt
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from cryptography.fernet import Fernet
+import pytest
 import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -67,7 +68,15 @@ def test_set_relays_persists_changes():
         key = Fernet.generate_key()
         enc_mgr = EncryptionManager(key, Path(tmpdir))
         cfg_mgr = ConfigManager(enc_mgr, Path(tmpdir))
-
         cfg_mgr.set_relays(["wss://custom"], require_pin=False)
         cfg = cfg_mgr.load_config(require_pin=False)
         assert cfg["relays"] == ["wss://custom"]
+
+
+def test_set_relays_requires_at_least_one():
+    with TemporaryDirectory() as tmpdir:
+        key = Fernet.generate_key()
+        enc_mgr = EncryptionManager(key, Path(tmpdir))
+        cfg_mgr = ConfigManager(enc_mgr, Path(tmpdir))
+        with pytest.raises(ValueError):
+            cfg_mgr.set_relays([], require_pin=False)


### PR DESCRIPTION
## Summary
- prevent empty relay lists in ConfigManager
- block removing the final relay via the settings menu
- backup the encrypted index to Nostr when adding new relays
- test that at least one relay is required

## Testing
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686173dc44c4832ba5776f752e41f2c2