### PR TITLE
Add mutation testing and Nostr contract test

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -72,14 +72,19 @@ jobs:
           if [ "${{ github.event_name }}" = "schedule" ]; then
             echo "STRESS_ARGS=--stress" >> $GITHUB_ENV
           fi
-      - name: Enable Nostr network tests on main branch
-        if: github.ref == 'refs/heads/main'
+      - name: Enable Nostr network tests on main branch or nightly
+        if: github.ref == 'refs/heads/main' || github.event_name == 'schedule'
         run: echo "NOSTR_E2E=1" >> $GITHUB_ENV
       - name: Run tests with coverage
         shell: bash
         run: |
           pytest ${STRESS_ARGS} --cov=src --cov-report=xml --cov-report=term-missing \
             --cov-fail-under=20 src/tests
+      - name: Run mutation tests
+        if: github.event_name == 'push'
+        run: |
+          mutmut run --paths-to-mutate src --tests-dir src/tests --runner "python -m pytest -q"
+          mutmut results
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -18,3 +18,4 @@ websocket-client==1.7.0
 websockets>=15.0.0
 tomli
 hypothesis
+mutmut>=2.4.4

--- a/src/tests/test_nostr_contract.py
+++ b/src/tests/test_nostr_contract.py
@@ -1,0 +1,76 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+from cryptography.fernet import Fernet
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.encryption import EncryptionManager
+from nostr.client import NostrClient
+
+
+class MockNostrServer:
+    def __init__(self):
+        self.events = []
+
+
+class MockClient:
+    def __init__(self, server):
+        self.server = server
+
+    async def add_relays(self, relays):
+        pass
+
+    async def add_relay(self, relay):
+        pass
+
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def send_event(self, event):
+        self.server.events.append(event)
+
+        class FakeId:
+            def to_hex(self_inner):
+                return "abcd"
+
+        class FakeOutput:
+            def __init__(self):
+                self.id = FakeId()
+
+        return FakeOutput()
+
+    async def fetch_events(self, filter_obj, timeout):
+        class FakeEvents:
+            def __init__(self, events):
+                self._events = events
+
+            def to_vec(self):
+                return self._events
+
+        return FakeEvents(self.server.events[-1:])
+
+
+def setup_client(tmp_path, server):
+    key = Fernet.generate_key()
+    enc_mgr = EncryptionManager(key, tmp_path)
+
+    with patch("nostr.client.Client", lambda signer: MockClient(server)), patch(
+        "nostr.client.KeyManager"
+    ) as MockKM, patch.object(enc_mgr, "decrypt_parent_seed", return_value="seed"):
+        km_inst = MockKM.return_value
+        km_inst.keys.private_key_hex.return_value = "1" * 64
+        km_inst.keys.public_key_hex.return_value = "2" * 64
+        client = NostrClient(enc_mgr, "fp", relays=["ws://mock"])
+    return client
+
+
+def test_publish_and_retrieve(tmp_path):
+    server = MockNostrServer()
+    client = setup_client(tmp_path, server)
+    payload = b"contract-test"
+    assert client.publish_json_to_nostr(payload) is True
+    assert client.retrieve_json_from_nostr_sync() == payload


### PR DESCRIPTION
## Summary
- add `mutmut` to requirements for mutation testing
- run mutation tests in CI on push
- execute Nostr E2E tests on nightly schedule as well as main branch
- add contract test for Nostr publish/retrieve using a mock server

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686439b7fbec832bbd00f7a4661bcaef