### PR TITLE
Fix Nostr client seed decrypt bug

### DIFF
--- a/src/nostr/client.py
+++ b/src/nostr/client.py
@@ -46,15 +46,17 @@ class NostrClient:
         encryption_manager: EncryptionManager,
         fingerprint: str,
         relays: Optional[List[str]] = None,
+        parent_seed: Optional[str] = None,
     ) -> None:
         self.encryption_manager = encryption_manager
         self.fingerprint = fingerprint
         self.fingerprint_dir = self.encryption_manager.fingerprint_dir
 
+        if parent_seed is None:
+            parent_seed = self.encryption_manager.decrypt_parent_seed()
+
         # Use our project's KeyManager to derive the private key
-        self.key_manager = KeyManager(
-            self.encryption_manager.decrypt_parent_seed(), fingerprint
-        )
+        self.key_manager = KeyManager(parent_seed, fingerprint)
 
         # Create a nostr-sdk Keys object from our derived private key
         private_key_hex = self.key_manager.keys.private_key_hex()

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -370,6 +370,7 @@ class PasswordManager:
                 self.nostr_client = NostrClient(
                     encryption_manager=self.encryption_manager,
                     fingerprint=self.current_fingerprint,
+                    parent_seed=getattr(self, "parent_seed", None),
                 )
                 logging.info(
                     f"NostrClient re-initialized with seed profile {self.current_fingerprint}."
@@ -756,6 +757,7 @@ class PasswordManager:
                 encryption_manager=self.encryption_manager,
                 fingerprint=self.current_fingerprint,
                 relays=relay_list,
+                parent_seed=getattr(self, "parent_seed", None),
             )
 
             logger.debug("Managers re-initialized for the new fingerprint.")
@@ -1360,6 +1362,7 @@ class PasswordManager:
                 encryption_manager=self.encryption_manager,
                 fingerprint=self.current_fingerprint,
                 relays=relay_list,
+                parent_seed=getattr(self, "parent_seed", None),
             )
 
             print(colored("Master password changed successfully.", "green"))


### PR DESCRIPTION
## Summary
- make `NostrClient` accept optional `parent_seed`
- pass `parent_seed` to `NostrClient` from `PasswordManager`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68642c900998832bac15d400ec3c4278