### PR TITLE
Add test for seed encryption round trip

### DIFF
--- a/tests/test_seed_import.py
+++ b/tests/test_seed_import.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from cryptography.fernet import Fernet
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.encryption import EncryptionManager
+from password_manager.manager import PasswordManager
+
+SEED = "guard rule huge draft embark case any drastic horse bargain orchard mobile"
+
+
+def test_seed_encryption_round_trip():
+    with TemporaryDirectory() as tmpdir:
+        key = Fernet.generate_key()
+        enc_mgr = EncryptionManager(key, Path(tmpdir))
+
+        enc_mgr.encrypt_parent_seed(SEED)
+        decrypted = enc_mgr.decrypt_parent_seed()
+
+        assert decrypted == SEED
+        pm = PasswordManager.__new__(PasswordManager)
+        assert pm.validate_bip85_seed(SEED)


### PR DESCRIPTION
## Summary
- add a new unit test for encrypting and decrypting a seed

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68619e487c5c832bbdda3de7320460ac