### PR TITLE
Enable parallel stress testing

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "**" ]
   pull_request:
     branches: [ "**" ]
+  schedule:
+    - cron: '0 3 * * *'
 
 jobs:
   build:
@@ -19,6 +21,8 @@ jobs:
           - os: windows-latest
             python-version: "3.10"
     runs-on: ${{ matrix.os }}
+    env:
+      HYPOTHESIS_SEED: 123456
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -63,13 +67,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r src/requirements.txt
+      - name: Determine stress args
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "STRESS_ARGS=--stress" >> $GITHUB_ENV
+          fi
       - name: Enable Nostr network tests on main branch
         if: github.ref == 'refs/heads/main'
         run: echo "NOSTR_E2E=1" >> $GITHUB_ENV
       - name: Run tests with coverage
         shell: bash
         run: |
-          pytest --cov=src --cov-report=xml --cov-report=term-missing \
+          pytest ${STRESS_ARGS} --cov=src --cov-report=xml --cov-report=term-missing \
             --cov-fail-under=20 src/tests
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,10 @@
 [pytest]
+addopts = -n auto
 log_cli = true
 log_cli_level = WARNING
 log_level = WARNING
 testpaths = src/tests
 markers =
     network: tests that require network connectivity
+    stress: long running stress tests
+hypothesis_profile = ci

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,6 +10,7 @@ bcrypt
 bip85
 pytest>=7.0
 pytest-cov
+pytest-xdist
 portalocker>=2.8
 nostr-sdk>=0.42.1
 websocket-client==1.7.0

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -5,3 +5,28 @@ import pytest
 @pytest.fixture(autouse=True)
 def mute_logging():
     logging.getLogger().setLevel(logging.WARNING)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--stress",
+        action="store_true",
+        default=False,
+        help="run stress tests",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "stress: long running stress tests")
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    if config.getoption("--stress"):
+        return
+
+    skip_stress = pytest.mark.skip(reason="need --stress option to run")
+    for item in items:
+        if "stress" in item.keywords:
+            item.add_marker(skip_stress)

--- a/src/tests/test_concurrency_stress.py
+++ b/src/tests/test_concurrency_stress.py
@@ -42,19 +42,20 @@ def _backup(dir_path: Path, loops: int, out: Queue) -> None:
         out.put(repr(e))
 
 
+@pytest.mark.parametrize("loops", [5, pytest.param(20, marks=pytest.mark.stress)])
 @pytest.mark.parametrize("_", range(3))
-def test_concurrency_stress(tmp_path: Path, _):
+def test_concurrency_stress(tmp_path: Path, loops: int, _):
     key = Fernet.generate_key()
     enc = EncryptionManager(key, tmp_path)
     Vault(enc, tmp_path).save_index({"counter": 0})
 
     q: Queue = Queue()
     procs = [
-        Process(target=_writer, args=(key, tmp_path, 20, q)),
-        Process(target=_writer, args=(key, tmp_path, 20, q)),
-        Process(target=_reader, args=(key, tmp_path, 20, q)),
-        Process(target=_reader, args=(key, tmp_path, 20, q)),
-        Process(target=_backup, args=(tmp_path, 20, q)),
+        Process(target=_writer, args=(key, tmp_path, loops, q)),
+        Process(target=_writer, args=(key, tmp_path, loops, q)),
+        Process(target=_reader, args=(key, tmp_path, loops, q)),
+        Process(target=_reader, args=(key, tmp_path, loops, q)),
+        Process(target=_backup, args=(tmp_path, loops, q)),
     ]
 
     for p in procs:


### PR DESCRIPTION
## Summary
- allow running parallel tests via pytest-xdist
- skip heavy stress loops unless `--stress` is set
- run `--stress` only on nightly schedule
- fix deterministic Hypothesis runs by seeding in CI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686436c58e38832b8b798dac6edb4e15