### PR TITLE
Implement encryption mode switching

### DIFF
--- a/src/password_manager/config_manager.py
+++ b/src/password_manager/config_manager.py
@@ -12,6 +12,10 @@ import bcrypt
 
 from password_manager.vault import Vault
 from nostr.client import DEFAULT_RELAYS as DEFAULT_NOSTR_RELAYS
+from utils.key_derivation import (
+    EncryptionMode,
+    DEFAULT_ENCRYPTION_MODE,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +45,7 @@ class ConfigManager:
                 "relays": list(DEFAULT_NOSTR_RELAYS),
                 "pin_hash": "",
                 "password_hash": "",
+                "encryption_mode": DEFAULT_ENCRYPTION_MODE.value,
             }
         try:
             data = self.vault.load_config()
@@ -50,6 +55,7 @@ class ConfigManager:
             data.setdefault("relays", list(DEFAULT_NOSTR_RELAYS))
             data.setdefault("pin_hash", "")
             data.setdefault("password_hash", "")
+            data.setdefault("encryption_mode", DEFAULT_ENCRYPTION_MODE.value)
 
             # Migrate legacy hashed_password.enc if present and password_hash is missing
             legacy_file = self.fingerprint_dir / "hashed_password.enc"
@@ -112,4 +118,10 @@ class ConfigManager:
         """Persist the bcrypt password hash in the config."""
         config = self.load_config(require_pin=False)
         config["password_hash"] = password_hash
+        self.save_config(config)
+
+    def set_encryption_mode(self, mode: EncryptionMode) -> None:
+        """Persist the selected encryption mode in the config."""
+        config = self.load_config(require_pin=False)
+        config["encryption_mode"] = mode.value
         self.save_config(config)

--- a/src/tests/test_encryption_mode_change.py
+++ b/src/tests/test_encryption_mode_change.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.config_manager import ConfigManager
+from password_manager.vault import Vault
+from password_manager.manager import PasswordManager
+from utils.key_derivation import EncryptionMode
+
+
+def test_change_encryption_mode(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        fp = Path(tmpdir)
+        vault, enc_mgr = create_vault(
+            fp, TEST_SEED, TEST_PASSWORD, EncryptionMode.SEED_ONLY
+        )
+        entry_mgr = EntryManager(vault, fp)
+        cfg_mgr = ConfigManager(vault, fp)
+        vault.save_index({"passwords": {}})
+
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.encryption_manager = enc_mgr
+        pm.entry_manager = entry_mgr
+        pm.config_manager = cfg_mgr
+        pm.vault = vault
+        pm.password_generator = SimpleNamespace(encryption_manager=enc_mgr)
+        pm.fingerprint_dir = fp
+        pm.current_fingerprint = "fp"
+        pm.parent_seed = TEST_SEED
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+
+        monkeypatch.setattr(
+            "password_manager.manager.prompt_existing_password",
+            lambda *_: TEST_PASSWORD,
+        )
+        pm.verify_password = lambda pw: True
+
+        with patch("password_manager.manager.NostrClient") as MockClient:
+            mock = MockClient.return_value
+            pm.nostr_client = mock
+            pm.change_encryption_mode(EncryptionMode.SEED_PLUS_PW)
+            mock.publish_json_to_nostr.assert_called_once()
+
+        assert pm.encryption_mode is EncryptionMode.SEED_PLUS_PW
+        assert pm.password_generator.encryption_manager is pm.encryption_manager
+        loaded = vault.load_index()
+        assert loaded["passwords"] == {}
+        cfg = cfg_mgr.load_config(require_pin=False)
+        assert cfg["encryption_mode"] == EncryptionMode.SEED_PLUS_PW.value


### PR DESCRIPTION
## Summary
- allow profiles to persist encryption mode in config
- add ability to change encryption mode for a profile
- test encryption mode change behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6865411c2650832ba0bfbff4bcdecc0e