### PR TITLE
Add notes prompt when editing entries

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -801,6 +801,7 @@ class PasswordManager:
 
             username = input("Enter the username (optional): ").strip()
             url = input("Enter the URL (optional): ").strip()
+            notes = input("Enter notes (optional): ").strip()
 
             length_input = input(
                 f"Enter desired password length (default {DEFAULT_PASSWORD_LENGTH}): "
@@ -822,7 +823,12 @@ class PasswordManager:
 
             # Add the entry to the index and get the assigned index
             index = self.entry_manager.add_entry(
-                website_name, length, username, url, blacklisted=False
+                website_name,
+                length,
+                username,
+                url,
+                blacklisted=False,
+                notes=notes,
             )
 
             # Mark database as dirty for background sync
@@ -881,6 +887,10 @@ class PasswordManager:
             username = entry.get("username")
             url = entry.get("url")
             blacklisted = entry.get("blacklisted")
+            notes = entry.get("notes", "")
+            notes = entry.get("notes", "")
+            notes = entry.get("notes", "")
+            notes = entry.get("notes", "")
 
             print(
                 colored(
@@ -947,6 +957,7 @@ class PasswordManager:
             username = entry.get("username")
             url = entry.get("url")
             blacklisted = entry.get("blacklisted")
+            notes = entry.get("notes", "")
 
             # Display current values
             print(
@@ -996,9 +1007,20 @@ class PasswordManager:
                 )
                 new_blacklisted = blacklisted
 
+            new_notes = (
+                input(
+                    f'Enter new notes (leave blank to keep "{notes or "N/A"}"): '
+                ).strip()
+                or notes
+            )
+
             # Update the entry
             self.entry_manager.modify_entry(
-                index, new_username, new_url, new_blacklisted
+                index,
+                new_username,
+                new_url,
+                new_blacklisted,
+                new_notes,
             )
 
             # Mark database as dirty for background sync

--- a/src/tests/test_manager_workflow.py
+++ b/src/tests/test_manager_workflow.py
@@ -51,11 +51,13 @@ def test_manager_workflow(monkeypatch):
                 "",  # username
                 "",  # url
                 "",  # length (default)
+                "",  # notes
                 "0",  # retrieve index
                 "0",  # modify index
                 "user",  # new username
                 "",  # new url
                 "",  # blacklist status
+                "",  # new notes
             ]
         )
         monkeypatch.setattr("builtins.input", lambda *args, **kwargs: next(inputs))


### PR DESCRIPTION
## Summary
- ask for notes in `handle_add_password`
- ask for notes in `handle_modify_entry`
- update workflow test for new prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6865ecfb02ec832bae4c20a26e99abb3