### PR TITLE
Add TOTP entry support

### DIFF
--- a/src/tests/test_entry_add.py
+++ b/src/tests/test_entry_add.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
 import pytest
 from helpers import create_vault, TEST_SEED, TEST_PASSWORD
 
@@ -49,6 +51,10 @@ def test_round_trip_entry_types(method, expected_type):
 
         if method == "add_entry":
             index = entry_mgr.add_entry("example.com", 8)
+        elif method == "add_totp":
+            with patch.object(enc_mgr, "decrypt_parent_seed", return_value=TEST_SEED):
+                entry_mgr.add_totp("example", 0)
+            index = 0
         else:
             with pytest.raises(NotImplementedError):
                 getattr(entry_mgr, method)()

--- a/src/tests/test_totp_entry.py
+++ b/src/tests/test_totp_entry.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import pytest
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.vault import Vault
+from password_manager.totp import TotpManager
+
+
+def test_add_totp_and_get_code():
+    with TemporaryDirectory() as tmpdir:
+        vault, enc_mgr = create_vault(Path(tmpdir), TEST_SEED, TEST_PASSWORD)
+        entry_mgr = EntryManager(vault, Path(tmpdir))
+
+        with patch.object(enc_mgr, "decrypt_parent_seed", return_value=TEST_SEED):
+            uri = entry_mgr.add_totp("Example", 0)
+            assert uri.startswith("otpauth://totp/")
+
+        entry = entry_mgr.retrieve_entry(0)
+        assert entry == {
+            "type": "totp",
+            "label": "Example",
+            "index": 0,
+            "period": 30,
+            "digits": 6,
+        }
+
+        with patch.object(enc_mgr, "decrypt_parent_seed", return_value=TEST_SEED):
+            code = entry_mgr.get_totp_code(0, timestamp=0)
+
+        expected = TotpManager.current_code(TEST_SEED, 0, timestamp=0)
+        assert code == expected
+
+
+def test_totp_time_remaining(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        vault, enc_mgr = create_vault(Path(tmpdir), TEST_SEED, TEST_PASSWORD)
+        entry_mgr = EntryManager(vault, Path(tmpdir))
+
+        with patch.object(enc_mgr, "decrypt_parent_seed", return_value=TEST_SEED):
+            entry_mgr.add_totp("Example", 0)
+
+        monkeypatch.setattr(TotpManager, "time_remaining", lambda period: 7)
+        remaining = entry_mgr.get_totp_time_remaining(0)
+        assert remaining == 7


### PR DESCRIPTION
## Summary
- support legacy entries missing `type`
- implement TOTP entry handling and helper methods
- display TOTP entries cleanly in listings
- update existing tests for new TOTP behaviour
- add tests for TOTP entry workflow

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6865fe823a6c832bbf60e2dd14b64293