### PR TITLE
Add encryption file tests

### DIFF
--- a/src/tests/test_encryption_files.py
+++ b/src/tests/test_encryption_files.py
@@ -1,0 +1,41 @@
+import json
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from cryptography.fernet import Fernet
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.encryption import EncryptionManager
+
+
+def test_json_save_and_load_round_trip():
+    with TemporaryDirectory() as tmpdir:
+        key = Fernet.generate_key()
+        manager = EncryptionManager(key, Path(tmpdir))
+
+        data = {"hello": "world", "nums": [1, 2, 3]}
+        manager.save_json_data(data)
+        loaded = manager.load_json_data()
+        assert loaded == data
+
+        file_path = Path(tmpdir) / "seedpass_passwords_db.json.enc"
+        raw = file_path.read_bytes()
+        assert raw != json.dumps(data, indent=4).encode("utf-8")
+
+
+def test_encrypt_and_decrypt_file_binary_round_trip():
+    with TemporaryDirectory() as tmpdir:
+        key = Fernet.generate_key()
+        manager = EncryptionManager(key, Path(tmpdir))
+
+        payload = b"binary secret"
+        rel = Path("payload.bin.enc")
+        manager.encrypt_and_save_file(payload, rel)
+        decrypted = manager.decrypt_file(rel)
+        assert decrypted == payload
+
+        file_path = Path(tmpdir) / rel
+        raw = file_path.read_bytes()
+        assert raw != payload


### PR DESCRIPTION
## Summary
- add tests for encryption file operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6861ae40c0bc832bbc305ddfdb9ba891