### PR TITLE
Use unique fingerprints for Nostr tests

### DIFF
--- a/src/tests/test_nostr_index_size.py
+++ b/src/tests/test_nostr_index_size.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 import sys
+import uuid
 
 import pytest
 
@@ -32,7 +33,7 @@ def test_nostr_index_size_limits():
         with patch.object(enc_mgr, "decrypt_parent_seed", return_value=seed):
             client = NostrClient(
                 enc_mgr,
-                "size_test_fp",
+                f"size_test_{uuid.uuid4().hex}",
                 relays=["wss://relay.snort.social"],
             )
             npub = client.key_manager.get_npub()

--- a/src/tests/test_nostr_real.py
+++ b/src/tests/test_nostr_real.py
@@ -4,6 +4,7 @@ import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
+import uuid
 
 import pytest
 from cryptography.fernet import Fernet
@@ -26,7 +27,7 @@ def test_nostr_publish_and_retrieve():
         with patch.object(enc_mgr, "decrypt_parent_seed", return_value=seed):
             client = NostrClient(
                 enc_mgr,
-                "test_fp_real",
+                f"test_fp_{uuid.uuid4().hex}",
                 relays=["wss://relay.snort.social"],
             )
             payload = b"seedpass"


### PR DESCRIPTION
## Summary
- generate a random fingerprint for nostr network tests
- ensure a new npub is used on every run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686583b03f04832bbbb4ffddbecf1026