### PR TITLE
Add Nostr backup models and constants

### DIFF
--- a/src/nostr/__init__.py
+++ b/src/nostr/__init__.py
@@ -5,9 +5,24 @@
 from importlib import import_module
 import logging
 
+from .backup_models import (
+    KIND_MANIFEST,
+    KIND_SNAPSHOT_CHUNK,
+    KIND_DELTA,
+    Manifest,
+    ChunkMeta,
+)
+
 logger = logging.getLogger(__name__)
 
-__all__ = ["NostrClient"]
+__all__ = [
+    "NostrClient",
+    "KIND_MANIFEST",
+    "KIND_SNAPSHOT_CHUNK",
+    "KIND_DELTA",
+    "Manifest",
+    "ChunkMeta",
+]
 
 
 def __getattr__(name: str):

--- a/src/nostr/backup_models.py
+++ b/src/nostr/backup_models.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+# Event kind constants used for SeedPass backups
+KIND_MANIFEST = 30070
+KIND_SNAPSHOT_CHUNK = 30071
+KIND_DELTA = 30072
+
+
+@dataclass
+class ChunkMeta:
+    """Metadata for an individual snapshot chunk."""
+
+    id: str
+    size: int
+    hash: str
+
+
+@dataclass
+class Manifest:
+    """Structure of the backup manifest JSON."""
+
+    ver: int
+    algo: str
+    chunks: List[ChunkMeta]
+    delta_since: Optional[str] = None


### PR DESCRIPTION
## Summary
- add `backup_models` module defining manifest-related dataclasses
- export manifest constants and classes from `nostr`

## Testing
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68658bc6e65c832b8b2caf5cf6feb2f4