### PR TITLE
Update menu wording for entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ python src/main.py
 
    ```
    Select an option:
-   1. Generate Password
-   2. Retrieve Password
+   1. Add Entry
+   2. Retrieve Entry
    3. Modify an Existing Entry
     4. Backup to Nostr
     5. Restore from Nostr

--- a/landing/index.html
+++ b/landing/index.html
@@ -113,8 +113,8 @@ Enter your master password:
 Fingerprint 31DD880A523B9759 selected and managers initialized.
 
     Select an option:
-    1. Generate Password
-    2. Retrieve Password
+    1. Add Entry
+    2. Retrieve Entry
     3. Modify an Existing Entry
     4. Backup to Nostr
     5. Restore from Nostr

--- a/src/main.py
+++ b/src/main.py
@@ -409,8 +409,8 @@ def display_menu(password_manager: PasswordManager):
     """
     menu = """
     Select an option:
-    1. Generate Password
-    2. Retrieve Password
+    1. Add Entry
+    2. Retrieve Entry
     3. Modify an Existing Entry
     4. Backup to Nostr
     5. Restore from Nostr
@@ -436,9 +436,20 @@ def display_menu(password_manager: PasswordManager):
             )
             continue  # Re-display the menu without marking as invalid
         if choice == "1":
-            password_manager.handle_generate_password()
+            while True:
+                print("\nAdd Entry:")
+                print("1. Password")
+                print("2. Back")
+                sub_choice = input("Select entry type: ").strip()
+                if sub_choice == "1":
+                    password_manager.handle_add_password()
+                    break
+                elif sub_choice == "2":
+                    break
+                else:
+                    print(colored("Invalid choice.", "red"))
         elif choice == "2":
-            password_manager.handle_retrieve_password()
+            password_manager.handle_retrieve_entry()
         elif choice == "3":
             password_manager.handle_modify_entry()
         elif choice == "4":

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -697,7 +697,7 @@ class PasswordManager:
         except Exception as e:
             logger.warning(f"Unable to sync index from Nostr: {e}")
 
-    def handle_generate_password(self) -> None:
+    def handle_add_password(self) -> None:
         try:
             website_name = input("Enter the website name: ").strip()
             if not website_name:
@@ -746,7 +746,7 @@ class PasswordManager:
             logging.error(traceback.format_exc())
             print(colored(f"Error: Failed to generate password: {e}", "red"))
 
-    def handle_retrieve_password(self) -> None:
+    def handle_retrieve_entry(self) -> None:
         """
         Handles retrieving a password from the index by prompting the user for the index number
         and displaying the corresponding password and associated details.
@@ -1208,8 +1208,8 @@ if __name__ == "__main__":
 
     # Example operations
     # These would typically be triggered by user interactions, e.g., via a CLI menu
-    # manager.handle_generate_password()
-    # manager.handle_retrieve_password()
+    # manager.handle_add_password()
+    # manager.handle_retrieve_entry()
     # manager.handle_modify_entry()
     # manager.handle_verify_checksum()
     # manager.nostr_client.publish_and_subscribe("Sample password data")


### PR DESCRIPTION
## Summary
- rename password actions to use entry wording
- provide sub-menu for adding a password entry
- update example menu in README and landing page

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68618c5fffcc832bb0bf43a0794a7d24