### PR TITLE
Fix Windows workflow matrix

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.11"]
+        exclude:
+          - os: windows-latest
+            python-version: "3.11"
         include:
           - os: windows-latest
             python-version: "3.10"


### PR DESCRIPTION
## Summary
- exclude CPython 3.11 from the Windows job and run 3.10 instead

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest -q src/tests`

------
https://chatgpt.com/codex/tasks/task_b_6861db82b770832b95efc5ccef80697d