### PR TITLE
Ignore multiprocessing warning in tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,5 @@ testpaths = src/tests
 markers =
     network: tests that require network connectivity
     stress: long running stress tests
+filterwarnings =
+    ignore::DeprecationWarning:multiprocessing.popen_fork


### PR DESCRIPTION
## Summary
- configure pytest to ignore DeprecationWarning from `multiprocessing.popen_fork`

## Testing
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_b_68649dc726c4832baa312ae8613e3590