### PR TITLE
Add encryption mode configuration

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -15,3 +15,4 @@ nostr-sdk>=0.42.1
 websocket-client==1.7.0
 
 websockets>=15.0.0
+tomli


### PR DESCRIPTION
## Summary
- add `tomli` dependency
- support encryption modes via `--encryption-mode` option or `~/.seedpass/config.toml`
- initialize `PasswordManager` with chosen mode

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863f8f84088832bacf283a68b7fb1c2