### PR TITLE
Revise menu and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,19 +125,17 @@ python src/main.py
    1. Generate Password
    2. Retrieve Password
    3. Modify an Existing Entry
-   4. Verify Script Checksum
-   5. Backup to Nostr
-   6. Restore from Nostr
-   7. Display Nostr Public Key (npub)
-   8. Backup/Reveal Parent Seed
-   9. Switch Seed Profile
-   10. Add a New Seed Profile
-   11. Remove an Existing Seed Profile
-   12. List All Seed Profiles
-   13. Settings
-   14. Exit
+   4. Backup to Nostr
+   5. Restore from Nostr
+   6. Backup/Reveal Parent Seed
+   7. Switch Seed Profile
+   8. Add a New Seed Profile
+   9. Remove an Existing Seed Profile
+   10. List All Seed Profiles
+   11. Settings
+   12. Exit
 
-   Enter your choice (1-14):
+   Enter your choice (1-12):
    ```
 
 ### Managing Multiple Seeds
@@ -145,18 +143,18 @@ python src/main.py
 SeedPass allows you to manage multiple seed profiles (previously referred to as "fingerprints"). Each seed profile has its own parent seed and associated data, enabling you to compartmentalize your passwords.
 
 - **Add a New Seed Profile:**
-  - Select option `10` from the main menu.
+  - Select option `8` from the main menu.
   - Choose to enter an existing seed or generate a new one.
   - If generating a new seed, you'll be provided with a 12-word BIP-85 seed phrase. **Ensure you write this down and store it securely.**
 
 - **Switch Between Seed Profiles:**
-  - Select option `9` from the main menu.
+  - Select option `7` from the main menu.
   - You'll see a list of available seed profiles.
   - Enter the number corresponding to the seed profile you wish to switch to.
   - Enter the master password associated with that seed profile.
 
 - **List All Seed Profiles:**
-  - Select option `12` from the main menu to view all existing seed profiles.
+  - Select option `10` from the main menu to view all existing seed profiles.
 
 **Note:** The term "seed profile" is used to represent different sets of seeds you can manage within SeedPass. This provides an intuitive way to handle multiple identities or sets of passwords.
 
@@ -172,13 +170,15 @@ wss://relay.primal.net
 
 You can manage the relay list or change the PIN through the **Settings** menu:
 
-1. From the main menu, choose option `13` (**Settings**).
+1. From the main menu, choose option `11` (**Settings**).
 2. Select `1` to view your current relays.
 3. Choose `2` to add a new relay URL.
 4. Select `3` to remove a relay by number.
 5. Choose `4` to reset to the default relay list.
 6. Select `5` to change the settings PIN.
-7. Choose `6` to return to the main menu.
+7. Choose `6` to display your Nostr public key.
+8. Select `7` to verify the script checksum.
+9. Choose `8` to return to the main menu.
 
 ## Running Tests
 

--- a/landing/_pgbackup/index_1730048875.html
+++ b/landing/_pgbackup/index_1730048875.html
@@ -124,16 +124,14 @@ Fingerprint 31DD880A523B9759 selected and managers initialized.
     1. Generate Password
     2. Retrieve Password
     3. Modify an Existing Entry
-    4. Verify Script Checksum
-    5. Backup to Nostr
-    6. Restore from Nostr
-    7. Display Nostr Public Key (npub)
-    8. Backup/Reveal Parent Seed
-    9. Switch Fingerprint
-    10. Add a New Fingerprint
-    11. Remove an Existing Fingerprint
-    12. List All Fingerprints
-    13. Exit
+    4. Backup to Nostr
+    5. Restore from Nostr
+    6. Backup/Reveal Parent Seed
+    7. Switch Fingerprint
+    8. Add a New Fingerprint
+    9. Remove an Existing Fingerprint
+    10. List All Fingerprints
+    11. Exit
 
 Enter your choice (1-13): 1
 Enter the website name: newsitename

--- a/landing/_pgbackup/index_1730049869.html
+++ b/landing/_pgbackup/index_1730049869.html
@@ -121,18 +121,16 @@ Fingerprint 31DD880A523B9759 selected and managers initialized.
     1. Generate Password
     2. Retrieve Password
     3. Modify an Existing Entry
-    4. Verify Script Checksum
-    5. Backup to Nostr
-    6. Restore from Nostr
-    7. Display Nostr Public Key (npub)
-    8. Backup/Reveal Parent Seed
-    9. Switch Fingerprint
-    10. Add a New Fingerprint
-    11. Remove an Existing Fingerprint
-    12. List All Fingerprints
-    13. Exit
+    4. Backup to Nostr
+    5. Restore from Nostr
+    6. Backup/Reveal Parent Seed
+    7. Switch Fingerprint
+    8. Add a New Fingerprint
+    9. Remove an Existing Fingerprint
+    10. List All Fingerprints
+    11. Exit
 
-Enter your choice (1-13): 1
+Enter your choice (1-11): 1
 Enter the website name: newsitename
 Enter the username (optional): 
 Enter the URL (optional): 

--- a/landing/index.html
+++ b/landing/index.html
@@ -116,18 +116,16 @@ Fingerprint 31DD880A523B9759 selected and managers initialized.
     1. Generate Password
     2. Retrieve Password
     3. Modify an Existing Entry
-    4. Verify Script Checksum
-    5. Backup to Nostr
-    6. Restore from Nostr
-    7. Display Nostr Public Key (npub)
-    8. Backup/Reveal Parent Seed
-    9. Switch Fingerprint
-    10. Add a New Fingerprint
-    11. Remove an Existing Fingerprint
-    12. List All Fingerprints
-    13. Exit
+    4. Backup to Nostr
+    5. Restore from Nostr
+    6. Backup/Reveal Parent Seed
+    7. Switch Fingerprint
+    8. Add a New Fingerprint
+    9. Remove an Existing Fingerprint
+    10. List All Fingerprints
+    11. Exit
 
-Enter your choice (1-13): 1
+Enter your choice (1-11): 1
 Enter the website name: newsitename
 Enter the username (optional): 
 Enter the URL (optional): 

--- a/src/main.py
+++ b/src/main.py
@@ -376,7 +376,9 @@ def handle_settings(password_manager: PasswordManager) -> None:
         print("3. Remove a relay by number")
         print("4. Reset to default relays")
         print("5. Change password")
-        print("6. Back")
+        print("6. Display Nostr Public Key")
+        print("7. Verify Script Checksum")
+        print("8. Back")
         choice = input("Select an option: ").strip()
         if choice == "1":
             handle_view_relays(cfg_mgr)
@@ -389,6 +391,10 @@ def handle_settings(password_manager: PasswordManager) -> None:
         elif choice == "5":
             password_manager.change_password()
         elif choice == "6":
+            handle_display_npub(password_manager)
+        elif choice == "7":
+            password_manager.handle_verify_checksum()
+        elif choice == "8":
             break
         else:
             print(colored("Invalid choice.", "red"))
@@ -403,28 +409,26 @@ def display_menu(password_manager: PasswordManager):
     1. Generate Password
     2. Retrieve Password
     3. Modify an Existing Entry
-    4. Verify Script Checksum
-    5. Backup to Nostr
-    6. Restore from Nostr
-    7. Display Nostr Public Key (npub)
-    8. Backup/Reveal Parent Seed
-    9. Switch Seed Profile
-    10. Add a New Seed Profile
-    11. Remove an Existing Seed Profile
-    12. List All Seed Profiles
-    13. Settings
-    14. Exit
+    4. Backup to Nostr
+    5. Restore from Nostr
+    6. Backup/Reveal Parent Seed
+    7. Switch Seed Profile
+    8. Add a New Seed Profile
+    9. Remove an Existing Seed Profile
+    10. List All Seed Profiles
+    11. Settings
+    12. Exit
     """
     while True:
         # Flush logging handlers
         for handler in logging.getLogger().handlers:
             handler.flush()
         print(colored(menu, "cyan"))
-        choice = input("Enter your choice (1-14): ").strip()
+        choice = input("Enter your choice (1-12): ").strip()
         if not choice:
             print(
                 colored(
-                    "No input detected. Please enter a number between 1 and 14.",
+                    "No input detected. Please enter a number between 1 and 12.",
                     "yellow",
                 )
             )
@@ -436,27 +440,23 @@ def display_menu(password_manager: PasswordManager):
         elif choice == "3":
             password_manager.handle_modify_entry()
         elif choice == "4":
-            password_manager.handle_verify_checksum()
-        elif choice == "5":
             handle_post_to_nostr(password_manager)
-        elif choice == "6":
+        elif choice == "5":
             handle_retrieve_from_nostr(password_manager)
-        elif choice == "7":
-            handle_display_npub(password_manager)
-        elif choice == "8":
+        elif choice == "6":
             password_manager.handle_backup_reveal_parent_seed()
-        elif choice == "9":
+        elif choice == "7":
             if not password_manager.handle_switch_fingerprint():
                 print(colored("Failed to switch seed profile.", "red"))
-        elif choice == "10":
+        elif choice == "8":
             handle_add_new_fingerprint(password_manager)
-        elif choice == "11":
+        elif choice == "9":
             handle_remove_fingerprint(password_manager)
-        elif choice == "12":
+        elif choice == "10":
             handle_list_fingerprints(password_manager)
-        elif choice == "13":
+        elif choice == "11":
             handle_settings(password_manager)
-        elif choice == "14":
+        elif choice == "12":
             logging.info("Exiting the program.")
             print(colored("Exiting the program.", "green"))
             password_manager.nostr_client.close_client_pool()


### PR DESCRIPTION
## Summary
- streamline the interactive menu by removing checksum and npub options
- update settings menu with display npub and verify checksum actions
- document revised menus and settings flow
- sync example output in landing pages

## Testing
- `black src/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68618790a528832ba04bbd73a27281b7