### PR TITLE
Fix Nostr event retrieval

### DIFF
--- a/src/nostr/client.py
+++ b/src/nostr/client.py
@@ -101,7 +101,7 @@ class NostrClient:
                 flt = flt.limit(f["limit"])
 
             events = await self.client_pool.fetch_events(flt, Duration(seconds=timeout))
-            for evt in events:
+            for evt in events.to_vec():
                 handler(self.client_pool, "0", evt)
 
     def subscribe(


### PR DESCRIPTION
## Summary
- fix iteration over nostr events by using `to_vec`

## Testing
- `black src/nostr/client.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68634de0fb1c832bba5c6cc0bb8ea4f0