### PR TITLE
Add Nostr network integration test

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -63,6 +63,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r src/requirements.txt
+      - name: Enable Nostr network tests on main branch
+        if: github.ref == 'refs/heads/main'
+        run: echo "NOSTR_E2E=1" >> $GITHUB_ENV
       - name: Run tests with coverage
         shell: bash
         run: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 log_cli = true
 log_cli_level = INFO
 testpaths = src/tests
+markers =
+    network: tests that require network connectivity

--- a/src/tests/test_nostr_real.py
+++ b/src/tests/test_nostr_real.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import pytest
+from cryptography.fernet import Fernet
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.encryption import EncryptionManager
+from nostr.client import NostrClient
+
+
+@pytest.mark.network
+@pytest.mark.skipif(not os.getenv("NOSTR_E2E"), reason="NOSTR_E2E not set")
+def test_nostr_publish_and_retrieve():
+    seed = (
+        "abandon abandon abandon abandon abandon abandon abandon "
+        "abandon abandon abandon abandon about"
+    )
+    with TemporaryDirectory() as tmpdir:
+        enc_mgr = EncryptionManager(Fernet.generate_key(), Path(tmpdir))
+        with patch.object(enc_mgr, "decrypt_parent_seed", return_value=seed):
+            client = NostrClient(
+                enc_mgr,
+                "test_fp_real",
+                relays=["wss://relay.snort.social"],
+            )
+            payload = b"seedpass"
+            assert client.publish_json_to_nostr(payload) is True
+            time.sleep(2)
+            retrieved = client.retrieve_json_from_nostr_sync()
+            client.close_client_pool()
+            assert retrieved == payload


### PR DESCRIPTION
## Summary
- add a real network test using `NostrClient`
- define a new `network` marker in pytest config
- skip network test unless `NOSTR_E2E` is set
- enable the variable automatically for CI runs on `main`

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6864279e97d4832b86d40de31b387c8d