### PR TITLE
Fix missing path update in nostr index test

### DIFF
--- a/src/tests/test_nostr_index_size.py
+++ b/src/tests/test_nostr_index_size.py
@@ -2,9 +2,13 @@ import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
+import sys
 
 import pytest
+
 from cryptography.fernet import Fernet
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from password_manager.encryption import EncryptionManager
 from password_manager.entry_management import EntryManager


### PR DESCRIPTION
## Summary
- fix import path issue in `test_nostr_index_size.py`

## Testing
- `pytest -q src/tests/test_nostr_index_size.py -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68655b5c51d8832ba41fe3ea7f30f2b9