### PR TITLE
Shorten menu options

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ python src/main.py
 
    ```
    Select an option:
-   1. Generate a New Password and Add to Index
-   2. Retrieve a Password from Index
+   1. Generate Password
+   2. Retrieve Password
    3. Modify an Existing Entry
    4. Verify Script Checksum
-   5. Post Encrypted Index to Nostr
-   6. Retrieve Encrypted Index from Nostr
+   5. Backup to Nostr
+   6. Restore from Nostr
    7. Display Nostr Public Key (npub)
    8. Backup/Reveal Parent Seed
    9. Switch Seed Profile

--- a/landing/_pgbackup/index_1730048875.html
+++ b/landing/_pgbackup/index_1730048875.html
@@ -121,12 +121,12 @@ Enter your master password:
 Fingerprint 31DD880A523B9759 selected and managers initialized.
 
     Select an option:
-    1. Generate a New Password and Add to Index
-    2. Retrieve a Password from Index
+    1. Generate Password
+    2. Retrieve Password
     3. Modify an Existing Entry
     4. Verify Script Checksum
-    5. Post Encrypted Index to Nostr
-    6. Retrieve Encrypted Index from Nostr
+    5. Backup to Nostr
+    6. Restore from Nostr
     7. Display Nostr Public Key (npub)
     8. Backup/Reveal Parent Seed
     9. Switch Fingerprint

--- a/landing/_pgbackup/index_1730049869.html
+++ b/landing/_pgbackup/index_1730049869.html
@@ -118,12 +118,12 @@ Enter your master password:
 Fingerprint 31DD880A523B9759 selected and managers initialized.
 
     Select an option:
-    1. Generate a New Password and Add to Index
-    2. Retrieve a Password from Index
+    1. Generate Password
+    2. Retrieve Password
     3. Modify an Existing Entry
     4. Verify Script Checksum
-    5. Post Encrypted Index to Nostr
-    6. Retrieve Encrypted Index from Nostr
+    5. Backup to Nostr
+    6. Restore from Nostr
     7. Display Nostr Public Key (npub)
     8. Backup/Reveal Parent Seed
     9. Switch Fingerprint

--- a/landing/index.html
+++ b/landing/index.html
@@ -113,12 +113,12 @@ Enter your master password:
 Fingerprint 31DD880A523B9759 selected and managers initialized.
 
     Select an option:
-    1. Generate a New Password and Add to Index
-    2. Retrieve a Password from Index
+    1. Generate Password
+    2. Retrieve Password
     3. Modify an Existing Entry
     4. Verify Script Checksum
-    5. Post Encrypted Index to Nostr
-    6. Retrieve Encrypted Index from Nostr
+    5. Backup to Nostr
+    6. Restore from Nostr
     7. Display Nostr Public Key (npub)
     8. Backup/Reveal Parent Seed
     9. Switch Fingerprint

--- a/src/main.py
+++ b/src/main.py
@@ -400,12 +400,12 @@ def display_menu(password_manager: PasswordManager):
     """
     menu = """
     Select an option:
-    1. Generate a New Password and Add to Index
-    2. Retrieve a Password from Index
+    1. Generate Password
+    2. Retrieve Password
     3. Modify an Existing Entry
     4. Verify Script Checksum
-    5. Post Encrypted Index to Nostr
-    6. Retrieve Encrypted Index from Nostr
+    5. Backup to Nostr
+    6. Restore from Nostr
     7. Display Nostr Public Key (npub)
     8. Backup/Reveal Parent Seed
     9. Switch Seed Profile


### PR DESCRIPTION
## Summary
- simplify the menu option text in `src/main.py`
- update README example menu
- sync HTML menu text with new wording

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686185a9b890832bb9e52f5a66120c68