### PR TITLE
Remove unused import from password prompt

### DIFF
--- a/src/utils/password_prompt.py
+++ b/src/utils/password_prompt.py
@@ -11,7 +11,6 @@ this module enhances code reuse, security, and maintainability across the applic
 Ensure that all dependencies are installed and properly configured in your environment.
 """
 
-import os
 import getpass
 import logging
 import sys


### PR DESCRIPTION
## Summary
- clean up password_prompt import list

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6864047e2a5c832b9628369a338c65f9