### PR TITLE
Fix vault initialization when creating new seed

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -687,8 +687,12 @@ class PasswordManager:
                 password,
                 self.encryption_mode,
             )
+
             # Re-initialize EncryptionManager with the new key and fingerprint_dir
             self.encryption_manager = EncryptionManager(key, fingerprint_dir)
+
+            # Initialize the vault now that encryption manager is available
+            self.vault = Vault(self.encryption_manager, fingerprint_dir)
 
             # Store the hashed password
             self.store_hashed_password(password)

--- a/src/tests/test_vault_initialization.py
+++ b/src/tests/test_vault_initialization.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.manager import PasswordManager, EncryptionMode
+from password_manager.vault import Vault
+
+VALID_SEED = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+
+def test_save_and_encrypt_seed_initializes_vault(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+        pm.vault = None
+        pm.config_manager = None
+        pm.current_fingerprint = "fp"
+
+        monkeypatch.setattr(
+            "password_manager.manager.prompt_for_password", lambda: "pw"
+        )
+        monkeypatch.setattr(
+            "password_manager.manager.NostrClient", lambda *a, **kw: object()
+        )
+
+        pm.save_and_encrypt_seed(VALID_SEED, tmp_path)
+
+        assert isinstance(pm.vault, Vault)
+        assert pm.entry_manager is not None


### PR DESCRIPTION
## Summary
- create Vault instance when saving and encrypting a new seed
- test that save_and_encrypt_seed sets up the vault and managers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68640ddbeb4c832b89dedd305c964789