### PR TITLE
Generate random BIP‑39 seed for encryption test

### DIFF
--- a/tests/test_seed_import.py
+++ b/tests/test_seed_import.py
@@ -2,13 +2,12 @@ import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from cryptography.fernet import Fernet
+from mnemonic import Mnemonic
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from password_manager.encryption import EncryptionManager
 from password_manager.manager import PasswordManager
-
-SEED = "guard rule huge draft embark case any drastic horse bargain orchard mobile"
 
 
 def test_seed_encryption_round_trip():
@@ -16,9 +15,10 @@ def test_seed_encryption_round_trip():
         key = Fernet.generate_key()
         enc_mgr = EncryptionManager(key, Path(tmpdir))
 
-        enc_mgr.encrypt_parent_seed(SEED)
+        seed = Mnemonic("english").generate(strength=128)
+        enc_mgr.encrypt_parent_seed(seed)
         decrypted = enc_mgr.decrypt_parent_seed()
 
-        assert decrypted == SEED
+        assert decrypted == seed
         pm = PasswordManager.__new__(PasswordManager)
-        assert pm.validate_bip85_seed(SEED)
+        assert pm.validate_bip85_seed(seed)


### PR DESCRIPTION
## Summary
- avoid using a hard-coded seed in `test_seed_import.py`
- generate a fresh 12-word BIP‑39 seed with `mnemonic`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861a0adc804832bbc921f813da38b00