### PR TITLE
Remove legacy encryption options from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ SeedPass and create a backup:
 # Start the application
 python src/main.py
 
-# Export your index using seed-only encryption
-seedpass export --mode seed-only --file "~/seedpass_backup.json"
+# Export your index
+seedpass export --file "~/seedpass_backup.json"
 
 # Later you can restore it
-seedpass import --mode seed-only --file "~/seedpass_backup.json"
+seedpass import --file "~/seedpass_backup.json"
 ```
 
 
@@ -154,29 +154,6 @@ python src/main.py
    Enter your choice (1-5):
    ```
 
-### Encryption Mode
-
-Use the `--encryption-mode` flag to control how SeedPass derives the key used to
-encrypt your vault. Valid values are:
-
-- `seed-only` – default mode that derives the vault key solely from your BIP-85
-  seed.
-- `seed+pw` – combines the seed with your master password for key derivation.
-- `pw-only` – derives the key from your password alone.
-
-You can set this option when launching the application:
-
-```bash
-python src/main.py --encryption-mode seed+pw
-```
-
-To make the choice persistent, add it to `~/.seedpass/config.toml`:
-
-```toml
-encryption_mode = "seed+pw"
-```
-
-SeedPass will read this value on startup and use the specified mode by default.
 
 ### Managing Multiple Seeds
 

--- a/docs/advanced_cli.md
+++ b/docs/advanced_cli.md
@@ -219,23 +219,6 @@ seedpass export --file "backup_passwords.json"
 **Options:**
 - `--file` (`-F`): The destination file path for the exported data. If omitted, the export
   is saved to the current profile's `exports` directory under `~/.seedpass/<profile>/exports/`.
-- `--mode` (`-M`): Choose the encryption mode for the exported file. Valid values are:
-  `seed-only`, `seed+pw`, `pw-only`, and `plaintext`.
-
-**Examples:**
-```bash
-# Standard encrypted export
-seedpass export --mode seed-only --file "backup.json"
-# Combine seed and master password for the export key
-seedpass export --mode seed+pw --file "backup.json"
-# Derive the key solely from your password
-seedpass export --mode pw-only --file "backup.json"
-# Plaintext JSON export (not recommended)
-seedpass export --mode plaintext --file "backup.json"
-```
-
-**Warning:** The `plaintext` mode writes an unencrypted index to disk. Only use it
-for debugging and delete the file immediately after use.
 
 ---
 
@@ -255,15 +238,6 @@ seedpass import --file "backup_passwords.json"
 
 **Options:**
 - `--file` (`-F`): The source file path containing the password entries to import.
-- `--mode` (`-M`): Indicates the encryption mode used when the file was exported. Accepted values are `seed-only`, `seed+pw`, `pw-only`, and `plaintext`.
-
-**Examples:**
-```bash
-# Import a standard encrypted backup
-seedpass import --mode seed-only --file "backup.json"
-# Import a backup that also used the master password
-seedpass import --mode seed+pw --file "backup.json"
-```
 
 ---
 


### PR DESCRIPTION
## Summary
- scrub references to `seed+pw` and `pw-only` modes
- drop docs for `--encryption-mode` and backup `--mode`

## Testing
- `pip install -r src/requirements.txt`
- `black .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6865c3848e1c832b811f54d601e92bca