### PR TITLE
Add notes field and stub entry types

### DIFF
--- a/src/tests/test_entry_add.py
+++ b/src/tests/test_entry_add.py
@@ -23,6 +23,8 @@ def test_add_and_retrieve_entry():
             "username": "user",
             "url": "",
             "blacklisted": False,
+            "type": "password",
+            "notes": "",
         }
 
         data = enc_mgr.load_json_data(entry_mgr.index_file)


### PR DESCRIPTION
## Summary
- generalize docs and messages in entry management
- extend `add_entry` to support notes and automatically store entry type
- allow modifying notes in `modify_entry`
- add placeholder methods for other entry types
- update entry add test to include notes and type fields

## Testing
- `black src/password_manager/entry_management.py src/tests/test_entry_add.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6865e85a00e0832bac8bc7b0813e6ce9