### PR TITLE
Fix checksum path handling

### DIFF
--- a/src/password_manager/entry_management.py
+++ b/src/password_manager/entry_management.py
@@ -344,8 +344,8 @@ class EntryManager:
             json_content = json.dumps(data, indent=4)
             checksum = hashlib.sha256(json_content.encode("utf-8")).hexdigest()
 
-            # Construct the full path for the checksum file
-            checksum_path = self.fingerprint_dir / self.checksum_file
+            # The checksum file path already includes the fingerprint directory
+            checksum_path = self.checksum_file
 
             with open(checksum_path, "w") as f:
                 f.write(checksum)
@@ -363,7 +363,8 @@ class EntryManager:
         Creates a backup of the encrypted JSON index file to prevent data loss.
         """
         try:
-            index_file_path = self.fingerprint_dir / self.index_file
+            # self.index_file already includes the fingerprint directory
+            index_file_path = self.index_file
             if not index_file_path.exists():
                 logger.warning(
                     f"Index file '{index_file_path}' does not exist. No backup created."

--- a/src/tests/test_entry_management_checksum_path.py
+++ b/src/tests/test_entry_management_checksum_path.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from cryptography.fernet import Fernet
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.encryption import EncryptionManager
+from password_manager.vault import Vault
+from password_manager.entry_management import EntryManager
+
+
+def test_update_checksum_writes_to_expected_path():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        key = Fernet.generate_key()
+        enc_mgr = EncryptionManager(key, tmp_path)
+        vault = Vault(enc_mgr, tmp_path)
+        entry_mgr = EntryManager(vault, tmp_path)
+
+        # create an empty index file
+        vault.save_index({"passwords": {}})
+        entry_mgr.update_checksum()
+
+        expected = tmp_path / "seedpass_passwords_db_checksum.txt"
+        assert expected.exists()
+
+
+def test_backup_index_file_creates_backup_in_directory():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        key = Fernet.generate_key()
+        enc_mgr = EncryptionManager(key, tmp_path)
+        vault = Vault(enc_mgr, tmp_path)
+        entry_mgr = EntryManager(vault, tmp_path)
+
+        vault.save_index({"passwords": {}})
+        entry_mgr.backup_index_file()
+
+        backups = list(tmp_path.glob("passwords_db_backup_*.json.enc"))
+        assert len(backups) == 1


### PR DESCRIPTION
## Summary
- correct checksum file path handling
- new tests to ensure checksum and backups are saved in the fingerprint directory

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68645c4c0698832b8fc593c98d748e74