### PR TITLE
Add docs for encryption mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,30 @@ python src/main.py
    Enter your choice (1-5):
    ```
 
+### Encryption Mode
+
+Use the `--encryption-mode` flag to control how SeedPass derives the key used to
+encrypt your vault. Valid values are:
+
+- `seed-only` – default mode that derives the vault key solely from your BIP-85
+  seed.
+- `seed+pw` – combines the seed with your master password for key derivation.
+- `pw-only` – derives the key from your password alone.
+
+You can set this option when launching the application:
+
+```bash
+python src/main.py --encryption-mode seed+pw
+```
+
+To make the choice persistent, add it to `~/.seedpass/config.toml`:
+
+```toml
+encryption_mode = "seed+pw"
+```
+
+SeedPass will read this value on startup and use the specified mode by default.
+
 ### Managing Multiple Seeds
 
 SeedPass allows you to manage multiple seed profiles (previously referred to as "fingerprints"). Each seed profile has its own parent seed and associated data, enabling you to compartmentalize your passwords.


### PR DESCRIPTION
## Summary
- document the `--encryption-mode` option in the README
- explain valid values and default
- show how to persist the setting in `~/.seedpass/config.toml`

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68646401cf3c832bbed5b0fe4d823aa4