### PR TITLE
Implement seed-based index key derivation

### DIFF
--- a/src/tests/test_key_derivation.py
+++ b/src/tests/test_key_derivation.py
@@ -1,6 +1,10 @@
 import logging
 import pytest
-from utils.key_derivation import derive_key_from_password
+from utils.key_derivation import (
+    derive_key_from_password,
+    derive_index_key_seed_only,
+    derive_index_key_seed_plus_pw,
+)
 
 
 def test_derive_key_deterministic():
@@ -16,3 +20,19 @@ def test_derive_key_empty_password_error():
     with pytest.raises(ValueError):
         derive_key_from_password("")
     logging.info("Empty password correctly raised ValueError")
+
+
+def test_seed_only_key_deterministic():
+    seed = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    k1 = derive_index_key_seed_only(seed)
+    k2 = derive_index_key_seed_only(seed)
+    assert k1 == k2
+    assert len(k1) == 44
+
+
+def test_seed_plus_pw_differs_from_seed_only():
+    seed = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    pw = "hunter2"
+    k1 = derive_index_key_seed_only(seed)
+    k2 = derive_index_key_seed_plus_pw(seed, pw)
+    assert k1 != k2


### PR DESCRIPTION
## Summary
- support deterministic keys for the index derived from the seed
- ensure seed+password produces a different key
- test the new derivation helpers

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863ef195a90832bbd33b5905e6eee04