### PR TITLE
Fix dark mode toggle placement

### DIFF
--- a/landing/style.css
+++ b/landing/style.css
@@ -90,7 +90,7 @@ body.dark-mode {
 /* Dark Mode Toggle */
 .dark-mode-toggle {
     position: fixed;
-    top: 20px;
+    top: 12px;
     right: 20px;
     z-index: 1000;
 }
@@ -832,8 +832,8 @@ footer .social-media a:focus {
 
 @media screen and (max-width: 768px) {
     .navbar .container {
-        flex-direction: column;
-        align-items: flex-start;
+        flex-direction: row;
+        align-items: center;
     }
 
     .nav-links {


### PR DESCRIPTION
## Summary
- align dark mode toggle with the navigation bar
- keep navbar layout horizontal on mobile so the menu button doesn't wrap

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68646d875b44832ba81a1be5edf47655