### PR TITLE
Add test for empty entry manager

### DIFF
--- a/tests/test_entries_empty.py
+++ b/tests/test_entries_empty.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from cryptography.fernet import Fernet
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.encryption import EncryptionManager
+from password_manager.entry_management import EntryManager
+
+
+def test_list_entries_empty():
+    with TemporaryDirectory() as tmpdir:
+        key = Fernet.generate_key()
+        enc_mgr = EncryptionManager(key, Path(tmpdir))
+        entry_mgr = EntryManager(enc_mgr, Path(tmpdir))
+
+        entries = entry_mgr.list_entries()
+        assert entries == []


### PR DESCRIPTION
## Summary
- add regression test ensuring that `EntryManager.list_entries()` returns an empty list when no index is present

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6861a2e07848832b8145020c2b2766fc