### PR TITLE
Fix seed profile switching

### DIFF
--- a/src/password_manager/encryption.py
+++ b/src/password_manager/encryption.py
@@ -121,7 +121,6 @@ class EncryptionManager:
             logger.error(
                 "Invalid encryption key or corrupted data while decrypting parent seed."
             )
-            print(colored("Error: Invalid encryption key or corrupted data.", "red"))
             raise
         except Exception as e:
             logger.error(f"Failed to decrypt parent seed: {e}", exc_info=True)
@@ -159,7 +158,6 @@ class EncryptionManager:
             logger.error(
                 "Invalid encryption key or corrupted data while decrypting data."
             )
-            print(colored("Error: Invalid encryption key or corrupted data.", "red"))
             raise
         except Exception as e:
             logger.error(f"Failed to decrypt data: {e}", exc_info=True)
@@ -230,7 +228,6 @@ class EncryptionManager:
             logger.error(
                 "Invalid encryption key or corrupted data while decrypting file."
             )
-            print(colored("Error: Invalid encryption key or corrupted data.", "red"))
             raise
         except Exception as e:
             logger.error(
@@ -306,26 +303,15 @@ class EncryptionManager:
             logger.error(
                 f"Failed to decode JSON data from '{file_path}': {e}", exc_info=True
             )
-            print(
-                colored(
-                    f"Error: Failed to decode JSON data from '{file_path}': {e}", "red"
-                )
-            )
             raise
         except InvalidToken:
             logger.error(
                 "Invalid encryption key or corrupted data while decrypting JSON data."
             )
-            print(colored("Error: Invalid encryption key or corrupted data.", "red"))
             raise
         except Exception as e:
             logger.error(
                 f"Failed to load JSON data from '{file_path}': {e}", exc_info=True
-            )
-            print(
-                colored(
-                    f"Error: Failed to load JSON data from '{file_path}': {e}", "red"
-                )
             )
             raise
 

--- a/src/tests/test_profiles.py
+++ b/src/tests/test_profiles.py
@@ -34,7 +34,7 @@ def test_add_and_switch_fingerprint(monkeypatch):
         monkeypatch.setattr(
             PasswordManager,
             "setup_encryption_manager",
-            lambda self, d, password=None: None,
+            lambda self, d, password=None, exit_on_fail=True: True,
         )
         monkeypatch.setattr(PasswordManager, "load_parent_seed", lambda self, d: None)
         monkeypatch.setattr(PasswordManager, "initialize_bip85", lambda self: None)


### PR DESCRIPTION
## Summary
- stop printing encryption errors from `EncryptionManager`
- reload parent seed when switching profiles and add exit control
- clarify password prompt when switching profiles
- adjust tests to new function signature

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6864a2ff3fb8832b96c75f981573de95