### PR TITLE
Fix file lock timing test on slower platforms

### DIFF
--- a/src/tests/test_file_lock.py
+++ b/src/tests/test_file_lock.py
@@ -37,4 +37,7 @@ def test_exclusive_lock_blocks_until_released(tmp_path: Path):
     p2.join()
 
     # CI runners can be jittery; allow generous slack around the 1s lock hold time
-    assert wait_time.value == pytest.approx(1.0, abs=0.4)
+    # Different operating systems spawn processes at slightly different speeds
+    # which can shift the measured wait time by a few hundred milliseconds. A
+    # wider tolerance keeps the test stable across platforms.
+    assert wait_time.value == pytest.approx(1.0, abs=0.5)


### PR DESCRIPTION
## Summary
- relax tolerance in `test_file_lock` so slower process startup on macOS and Windows doesn't break the test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861dd91fa3c832b8dc347e1e6468a2e