### PR TITLE
Update tests for snapshot API

### DIFF
--- a/src/tests/test_encryption_mode_migration.py
+++ b/src/tests/test_encryption_mode_migration.py
@@ -57,7 +57,7 @@ def test_encryption_mode_migration(monkeypatch, start_mode, new_mode):
         pm.current_fingerprint = "fp"
         pm.parent_seed = TEST_SEED
         pm.encryption_mode = start_mode
-        pm.nostr_client = SimpleNamespace(publish_json_to_nostr=lambda *a, **k: None)
+        pm.nostr_client = SimpleNamespace(publish_snapshot=lambda *a, **k: None)
 
         monkeypatch.setattr(
             "password_manager.manager.prompt_existing_password",
@@ -65,9 +65,7 @@ def test_encryption_mode_migration(monkeypatch, start_mode, new_mode):
         )
         monkeypatch.setattr(
             "password_manager.manager.NostrClient",
-            lambda *a, **kw: SimpleNamespace(
-                publish_json_to_nostr=lambda *a, **k: None
-            ),
+            lambda *a, **kw: SimpleNamespace(publish_snapshot=lambda *a, **k: None),
         )
 
         pm.change_encryption_mode(new_mode)

--- a/src/tests/test_manager_workflow.py
+++ b/src/tests/test_manager_workflow.py
@@ -20,9 +20,8 @@ class FakeNostrClient:
     def __init__(self, *args, **kwargs):
         self.published = []
 
-    def publish_json_to_nostr(self, data: bytes):
+    def publish_snapshot(self, data: bytes):
         self.published.append(data)
-        return True
 
 
 def test_manager_workflow(monkeypatch):

--- a/src/tests/test_nostr_backup.py
+++ b/src/tests/test_nostr_backup.py
@@ -1,7 +1,8 @@
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
+import asyncio
 from helpers import create_vault, TEST_SEED, TEST_PASSWORD
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -23,7 +24,8 @@ def test_backup_and_publish_to_nostr():
         assert encrypted_index is not None
 
         with patch(
-            "nostr.client.NostrClient.publish_json_to_nostr", return_value=True
+            "nostr.client.NostrClient.publish_snapshot",
+            AsyncMock(return_value=None),
         ) as mock_publish, patch("nostr.client.ClientBuilder"), patch(
             "nostr.client.KeyManager"
         ), patch.object(
@@ -33,7 +35,7 @@ def test_backup_and_publish_to_nostr():
         ):
             nostr_client = NostrClient(enc_mgr, "fp")
             entry_mgr.backup_index_file()
-            result = nostr_client.publish_json_to_nostr(encrypted_index)
+            result = asyncio.run(nostr_client.publish_snapshot(encrypted_index))
 
-        mock_publish.assert_called_with(encrypted_index)
-        assert result is True
+        mock_publish.assert_awaited_with(encrypted_index)
+        assert result is None

--- a/src/tests/test_nostr_real.py
+++ b/src/tests/test_nostr_real.py
@@ -4,6 +4,8 @@ import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
+import asyncio
+import gzip
 import uuid
 
 import pytest
@@ -31,8 +33,9 @@ def test_nostr_publish_and_retrieve():
                 relays=["wss://relay.snort.social"],
             )
             payload = b"seedpass"
-            assert client.publish_json_to_nostr(payload) is True
+            asyncio.run(client.publish_snapshot(payload))
             time.sleep(2)
-            retrieved = client.retrieve_json_from_nostr_sync()
+            result = asyncio.run(client.fetch_latest_snapshot())
+            retrieved = gzip.decompress(b"".join(result[1])) if result else None
             client.close_client_pool()
             assert retrieved == payload

--- a/src/tests/test_password_unlock_after_change.py
+++ b/src/tests/test_password_unlock_after_change.py
@@ -54,7 +54,7 @@ def test_password_change_and_unlock(monkeypatch):
         pm.fingerprint_dir = fp
         pm.current_fingerprint = "fp"
         pm.parent_seed = SEED
-        pm.nostr_client = SimpleNamespace(publish_json_to_nostr=lambda *a, **k: None)
+        pm.nostr_client = SimpleNamespace(publish_snapshot=lambda *a, **k: None)
 
         monkeypatch.setattr(
             "password_manager.manager.prompt_existing_password", lambda *_: old_pw
@@ -64,9 +64,7 @@ def test_password_change_and_unlock(monkeypatch):
         )
         monkeypatch.setattr(
             "password_manager.manager.NostrClient",
-            lambda *a, **kw: SimpleNamespace(
-                publish_json_to_nostr=lambda *a, **k: None
-            ),
+            lambda *a, **kw: SimpleNamespace(publish_snapshot=lambda *a, **k: None),
         )
 
         pm.change_password()

--- a/src/tests/test_profile_management.py
+++ b/src/tests/test_profile_management.py
@@ -60,9 +60,7 @@ def test_add_and_delete_entry(monkeypatch):
 
         published = []
         pm.nostr_client = SimpleNamespace(
-            publish_json_to_nostr=lambda data, alt_summary=None: (
-                published.append(data) or True
-            )
+            publish_snapshot=lambda data, alt_summary=None: published.append(data)
         )
 
         inputs = iter([str(index)])

--- a/src/tests/test_settings_menu.py
+++ b/src/tests/test_settings_menu.py
@@ -33,7 +33,7 @@ def setup_pm(tmp_path, monkeypatch):
         relays=list(DEFAULT_RELAYS),
         close_client_pool=lambda: None,
         initialize_client_pool=lambda: None,
-        publish_json_to_nostr=lambda data, alt_summary=None: None,
+        publish_snapshot=lambda data, alt_summary=None: None,
         key_manager=SimpleNamespace(get_npub=lambda: "npub"),
     )
 


### PR DESCRIPTION
## Summary
- update all tests to use `publish_snapshot` and `fetch_latest_snapshot`
- adjust fake clients and helpers accordingly
- add `asyncio.run(...)` calls for new coroutine methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68659d1d996c832bb68333dd43dc6a40