### PR TITLE
Add EntryType enum

### DIFF
--- a/src/password_manager/__init__.py
+++ b/src/password_manager/__init__.py
@@ -4,7 +4,7 @@
 
 from importlib import import_module
 
-__all__ = ["PasswordManager", "ConfigManager", "Vault"]
+__all__ = ["PasswordManager", "ConfigManager", "Vault", "EntryType"]
 
 
 def __getattr__(name: str):
@@ -14,4 +14,6 @@ def __getattr__(name: str):
         return import_module(".config_manager", __name__).ConfigManager
     if name == "Vault":
         return import_module(".vault", __name__).Vault
+    if name == "EntryType":
+        return import_module(".entry_types", __name__).EntryType
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/src/password_manager/entry_types.py
+++ b/src/password_manager/entry_types.py
@@ -1,0 +1,13 @@
+# password_manager/entry_types.py
+"""Enumerations for entry types used by SeedPass."""
+
+from enum import Enum
+
+
+class EntryType(str, Enum):
+    """Enumeration of different entry types supported by the manager."""
+
+    PASSWORD = "password"
+    TOTP = "totp"
+    SSH = "ssh"
+    SEED = "seed"


### PR DESCRIPTION
## Summary
- add `entry_types.py` with `EntryType` enum
- export `EntryType` from `password_manager.__init__`

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6865d705191c832b998cfbed7f532bda