### PR TITLE
Fix duplicate JSON load message

### DIFF
--- a/src/password_manager/encryption.py
+++ b/src/password_manager/encryption.py
@@ -302,9 +302,6 @@ class EncryptionManager:
             json_content = decrypted_data.decode("utf-8").strip()
             data = json.loads(json_content)
             logger.debug(f"JSON data loaded and decrypted from '{file_path}': {data}")
-            print(
-                colored(f"JSON data loaded and decrypted from '{file_path}'.", "green")
-            )
             return data
         except json.JSONDecodeError as e:
             logger.error(f"Failed to decode JSON data from '{file_path}': {e}")


### PR DESCRIPTION
## Summary
- remove extra `print` from `load_json_data`

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `black src/password_manager/encryption.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862b89123cc832baf85322396682ffe