### PR TITLE
Fix relay connection issue

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -12,5 +12,5 @@ pytest>=7.0
 pytest-cov
 portalocker>=2.8
 pynostr>=0.6.2
-websocket-client
+websocket-client==1.7.0
 


### PR DESCRIPTION
## Summary
- pin `websocket-client` to `1.7.0` to keep compatibility with `pynostr`

## Testing
- `black .`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686339b1674c832ba0d73d331ed66407