### PR TITLE
Add release pipeline and expand CI matrix

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -13,13 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.11"]
-        exclude:
-          - os: windows-latest
-            python-version: "3.11"
-        include:
-          - os: windows-latest
-            python-version: "3.10"
+        python-version: ["3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     env:
       HYPOTHESIS_SEED: 123456
@@ -71,6 +65,10 @@ jobs:
         run: |
           pip install pip-audit
           pip-audit -r requirements.lock
+      - name: Run pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run --all-files
       - name: Determine stress args
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install hatch
+        run: pip install hatch
+      - name: Build wheel
+        run: hatch build -t wheel
+      - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          for f in dist/*.whl; do
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --detach-sign --armor "$f"
+          done
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TESTPYPI_API_TOKEN }}
+          gpg-sign: true
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,4 @@ repos:
     hooks:
       - id: bandit
         name: bandit
+        args: ["-x", "src/tests"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
   - [Running the Application](#running-the-application)
   - [Managing Multiple Seeds](#managing-multiple-seeds)
 - [Security Considerations](#security-considerations)
+- [Release Workflow](#release-workflow)
 - [Contributing](#contributing)
 - [License](#license)
 - [Contact](#contact)
@@ -242,6 +243,22 @@ Contributions are welcome! If you have suggestions for improvements, bug fixes, 
    ```
 
 5. **Create a Pull Request:** Navigate to the original repository and create a pull request describing your changes.
+
+## Release Workflow
+
+SeedPass is packaged with **hatch**. Signed wheels are automatically published to **TestPyPI** whenever a Git tag is pushed. The workflow imports a GPG key and uploads the package using `pypa/gh-action-pypi-publish`.
+
+To trigger a release:
+
+1. Update the version in `pyproject.toml`.
+2. Commit the change and create a tag:
+
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+GitHub Actions will build the wheel with `hatch`, sign it with the provided GPG key, and upload it to TestPyPI.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,35 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "seedpass"
+version = "0.1.0"
+description = "Secure deterministic password manager using BIP-85 and Nostr"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+dependencies = [
+    "colorama>=0.4.6",
+    "termcolor>=1.1.0",
+    "cryptography>=40.0.2",
+    "bip-utils>=2.5.0",
+    "bech32==1.2.0",
+    "coincurve>=18.0.0",
+    "mnemonic",
+    "aiohttp",
+    "bcrypt",
+    "bip85",
+    "portalocker>=2.8",
+    "nostr-sdk>=0.42.1",
+    "websocket-client==1.7.0",
+    "websockets>=15.0.0",
+    "tomli"
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]
+
 [tool.mypy]
 python_version = "3.11"
 strict = true

--- a/src/password_manager/entry_management.py
+++ b/src/password_manager/entry_management.py
@@ -374,9 +374,10 @@ class EntryManager:
             backup_filename = f"passwords_db_backup_{timestamp}.json.enc"
             backup_path = self.fingerprint_dir / backup_filename
 
-            with open(index_file_path, "rb") as original_file, open(
-                backup_path, "wb"
-            ) as backup_file:
+            with (
+                open(index_file_path, "rb") as original_file,
+                open(backup_path, "wb") as backup_file,
+            ):
                 shutil.copyfileobj(original_file, backup_file)
 
             logger.debug(f"Backup created at '{backup_path}'.")
@@ -404,9 +405,10 @@ class EntryManager:
                 )
                 return
 
-            with open(backup_path, "rb") as backup_file, open(
-                self.index_file, "wb"
-            ) as index_file:
+            with (
+                open(backup_path, "rb") as backup_file,
+                open(self.index_file, "wb") as index_file,
+            ):
                 shutil.copyfileobj(backup_file, index_file)
 
             logger.debug(f"Index file restored from backup '{backup_path}'.")

--- a/src/tests/test_nostr_backup.py
+++ b/src/tests/test_nostr_backup.py
@@ -25,14 +25,14 @@ def test_backup_and_publish_to_nostr():
         encrypted_index = entry_mgr.get_encrypted_index()
         assert encrypted_index is not None
 
-        with patch(
-            "nostr.client.NostrClient.publish_json_to_nostr", return_value=True
-        ) as mock_publish, patch("nostr.client.ClientBuilder"), patch(
-            "nostr.client.KeyManager"
-        ), patch.object(
-            NostrClient, "initialize_client_pool"
-        ), patch.object(
-            enc_mgr, "decrypt_parent_seed", return_value="seed"
+        with (
+            patch(
+                "nostr.client.NostrClient.publish_json_to_nostr", return_value=True
+            ) as mock_publish,
+            patch("nostr.client.ClientBuilder"),
+            patch("nostr.client.KeyManager"),
+            patch.object(NostrClient, "initialize_client_pool"),
+            patch.object(enc_mgr, "decrypt_parent_seed", return_value="seed"),
         ):
             nostr_client = NostrClient(enc_mgr, "fp")
             entry_mgr.backup_index_file()

--- a/src/tests/test_nostr_client.py
+++ b/src/tests/test_nostr_client.py
@@ -16,9 +16,11 @@ def test_nostr_client_uses_custom_relays():
         enc_mgr = EncryptionManager(key, Path(tmpdir))
         custom_relays = ["wss://relay1", "wss://relay2"]
 
-        with patch("nostr.client.ClientBuilder") as MockBuilder, patch(
-            "nostr.client.KeyManager"
-        ), patch.object(NostrClient, "initialize_client_pool"):
+        with (
+            patch("nostr.client.ClientBuilder") as MockBuilder,
+            patch("nostr.client.KeyManager"),
+            patch.object(NostrClient, "initialize_client_pool"),
+        ):
             mock_builder = MockBuilder.return_value
             with patch.object(enc_mgr, "decrypt_parent_seed", return_value="seed"):
                 client = NostrClient(enc_mgr, "fp", relays=custom_relays)
@@ -54,9 +56,11 @@ def _setup_client(tmpdir, fake_cls):
     key = Fernet.generate_key()
     enc_mgr = EncryptionManager(key, Path(tmpdir))
 
-    with patch("nostr.client.Client", fake_cls), patch(
-        "nostr.client.KeyManager"
-    ) as MockKM, patch.object(enc_mgr, "decrypt_parent_seed", return_value="seed"):
+    with (
+        patch("nostr.client.Client", fake_cls),
+        patch("nostr.client.KeyManager") as MockKM,
+        patch.object(enc_mgr, "decrypt_parent_seed", return_value="seed"),
+    ):
         km_inst = MockKM.return_value
         km_inst.keys.private_key_hex.return_value = "1" * 64
         client = NostrClient(enc_mgr, "fp")

--- a/src/tests/test_nostr_contract.py
+++ b/src/tests/test_nostr_contract.py
@@ -58,9 +58,11 @@ def setup_client(tmp_path, server):
     key = Fernet.generate_key()
     enc_mgr = EncryptionManager(key, tmp_path)
 
-    with patch("nostr.client.Client", lambda signer: MockClient(server)), patch(
-        "nostr.client.KeyManager"
-    ) as MockKM, patch.object(enc_mgr, "decrypt_parent_seed", return_value="seed"):
+    with (
+        patch("nostr.client.Client", lambda signer: MockClient(server)),
+        patch("nostr.client.KeyManager") as MockKM,
+        patch.object(enc_mgr, "decrypt_parent_seed", return_value="seed"),
+    ):
         km_inst = MockKM.return_value
         km_inst.keys.private_key_hex.return_value = "1" * 64
         km_inst.keys.public_key_hex.return_value = "2" * 64

--- a/src/tests/test_publish_json_result.py
+++ b/src/tests/test_publish_json_result.py
@@ -14,10 +14,11 @@ def setup_client(tmp_path):
     key = Fernet.generate_key()
     enc_mgr = EncryptionManager(key, tmp_path)
 
-    with patch("nostr.client.ClientBuilder"), patch(
-        "nostr.client.KeyManager"
-    ) as MockKM, patch.object(NostrClient, "initialize_client_pool"), patch.object(
-        enc_mgr, "decrypt_parent_seed", return_value="seed"
+    with (
+        patch("nostr.client.ClientBuilder"),
+        patch("nostr.client.KeyManager") as MockKM,
+        patch.object(NostrClient, "initialize_client_pool"),
+        patch.object(enc_mgr, "decrypt_parent_seed", return_value="seed"),
     ):
         km_inst = MockKM.return_value
         km_inst.keys.private_key_hex.return_value = "1" * 64
@@ -55,8 +56,9 @@ class FakeSendEventOutput:
 
 
 def test_publish_json_success():
-    with TemporaryDirectory() as tmpdir, patch(
-        "nostr.client.EventBuilder.text_note", return_value=FakeBuilder()
+    with (
+        TemporaryDirectory() as tmpdir,
+        patch("nostr.client.EventBuilder.text_note", return_value=FakeBuilder()),
     ):
         client = setup_client(Path(tmpdir))
         with patch.object(
@@ -67,8 +69,9 @@ def test_publish_json_success():
 
 
 def test_publish_json_failure():
-    with TemporaryDirectory() as tmpdir, patch(
-        "nostr.client.EventBuilder.text_note", return_value=FakeBuilder()
+    with (
+        TemporaryDirectory() as tmpdir,
+        patch("nostr.client.EventBuilder.text_note", return_value=FakeBuilder()),
     ):
         client = setup_client(Path(tmpdir))
         with patch.object(client, "publish_event", side_effect=Exception("boom")):

--- a/src/tests/test_settings_menu.py
+++ b/src/tests/test_settings_menu.py
@@ -61,17 +61,20 @@ def test_relay_and_profile_actions(monkeypatch, capsys):
         )
 
         # Add a relay
-        with patch("builtins.input", return_value="wss://new"), patch(
-            "main.handle_post_to_nostr"
-        ), patch("main._reload_relays"):
+        with (
+            patch("builtins.input", return_value="wss://new"),
+            patch("main.handle_post_to_nostr"),
+            patch("main._reload_relays"),
+        ):
             main.handle_add_relay(pm)
         cfg = cfg_mgr.load_config(require_pin=False)
         assert "wss://new" in cfg["relays"]
 
         # Remove the relay
         idx = cfg["relays"].index("wss://new") + 1
-        with patch("builtins.input", return_value=str(idx)), patch(
-            "main._reload_relays"
+        with (
+            patch("builtins.input", return_value=str(idx)),
+            patch("main._reload_relays"),
         ):
             main.handle_remove_relay(pm)
         cfg = cfg_mgr.load_config(require_pin=False)

--- a/src/utils/key_derivation.py
+++ b/src/utils/key_derivation.py
@@ -117,7 +117,9 @@ def derive_key_from_parent_seed(parent_seed: str, fingerprint: str = None) -> by
         # If a fingerprint is provided, use it to differentiate the derivation
         if fingerprint:
             # Convert fingerprint to a stable integer index
-            index = int(hashlib.sha256(fingerprint.encode()).hexdigest(), 16) % (2**31)
+            index = int(hashlib.sha256(fingerprint.encode()).hexdigest(), 16) % (
+                2**31
+            )
             info = f"password-manager-{index}".encode()  # Unique info for HKDF
         else:
             info = b"password-manager"


### PR DESCRIPTION
## Summary
- test Python 3.10-3.12 on all OSes
- run pre-commit in CI
- add hatch-based packaging
- publish signed wheels to TestPyPI on tag pushes
- document the release workflow

## Testing
- `python3 -m venv venv`
- `pip install -r src/requirements.txt`
- `pytest -q src/tests`

------
https://chatgpt.com/codex/tasks/task_b_686449809638832b97c9cffa5e5299ed