### PR TITLE
Document get-code progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 - **Checksum Verification:** Ensure the integrity of the script with checksum verification.
 - **Multiple Seed Profiles:** Manage separate seed profiles and switch between them seamlessly.
 - **Interactive TUI:** Navigate through menus to add, retrieve, and modify entries as well as configure Nostr settings.
+- **SeedPass 2FA:** Generate TOTP codes with a real-time countdown progress bar.
 
 ## Prerequisites
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# SeedPass Documentation
+
+This directory contains supplementary guides for using SeedPass.
+
+## Quick Example: Get a TOTP Code
+
+Run `seedpass get-code` to retrieve a time-based one-time password (TOTP). A progress bar shows the remaining seconds in the current period.
+
+```bash
+$ seedpass get-code --index 0
+[##########----------] 15s
+Code: 123456
+```
+
+See [advanced_cli.md](advanced_cli.md) for a full command reference.


### PR DESCRIPTION
## Summary
- document get-code usage in docs/README
- mention the new "SeedPass 2FA" capability in the main README

## Testing
- `black .`
- `pytest -k totp`


------
https://chatgpt.com/codex/tasks/task_b_68660276c344832b8339fba652a6b37d