### PR TITLE
Drop encryption mode selection

### DIFF
--- a/src/tests/test_default_encryption_mode.py
+++ b/src/tests/test_default_encryption_mode.py
@@ -3,9 +3,27 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from types import SimpleNamespace
+from pathlib import Path
+
 from password_manager.manager import PasswordManager
-from utils.key_derivation import DEFAULT_ENCRYPTION_MODE
+from utils.key_derivation import EncryptionMode
 
 
-def test_default_encryption_mode():
-    assert PasswordManager.__init__.__defaults__[0] is DEFAULT_ENCRYPTION_MODE
+def test_default_encryption_mode(monkeypatch):
+    monkeypatch.setattr(
+        PasswordManager,
+        "initialize_fingerprint_manager",
+        lambda self: setattr(
+            self,
+            "fingerprint_manager",
+            SimpleNamespace(
+                get_current_fingerprint_dir=lambda: Path("./"),
+                list_fingerprints=lambda: [],
+            ),
+        ),
+    )
+    monkeypatch.setattr(PasswordManager, "setup_parent_seed", lambda self: None)
+
+    pm = PasswordManager()
+    assert pm.encryption_mode is EncryptionMode.SEED_ONLY


### PR DESCRIPTION
## Summary
- remove unused encryption mode logic from `PasswordManager`
- fix tests for new `PasswordManager` initializer

## Testing
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6865ba837834832b93e9e86632b885a9