### PR TITLE
Fix new profile password hashing

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -548,6 +548,12 @@ class PasswordManager:
                 seed_mgr = EncryptionManager(seed_key, fingerprint_dir)
                 self.vault = Vault(self.encryption_manager, fingerprint_dir)
 
+                # Ensure config manager is set for the new fingerprint
+                self.config_manager = ConfigManager(
+                    vault=self.vault,
+                    fingerprint_dir=fingerprint_dir,
+                )
+
                 # Encrypt and save the parent seed
                 seed_mgr.encrypt_parent_seed(parent_seed)
                 logging.info("Parent seed encrypted and saved successfully.")
@@ -683,6 +689,13 @@ class PasswordManager:
             seed_mgr = EncryptionManager(seed_key, fingerprint_dir)
 
             self.vault = Vault(self.encryption_manager, fingerprint_dir)
+
+            # Ensure the config manager points to the new fingerprint before
+            # storing the hashed password
+            self.config_manager = ConfigManager(
+                vault=self.vault,
+                fingerprint_dir=fingerprint_dir,
+            )
 
             self.store_hashed_password(password)
             logging.info("User password hashed and stored successfully.")

--- a/src/password_manager/migrations.py
+++ b/src/password_manager/migrations.py
@@ -7,7 +7,9 @@ from typing import Callable, Dict
 MIGRATIONS: Dict[int, Callable[[dict], dict]] = {}
 
 
-def migration(from_ver: int) -> Callable[[Callable[[dict], dict]], Callable[[dict], dict]]:
+def migration(
+    from_ver: int,
+) -> Callable[[Callable[[dict], dict]], Callable[[dict], dict]]:
     """Register a migration function from *from_ver* to *from_ver* + 1."""
 
     def decorator(func: Callable[[dict], dict]) -> Callable[[dict], dict]:


### PR DESCRIPTION
## Summary
- initialize ConfigManager when creating or importing new seed
- ensure hashed passwords are stored in the correct profile
- format migrations with black

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68649fe4fd5c832bbd2f5d0ca6505334