### PR TITLE
Add pre-push checksum updater

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,10 @@ repos:
     hooks:
       - id: bandit
         name: bandit
+  - repo: local
+    hooks:
+      - id: update-checksum
+        name: update-checksum
+        entry: python scripts/update_checksum.py
+        language: system
+        stages: [push]

--- a/README.md
+++ b/README.md
@@ -195,6 +195,18 @@ pip install -r src/requirements.txt
 pytest -vv
 ```
 
+### Automatically Updating the Script Checksum
+
+SeedPass stores a SHA-256 checksum for the main program in `~/.seedpass/seedpass_script_checksum.txt`.
+To keep this value in sync with the source code, install the pre‑push git hook:
+
+```bash
+pre-commit install -t pre-push
+```
+
+After running this command, every `git push` will execute `scripts/update_checksum.py`,
+updating the checksum file automatically.
+
 To run mutation tests locally, generate coverage data first and then execute `mutmut`:
 
 ```bash

--- a/scripts/update_checksum.py
+++ b/scripts/update_checksum.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+# Ensure src directory is in sys.path for imports
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from utils.checksum import calculate_checksum
+from constants import SCRIPT_CHECKSUM_FILE
+
+
+def main() -> None:
+    """Calculate checksum for the main script and write it to SCRIPT_CHECKSUM_FILE."""
+    script_path = SRC_DIR / "password_manager" / "manager.py"
+    checksum = calculate_checksum(str(script_path))
+    if checksum is None:
+        raise SystemExit(f"Failed to calculate checksum for {script_path}")
+
+    SCRIPT_CHECKSUM_FILE.write_text(checksum)
+    print(f"Updated checksum written to {SCRIPT_CHECKSUM_FILE}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `scripts/update_checksum.py` to calculate manager checksum
- run new script during pre-push via pre-commit
- document how to enable the pre-push hook in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6864502be1f0832b845fdd7eda7f01fa