### PR TITLE
Add logging-enabled tests and pytest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ You can manage the relay list or change the PIN through the **Settings** menu:
 
 ## Running Tests
 
-SeedPass includes a small suite of unit tests. After activating your virtual environment and installing dependencies, run the tests with **pytest**:
+SeedPass includes a small suite of unit tests. After activating your virtual environment and installing dependencies, run the tests with **pytest**. Use `-vv` to see INFO-level log messages from each passing test:
 
 ```bash
 pip install -r src/requirements.txt
-pytest
+pytest -vv
 ```
 
 ## Security Considerations

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+log_cli = true
+log_cli_level = INFO

--- a/src/tests/test_key_derivation.py
+++ b/src/tests/test_key_derivation.py
@@ -1,0 +1,18 @@
+import logging
+import pytest
+from utils.key_derivation import derive_key_from_password
+
+
+def test_derive_key_deterministic():
+    password = "correct horse battery staple"
+    key1 = derive_key_from_password(password, iterations=1)
+    key2 = derive_key_from_password(password, iterations=1)
+    assert key1 == key2
+    assert len(key1) == 44
+    logging.info("Deterministic key derivation succeeded")
+
+
+def test_derive_key_empty_password_error():
+    with pytest.raises(ValueError):
+        derive_key_from_password("")
+    logging.info("Empty password correctly raised ValueError")


### PR DESCRIPTION
## Summary
- enable CLI logging for pytest
- cover key derivation helper with unit tests
- explain running tests with `pytest -vv` in documentation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6861fe2cc2f8832bbc4c8f03c2004b80