### PR TITLE
Add portable backup export/import CLI

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -24,6 +24,11 @@ from password_manager.entry_management import EntryManager
 from password_manager.password_generation import PasswordGenerator
 from password_manager.backup import BackupManager
 from password_manager.vault import Vault
+from password_manager.portable_backup import (
+    export_backup,
+    import_backup,
+    PortableMode,
+)
 from utils.key_derivation import (
     derive_key_from_parent_seed,
     derive_key_from_password,
@@ -1136,6 +1141,35 @@ class PasswordManager:
         except Exception as e:
             logging.error(f"Failed to restore backup: {e}", exc_info=True)
             print(colored(f"Error: Failed to restore backup: {e}", "red"))
+
+    def handle_export_database(
+        self,
+        mode: "PortableMode" = PortableMode.SEED_ONLY,
+        dest: Path | None = None,
+    ) -> Path | None:
+        """Export the current database to an encrypted portable file."""
+        try:
+            path = export_backup(
+                self.vault,
+                self.backup_manager,
+                mode,
+                dest,
+            )
+            print(colored(f"Database exported to '{path}'.", "green"))
+            return path
+        except Exception as e:
+            logging.error(f"Failed to export database: {e}", exc_info=True)
+            print(colored(f"Error: Failed to export database: {e}", "red"))
+            return None
+
+    def handle_import_database(self, src: Path) -> None:
+        """Import a portable database file, replacing the current index."""
+        try:
+            import_backup(self.vault, self.backup_manager, src)
+            print(colored("Database imported successfully.", "green"))
+        except Exception as e:
+            logging.error(f"Failed to import database: {e}", exc_info=True)
+            print(colored(f"Error: Failed to import database: {e}", "red"))
 
     def handle_backup_reveal_parent_seed(self) -> None:
         """

--- a/src/tests/test_cli_portable_backup_commands.py
+++ b/src/tests/test_cli_portable_backup_commands.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+import runpy
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import main
+from password_manager.portable_backup import PortableMode
+from password_manager.manager import PasswordManager
+
+
+def _run(argv, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["seedpass"] + argv)
+    monkeypatch.setattr(main, "load_global_config", lambda: {})
+    called = {}
+
+    def fake_init(self, encryption_mode):
+        called["init"] = True
+
+    def fake_export(self, mode, dest):
+        called["export"] = (mode, Path(dest))
+
+    def fake_import(self, src):
+        called["import"] = Path(src)
+
+    monkeypatch.setattr(PasswordManager, "__init__", fake_init)
+    monkeypatch.setattr(PasswordManager, "handle_export_database", fake_export)
+    monkeypatch.setattr(PasswordManager, "handle_import_database", fake_import)
+
+    with pytest.raises(SystemExit):
+        runpy.run_module("main", run_name="__main__")
+
+    return called
+
+
+def test_export_command_invokes_handler(monkeypatch):
+    called = _run(["export", "--mode", "pw-only", "--file", "out.json"], monkeypatch)
+    assert called["export"] == (PortableMode.PW_ONLY, Path("out.json"))
+    assert "import" not in called
+
+
+def test_import_command_invokes_handler(monkeypatch):
+    called = _run(["import", "--file", "backup.json"], monkeypatch)
+    assert called["import"] == Path("backup.json")
+    assert "export" not in called


### PR DESCRIPTION
## Summary
- hook up portable backup operations inside `PasswordManager`
- expose export/import in settings menu
- add CLI subcommands `export` and `import`
- add tests for CLI portable backup commands

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686489f2ffbc832b973ba6c4d5d7d019