### PR TITLE
Auto backup after password change

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -206,7 +206,9 @@ def handle_display_npub(password_manager: PasswordManager):
         print(colored(f"Error: Failed to display npub: {e}", "red"))
 
 
-def handle_post_to_nostr(password_manager: PasswordManager):
+def handle_post_to_nostr(
+    password_manager: PasswordManager, alt_summary: str | None = None
+):
     """
     Handles the action of posting the encrypted password index to Nostr.
     """
@@ -216,7 +218,8 @@ def handle_post_to_nostr(password_manager: PasswordManager):
         if encrypted_data:
             # Post to Nostr
             success = password_manager.nostr_client.publish_json_to_nostr(
-                encrypted_data
+                encrypted_data,
+                alt_summary=alt_summary,
             )
             if success:
                 print(colored("\N{WHITE HEAVY CHECK MARK} Sync complete.", "green"))

--- a/src/tests/test_password_change.py
+++ b/src/tests/test_password_change.py
@@ -15,7 +15,7 @@ from password_manager.vault import Vault
 from password_manager.manager import PasswordManager
 
 
-def test_change_password_does_not_trigger_nostr_backup(monkeypatch):
+def test_change_password_triggers_nostr_backup(monkeypatch):
     with TemporaryDirectory() as tmpdir:
         fp = Path(tmpdir)
         enc_mgr = EncryptionManager(Fernet.generate_key(), fp)
@@ -46,4 +46,4 @@ def test_change_password_does_not_trigger_nostr_backup(monkeypatch):
             mock_instance = MockClient.return_value
             pm.nostr_client = mock_instance
             pm.change_password()
-            mock_instance.publish_json_to_nostr.assert_not_called()
+            mock_instance.publish_json_to_nostr.assert_called_once()

--- a/src/tests/test_post_sync_messages.py
+++ b/src/tests/test_post_sync_messages.py
@@ -10,7 +10,9 @@ import main
 def test_handle_post_success(capsys):
     pm = SimpleNamespace(
         get_encrypted_data=lambda: b"data",
-        nostr_client=SimpleNamespace(publish_json_to_nostr=lambda data: True),
+        nostr_client=SimpleNamespace(
+            publish_json_to_nostr=lambda data, alt_summary=None: True
+        ),
     )
     main.handle_post_to_nostr(pm)
     out = capsys.readouterr().out
@@ -20,7 +22,9 @@ def test_handle_post_success(capsys):
 def test_handle_post_failure(capsys):
     pm = SimpleNamespace(
         get_encrypted_data=lambda: b"data",
-        nostr_client=SimpleNamespace(publish_json_to_nostr=lambda data: False),
+        nostr_client=SimpleNamespace(
+            publish_json_to_nostr=lambda data, alt_summary=None: False
+        ),
     )
     main.handle_post_to_nostr(pm)
     out = capsys.readouterr().out

--- a/src/tests/test_settings_menu.py
+++ b/src/tests/test_settings_menu.py
@@ -35,7 +35,7 @@ def setup_pm(tmp_path, monkeypatch):
         relays=list(DEFAULT_RELAYS),
         close_client_pool=lambda: None,
         initialize_client_pool=lambda: None,
-        publish_json_to_nostr=lambda data: None,
+        publish_json_to_nostr=lambda data, alt_summary=None: None,
         key_manager=SimpleNamespace(get_npub=lambda: "npub"),
     )
 


### PR DESCRIPTION
## Summary
- add optional alt tag support when publishing to Nostr
- support notes when backing up
- automatically push a backup to Nostr after changing master password
- update tests for new behavior

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863e6760d00832b942683e235aab0c6