### PR TITLE
Improve CI coverage gating

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -31,7 +31,7 @@ jobs:
           pytest --cov=src --cov-report=xml --cov-report=term-missing \
             --cov-fail-under=20 src/tests
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-xml
           path: coverage.xml

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "**" ]
 
 jobs:
   build:
@@ -28,7 +28,8 @@ jobs:
           pip install -r src/requirements.txt
       - name: Run tests with coverage
         run: |
-          pytest --cov=src --cov-report=xml --cov-report=term-missing src/tests
+          pytest --cov=src --cov-report=xml --cov-report=term-missing \
+            --cov-fail-under=20 src/tests
       - name: Upload coverage report
         uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ Thumbs.db
 # Python env
 .env
 *.env
+
+# Coverage files
+.coverage
+coverage.xml


### PR DESCRIPTION
## Summary
- trigger CI on all branches and PRs
- gate tests on minimum coverage
- ignore generated coverage files

## Testing
- `pytest --cov=src --cov-report=term-missing --cov-fail-under=20 src/tests`

------
https://chatgpt.com/codex/tasks/task_b_6861942cce48832bb87a379e554e2e64