### PR TITLE
Fix Nostr publish logging

### DIFF
--- a/src/nostr/client.py
+++ b/src/nostr/client.py
@@ -100,8 +100,13 @@ class NostrClient:
             )
 
             # Send the event using the client
-            event_id = self.publish_event(event)
-            logger.info(f"Successfully published event with ID: {event_id.to_hex()}")
+            event_output = self.publish_event(event)
+            event_id_hex = (
+                event_output.id.to_hex()
+                if hasattr(event_output, "id")
+                else str(event_output)
+            )
+            logger.info(f"Successfully published event with ID: {event_id_hex}")
             return True
 
         except Exception as e:

--- a/src/tests/test_publish_json_result.py
+++ b/src/tests/test_publish_json_result.py
@@ -44,12 +44,24 @@ class FakeBuilder:
         return FakeUnsignedEvent()
 
 
+class FakeEventId:
+    def to_hex(self):
+        return "abcd"
+
+
+class FakeSendEventOutput:
+    def __init__(self):
+        self.id = FakeEventId()
+
+
 def test_publish_json_success():
     with TemporaryDirectory() as tmpdir, patch(
         "nostr.client.EventBuilder.text_note", return_value=FakeBuilder()
     ):
         client = setup_client(Path(tmpdir))
-        with patch.object(client, "publish_event") as mock_pub:
+        with patch.object(
+            client, "publish_event", return_value=FakeSendEventOutput()
+        ) as mock_pub:
             assert client.publish_json_to_nostr(b"data") is True
             mock_pub.assert_called()
 


### PR DESCRIPTION
## Summary
- fix logging after publishing events with new nostr-sdk return type
- update publish_json tests for SendEventOutput

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68635b8e3994832b802b1856fe36227e