### PR TITLE
Add totp tests and legacy entry fallback

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -19,3 +19,5 @@ tomli
 hypothesis
 mutmut==2.4.4
 pyotp>=2.8.0
+
+freezegun

--- a/src/tests/test_entry_add.py
+++ b/src/tests/test_entry_add.py
@@ -64,3 +64,18 @@ def test_round_trip_entry_types(method, expected_type):
         assert entry["type"] == expected_type
         data = enc_mgr.load_json_data(entry_mgr.index_file)
         assert data["entries"][str(index)]["type"] == expected_type
+
+
+def test_legacy_entry_defaults_to_password():
+    with TemporaryDirectory() as tmpdir:
+        vault, enc_mgr = create_vault(Path(tmpdir), TEST_SEED, TEST_PASSWORD)
+        entry_mgr = EntryManager(vault, Path(tmpdir))
+
+        index = entry_mgr.add_entry("example.com", 8)
+
+        data = enc_mgr.load_json_data(entry_mgr.index_file)
+        data["entries"][str(index)].pop("type", None)
+        enc_mgr.save_json_data(data, entry_mgr.index_file)
+
+        loaded = entry_mgr._load_index()
+        assert loaded["entries"][str(index)]["type"] == "password"

--- a/src/tests/test_totp.py
+++ b/src/tests/test_totp.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+import pyotp
+from freezegun import freeze_time
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from helpers import TEST_SEED
+from password_manager.totp import TotpManager
+
+
+@freeze_time("1970-01-01 00:16:40")
+def test_current_code_matches_pyotp():
+    secret = TotpManager.derive_secret(TEST_SEED, 0)
+    expected = pyotp.TOTP(secret).now()
+    assert TotpManager.current_code(TEST_SEED, 0) == expected
+
+
+@freeze_time("1970-01-01 00:00:15")
+def test_time_remaining():
+    assert TotpManager.time_remaining(period=30) == 15
+
+
+def test_print_progress_bar_terminates(monkeypatch):
+    monkeypatch.setattr(TotpManager, "time_remaining", lambda period: 0)
+    calls = []
+    monkeypatch.setattr("password_manager.totp.time.sleep", lambda s: calls.append(s))
+    TotpManager.print_progress_bar(period=30)
+    assert calls == []


### PR DESCRIPTION
## Summary
- test TotpManager utilities with frozen time
- verify EntryManager handles entries without `type`
- add `freezegun` test dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686600da6ebc832bade39d7b91288a6f