### PR TITLE
Add coverage workflow for CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -14,9 +14,23 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - name: Install dependencies
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('src/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Set up Python dependencies
+        id: deps
         run: |
           python -m pip install --upgrade pip
           pip install -r src/requirements.txt
-      - name: Test with pytest
-        run: pytest -q src/tests
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=src --cov-report=xml --cov-report=term-missing src/tests
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-xml
+          path: coverage.xml

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -9,4 +9,5 @@ aiohttp
 bcrypt
 bip85
 pytest>=7.0
+pytest-cov
 


### PR DESCRIPTION
## Summary
- install pytest-cov for coverage reporting
- cache pip dependencies in CI
- run pytest with coverage and upload XML report

## Testing
- `pytest --cov=src --cov-report=term-missing -q src/tests`

------
https://chatgpt.com/codex/tasks/task_b_686190a26bd4832b9929412a32eead69