### PR TITLE
Improve checksum verification error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ pre-commit install -t pre-push
 After running this command, every `git push` will execute `scripts/update_checksum.py`,
 updating the checksum file automatically.
 
+If the checksum file is missing, generate it manually:
+
+```bash
+python scripts/update_checksum.py
+```
+
 To run mutation tests locally, generate coverage data first and then execute `mutmut`:
 
 ```bash

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1059,7 +1059,19 @@ class PasswordManager:
         """
         try:
             current_checksum = calculate_checksum(__file__)
-            if verify_checksum(current_checksum, SCRIPT_CHECKSUM_FILE):
+            try:
+                verified = verify_checksum(current_checksum, SCRIPT_CHECKSUM_FILE)
+            except FileNotFoundError:
+                print(
+                    colored(
+                        "Checksum file missing. Run scripts/update_checksum.py to generate it.",
+                        "yellow",
+                    )
+                )
+                logging.warning("Checksum file missing during verification.")
+                return
+
+            if verified:
                 print(colored("Checksum verification passed.", "green"))
                 logging.info("Checksum verification passed.")
             else:

--- a/src/tests/test_manager_checksum_backup.py
+++ b/src/tests/test_manager_checksum_backup.py
@@ -44,6 +44,21 @@ def test_handle_verify_checksum_failure(monkeypatch, tmp_path, capsys):
     assert "Checksum verification failed" in out
 
 
+def test_handle_verify_checksum_missing(monkeypatch, tmp_path, capsys):
+    pm = _make_pm()
+    chk_file = tmp_path / "chk.txt"
+    monkeypatch.setattr("password_manager.manager.SCRIPT_CHECKSUM_FILE", chk_file)
+    monkeypatch.setattr("password_manager.manager.calculate_checksum", lambda _: "abc")
+
+    def raise_missing(*_args, **_kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr("password_manager.manager.verify_checksum", raise_missing)
+    pm.handle_verify_checksum()
+    out = capsys.readouterr().out.lower()
+    assert "update_checksum.py" in out
+
+
 def test_backup_and_restore_database(monkeypatch, capsys):
     pm = _make_pm()
     calls = {"create": 0, "restore": 0}

--- a/src/utils/checksum.py
+++ b/src/utils/checksum.py
@@ -89,26 +89,20 @@ def verify_checksum(current_checksum: str, checksum_file_path: str) -> bool:
     try:
         with open(checksum_file_path, "r") as f:
             stored_checksum = f.read().strip()
-        if current_checksum == stored_checksum:
-            logging.debug(f"Checksum verification passed for '{checksum_file_path}'.")
-            return True
-        else:
-            logging.warning(f"Checksum mismatch for '{checksum_file_path}'.")
-            return False
     except FileNotFoundError:
         logging.error(f"Checksum file '{checksum_file_path}' not found.")
-        print(colored(f"Error: Checksum file '{checksum_file_path}' not found.", "red"))
-        return False
+        raise
     except Exception as e:
         logging.error(
             f"Error reading checksum file '{checksum_file_path}': {e}", exc_info=True
         )
-        print(
-            colored(
-                f"Error: Failed to read checksum file '{checksum_file_path}': {e}",
-                "red",
-            )
-        )
+        raise
+
+    if current_checksum == stored_checksum:
+        logging.debug(f"Checksum verification passed for '{checksum_file_path}'.")
+        return True
+    else:
+        logging.warning(f"Checksum mismatch for '{checksum_file_path}'.")
         return False
 
 


### PR DESCRIPTION
## Summary
- raise `FileNotFoundError` from `verify_checksum`
- show helpful message in `handle_verify_checksum` when checksum file is missing
- document how to regenerate the checksum
- test missing checksum file case

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68649844f26c832b9218249e7a393324