### PR TITLE
Implement automatic Nostr sync

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ import sys
 import logging
 import signal
 import getpass
+import time
 from colorama import init as colorama_init
 from termcolor import colored
 import traceback
@@ -453,7 +454,7 @@ def handle_settings(password_manager: PasswordManager) -> None:
             print(colored("Invalid choice.", "red"))
 
 
-def display_menu(password_manager: PasswordManager):
+def display_menu(password_manager: PasswordManager, sync_interval: float = 60.0):
     """
     Displays the interactive menu and handles user input to perform various actions.
     """
@@ -466,6 +467,14 @@ def display_menu(password_manager: PasswordManager):
     5. Exit
     """
     while True:
+        # Periodically push updates to Nostr
+        if (
+            password_manager.is_dirty
+            and time.time() - password_manager.last_update >= sync_interval
+        ):
+            handle_post_to_nostr(password_manager)
+            password_manager.is_dirty = False
+
         # Flush logging handlers
         for handler in logging.getLogger().handlers:
             handler.flush()

--- a/src/tests/test_auto_sync.py
+++ b/src/tests/test_auto_sync.py
@@ -1,0 +1,36 @@
+import time
+from types import SimpleNamespace
+from pathlib import Path
+import pytest
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import main
+
+
+def test_auto_sync_triggers_post(monkeypatch):
+    pm = SimpleNamespace(
+        is_dirty=True,
+        last_update=time.time() - 0.2,
+        nostr_client=SimpleNamespace(close_client_pool=lambda: None),
+        handle_add_password=lambda: None,
+        handle_retrieve_entry=lambda: None,
+        handle_modify_entry=lambda: None,
+    )
+
+    called = False
+
+    def fake_post(manager):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(main, "handle_post_to_nostr", fake_post)
+    monkeypatch.setattr("builtins.input", lambda _: "5")
+
+    with pytest.raises(SystemExit):
+        main.display_menu(pm, sync_interval=0.1)
+
+    assert called
+    assert pm.is_dirty is False


### PR DESCRIPTION
## Summary
- track modification state in `PasswordManager`
- periodically push updates to Nostr from `display_menu`
- unit test auto-sync behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68620c41ae5c832b82469203d4e71d5d