### PR TITLE
Add tests for vault index import/export

### DIFF
--- a/src/tests/test_index_import_export.py
+++ b/src/tests/test_index_import_export.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+import sys
+from cryptography.fernet import Fernet
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.encryption import EncryptionManager
+from password_manager.vault import Vault
+from utils.key_derivation import derive_index_key, EncryptionMode
+
+SEED = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+PASSWORD = "passw0rd"
+
+
+def setup_vault(tmp: Path, mode: EncryptionMode) -> Vault:
+    key = derive_index_key(SEED, PASSWORD, mode)
+    enc_mgr = EncryptionManager(key, tmp)
+    enc_mgr.encrypt_parent_seed(SEED)
+    return Vault(enc_mgr, tmp)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        EncryptionMode.SEED_ONLY,
+        EncryptionMode.SEED_PLUS_PW,
+        EncryptionMode.PW_ONLY,
+    ],
+)
+def test_index_export_import_round_trip(mode):
+    with TemporaryDirectory() as td:
+        tmp = Path(td)
+        vault = setup_vault(tmp, mode)
+
+        original = {"passwords": {"0": {"website": "example"}}}
+        vault.save_index(original)
+
+        encrypted = vault.get_encrypted_index()
+        assert isinstance(encrypted, bytes)
+
+        vault.save_index({"passwords": {"0": {"website": "changed"}}})
+        vault.decrypt_and_save_index_from_nostr(encrypted)
+
+        loaded = vault.load_index()
+        assert loaded["passwords"] == original["passwords"]
+
+
+def test_get_encrypted_index_missing_file(tmp_path):
+    key = Fernet.generate_key()
+    enc_mgr = EncryptionManager(key, tmp_path)
+    vault = Vault(enc_mgr, tmp_path)
+    assert vault.get_encrypted_index() is None


### PR DESCRIPTION
## Summary
- add new `test_index_import_export` module
- ensure index import/export works across all encryption modes
- cover missing index handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686491617c94832b81c797abc2534373