### PR TITLE
Implement new TOTP derivation

### DIFF
--- a/src/password_manager/password_generation.py
+++ b/src/password_manager/password_generation.py
@@ -335,12 +335,6 @@ class PasswordGenerator:
             raise
 
 
-def derive_totp_secret(bip85: BIP85, idx: int) -> str:
-    """Derive a TOTP secret for the given index using BIP85."""
-    entropy = bip85.derive_entropy(index=idx, bytes_len=10, app_no=2)
-    return base64.b32encode(entropy).decode("utf-8")
-
-
 def derive_ssh_key(bip85: BIP85, idx: int) -> bytes:
     """Derive 32 bytes of entropy suitable for an SSH key."""
     return bip85.derive_entropy(index=idx, bytes_len=32, app_no=32)

--- a/src/tests/test_bip85_vectors.py
+++ b/src/tests/test_bip85_vectors.py
@@ -6,10 +6,10 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from local_bip85.bip85 import BIP85, Bip85Error
 from password_manager.password_generation import (
-    derive_totp_secret,
     derive_ssh_key,
     derive_seed_phrase,
 )
+from utils.key_derivation import derive_totp_secret
 
 MASTER_XPRV = "xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb"
 
@@ -18,7 +18,7 @@ EXPECTED_12 = "girl mad pet galaxy egg matter matrix prison refuse sense ordinar
 EXPECTED_24 = "puppy ocean match cereal symbol another shed magic wrap hammer bulb intact gadget divorce twin tonight reason outdoor destroy simple truth cigar social volcano"
 
 EXPECTED_SYMM_KEY = "7040bb53104f27367f317558e78a994ada7296c6fde36a364e5baf206e502bb1"
-EXPECTED_TOTP_SECRET = "OBALWUYQJ4TTM7ZR"
+EXPECTED_TOTP_SECRET = "VQYTWDNEWYBY2G3LOGGCEKR4LZ3LNEYY"
 EXPECTED_SSH_KEY = "52405cd0dd21c5be78314a7c1a3c65ffd8d896536cc7dee3157db5824f0c92e2"
 
 
@@ -39,8 +39,8 @@ def test_bip85_symmetric_key(bip85):
     assert bip85.derive_symmetric_key(index=0).hex() == EXPECTED_SYMM_KEY
 
 
-def test_derive_totp_secret(bip85):
-    assert derive_totp_secret(bip85, 0) == EXPECTED_TOTP_SECRET
+def test_derive_totp_secret():
+    assert derive_totp_secret(EXPECTED_24, 0) == EXPECTED_TOTP_SECRET
 
 
 def test_derive_ssh_key(bip85):

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -11,8 +11,10 @@ try:
         derive_key_from_password,
         derive_key_from_parent_seed,
         derive_index_key,
+        derive_totp_secret,
         EncryptionMode,
         DEFAULT_ENCRYPTION_MODE,
+        TOTP_PURPOSE,
     )
     from .checksum import (
         calculate_checksum,
@@ -33,8 +35,10 @@ __all__ = [
     "derive_key_from_password",
     "derive_key_from_parent_seed",
     "derive_index_key",
+    "derive_totp_secret",
     "EncryptionMode",
     "DEFAULT_ENCRYPTION_MODE",
+    "TOTP_PURPOSE",
     "calculate_checksum",
     "verify_checksum",
     "json_checksum",


### PR DESCRIPTION
## Summary
- support BIP85 TOTP derivation path
- export new helper in utils
- remove legacy TOTP helper
- update test vectors

## Testing
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6865fc343300832ba6dae5287642ad36