### PR TITLE
Clean pytest.ini config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,3 @@ testpaths = src/tests
 markers =
     network: tests that require network connectivity
     stress: long running stress tests
-hypothesis_profile = ci


### PR DESCRIPTION
## Summary
- remove unused `hypothesis_profile` key from `pytest.ini`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68645acdf0a8832b9477eb07f3e73d99