### PR TITLE
Implement vault sync with Nostr snapshots

### DIFF
--- a/src/password_manager/portable_backup.py
+++ b/src/password_manager/portable_backup.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import time
+import asyncio
 from enum import Enum
 from pathlib import Path
 
@@ -103,7 +104,7 @@ def export_backup(
         os.chmod(enc_file, 0o600)
         try:
             client = NostrClient(vault.encryption_manager, vault.fingerprint_dir.name)
-            client.publish_json_to_nostr(encrypted)
+            asyncio.run(client.publish_snapshot(encrypted))
         except Exception:
             logger.error("Failed to publish backup via Nostr", exc_info=True)
 

--- a/src/tests/test_encryption_mode_change.py
+++ b/src/tests/test_encryption_mode_change.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 from helpers import create_vault, TEST_SEED, TEST_PASSWORD
 
@@ -44,9 +44,10 @@ def test_change_encryption_mode(monkeypatch):
 
         with patch("password_manager.manager.NostrClient") as MockClient:
             mock = MockClient.return_value
+            mock.publish_snapshot = AsyncMock(return_value=None)
             pm.nostr_client = mock
             pm.change_encryption_mode(EncryptionMode.SEED_PLUS_PW)
-            mock.publish_json_to_nostr.assert_called_once()
+            mock.publish_snapshot.assert_called_once()
 
         assert pm.encryption_mode is EncryptionMode.SEED_PLUS_PW
         assert pm.password_generator.encryption_manager is pm.encryption_manager

--- a/src/tests/test_manager_workflow.py
+++ b/src/tests/test_manager_workflow.py
@@ -60,7 +60,7 @@ def test_manager_workflow(monkeypatch):
         monkeypatch.setattr("builtins.input", lambda *args, **kwargs: next(inputs))
 
         pm.handle_add_password()
-        assert pm.is_dirty is True
+        assert pm.is_dirty is False
         backups = list(tmp_path.glob("passwords_db_backup_*.json.enc"))
         assert len(backups) == 1
         checksum_file = tmp_path / "seedpass_passwords_db_checksum.txt"
@@ -73,7 +73,7 @@ def test_manager_workflow(monkeypatch):
         assert pm.is_dirty is False
 
         pm.handle_modify_entry()
-        assert pm.is_dirty is True
+        assert pm.is_dirty is False
         pm.backup_manager.create_backup()
         backup_dir = tmp_path / "backups"
         backups_mod = list(backup_dir.glob("passwords_db_backup_*.json.enc"))

--- a/src/tests/test_password_change.py
+++ b/src/tests/test_password_change.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 from helpers import create_vault, TEST_SEED, TEST_PASSWORD
 
@@ -42,6 +42,7 @@ def test_change_password_triggers_nostr_backup(monkeypatch):
 
         with patch("password_manager.manager.NostrClient") as MockClient:
             mock_instance = MockClient.return_value
+            mock_instance.publish_snapshot = AsyncMock(return_value=None)
             pm.nostr_client = mock_instance
             pm.change_password()
-            mock_instance.publish_json_to_nostr.assert_called_once()
+            mock_instance.publish_snapshot.assert_called_once()

--- a/src/tests/test_post_sync_messages.py
+++ b/src/tests/test_post_sync_messages.py
@@ -9,10 +9,7 @@ import main
 
 def test_handle_post_success(capsys):
     pm = SimpleNamespace(
-        get_encrypted_data=lambda: b"data",
-        nostr_client=SimpleNamespace(
-            publish_json_to_nostr=lambda data, alt_summary=None: True
-        ),
+        sync_vault=lambda alt_summary=None: True,
     )
     main.handle_post_to_nostr(pm)
     out = capsys.readouterr().out
@@ -21,10 +18,7 @@ def test_handle_post_success(capsys):
 
 def test_handle_post_failure(capsys):
     pm = SimpleNamespace(
-        get_encrypted_data=lambda: b"data",
-        nostr_client=SimpleNamespace(
-            publish_json_to_nostr=lambda data, alt_summary=None: False
-        ),
+        sync_vault=lambda alt_summary=None: False,
     )
     main.handle_post_to_nostr(pm)
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- introduce `sync_vault` helper that uses Nostr snapshots
- restore vault using `fetch_latest_snapshot` and deltas
- update CLI functions and password flows to use `sync_vault`
- adjust portable backup publishing
- update tests for new sync logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686592c8fd08832b9f718cc2cb98ea2d