### PR TITLE
Add initialization helper for SeedPass app directory

### DIFF
--- a/examples/entry_management_demo.py
+++ b/examples/entry_management_demo.py
@@ -4,10 +4,12 @@ from cryptography.fernet import Fernet
 from password_manager.encryption import EncryptionManager
 from password_manager.vault import Vault
 from password_manager.entry_management import EntryManager
+from constants import initialize_app
 
 
 def main() -> None:
     """Demonstrate basic EntryManager usage."""
+    initialize_app()
     key = Fernet.generate_key()
     enc = EncryptionManager(key, Path("."))
     vault = Vault(enc, Path("."))

--- a/examples/password_manager_demo.py
+++ b/examples/password_manager_demo.py
@@ -1,9 +1,11 @@
 from password_manager.manager import PasswordManager
 from nostr.client import NostrClient
+from constants import initialize_app
 
 
 def main() -> None:
     """Show how to initialise PasswordManager with Nostr support."""
+    initialize_app()
     manager = PasswordManager()
     manager.nostr_client = NostrClient(encryption_manager=manager.encryption_manager)
     # Sample actions could be called on ``manager`` here.

--- a/scripts/update_checksum.py
+++ b/scripts/update_checksum.py
@@ -8,11 +8,12 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 from utils.checksum import calculate_checksum
-from constants import SCRIPT_CHECKSUM_FILE
+from constants import SCRIPT_CHECKSUM_FILE, initialize_app
 
 
 def main() -> None:
     """Calculate checksum for the main script and write it to SCRIPT_CHECKSUM_FILE."""
+    initialize_app()
     script_path = SRC_DIR / "password_manager" / "manager.py"
     checksum = calculate_checksum(str(script_path))
     if checksum is None:

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,10 +1,7 @@
 # constants.py
 
-import os
 import logging
-import sys
 from pathlib import Path
-import traceback
 
 # Instantiate the logger
 logger = logging.getLogger(__name__)
@@ -15,38 +12,32 @@ logger = logging.getLogger(__name__)
 MAX_RETRIES = 3  # Maximum number of retries for relay connections
 RETRY_DELAY = 5  # Seconds to wait before retrying a failed connection
 
-try:
-    # -----------------------------------
-    # Application Directory and Paths
-    # -----------------------------------
-    APP_DIR = Path.home() / ".seedpass"
-    APP_DIR.mkdir(exist_ok=True, parents=True)  # Ensure the directory exists
-    if logger.isEnabledFor(logging.DEBUG):
-        logger.info(f"Application directory created at {APP_DIR}")
-except Exception as e:
-    if logger.isEnabledFor(logging.DEBUG):
-        logger.error(f"Failed to create application directory: {e}", exc_info=True)
-
-try:
-    PARENT_SEED_FILE = APP_DIR / "parent_seed.enc"  # Encrypted parent seed
-    if logger.isEnabledFor(logging.DEBUG):
-        logger.info(f"Parent seed file path set to {PARENT_SEED_FILE}")
-except Exception as e:
-    if logger.isEnabledFor(logging.DEBUG):
-        logger.error(f"Error setting file paths: {e}", exc_info=True)
+# -----------------------------------
+# Application Directory and Paths
+# -----------------------------------
+APP_DIR = Path.home() / ".seedpass"
+PARENT_SEED_FILE = APP_DIR / "parent_seed.enc"  # Encrypted parent seed
 
 # -----------------------------------
 # Checksum Files for Integrity
 # -----------------------------------
-try:
-    SCRIPT_CHECKSUM_FILE = (
-        APP_DIR / "seedpass_script_checksum.txt"
-    )  # Checksum for main script
-    if logger.isEnabledFor(logging.DEBUG):
-        logger.info(f"Checksum file path set: Script {SCRIPT_CHECKSUM_FILE}")
-except Exception as e:
-    if logger.isEnabledFor(logging.DEBUG):
-        logger.error(f"Error setting checksum file paths: {e}", exc_info=True)
+SCRIPT_CHECKSUM_FILE = (
+    APP_DIR / "seedpass_script_checksum.txt"
+)  # Checksum for main script
+
+
+def initialize_app() -> None:
+    """Ensure the application directory exists."""
+    try:
+        APP_DIR.mkdir(exist_ok=True, parents=True)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.info(f"Application directory created at {APP_DIR}")
+    except Exception as exc:
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.error(
+                f"Failed to create application directory: {exc}", exc_info=True
+            )
+
 
 # -----------------------------------
 # Password Generation Constants

--- a/src/main.py
+++ b/src/main.py
@@ -16,7 +16,7 @@ import traceback
 
 from password_manager.manager import PasswordManager
 from nostr.client import NostrClient
-from constants import INACTIVITY_TIMEOUT
+from constants import INACTIVITY_TIMEOUT, initialize_app
 from utils.password_prompt import PasswordPromptError
 from local_bip85.bip85 import Bip85Error
 
@@ -613,6 +613,7 @@ def display_menu(
 if __name__ == "__main__":
     # Configure logging with both file and console handlers
     configure_logging()
+    initialize_app()
     logger = logging.getLogger(__name__)
     logger.info("Starting SeedPass Password Manager")
 

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -47,6 +47,7 @@ from constants import (
     DEFAULT_PASSWORD_LENGTH,
     INACTIVITY_TIMEOUT,
     DEFAULT_SEED_BACKUP_FILENAME,
+    initialize_app,
 )
 
 import traceback
@@ -80,6 +81,7 @@ class PasswordManager:
 
     def __init__(self) -> None:
         """Initialize the PasswordManager."""
+        initialize_app()
         self.encryption_mode: EncryptionMode = EncryptionMode.SEED_ONLY
         self.encryption_manager: Optional[EncryptionManager] = None
         self.entry_manager: Optional[EntryManager] = None


### PR DESCRIPTION
## Summary
- create a new `initialize_app()` helper in `constants`
- move directory/path creation out of module scope
- invoke `initialize_app()` at startup in main script and demo utilities
- call the initializer from `PasswordManager.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6865e4171650832bb03b91092719a8df