### PR TITLE
Add manual 2FA entry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,17 @@ python src/main.py
    Enter your choice (1-5):
    ```
 
+   When choosing **Add Entry**, you can now select **Password** or **2FA (TOTP)**.
+
+### Adding a 2FA Entry
+
+1. From the main menu choose **Add Entry** and select **2FA (TOTP)**.
+2. Provide a label for the account (for example, `GitHub`).
+3. Enter the derivation index you wish to use for this 2FA code.
+4. Optionally specify the TOTP period and digit count.
+5. SeedPass will display an `otpauth://` URI and secret that you can manually
+   enter into your authenticator app.
+
 
 ### Managing Multiple Seeds
 

--- a/src/main.py
+++ b/src/main.py
@@ -591,13 +591,17 @@ def display_menu(
             while True:
                 print("\nAdd Entry:")
                 print("1. Password")
-                print("2. Back")
+                print("2. 2FA (TOTP)")
+                print("3. Back")
                 sub_choice = input("Select entry type: ").strip()
                 password_manager.update_activity()
                 if sub_choice == "1":
                     password_manager.handle_add_password()
                     break
                 elif sub_choice == "2":
+                    password_manager.handle_add_totp()
+                    break
+                elif sub_choice == "3":
                     break
                 else:
                     print(colored("Invalid choice.", "red"))

--- a/src/tests/test_cli_invalid_input.py
+++ b/src/tests/test_cli_invalid_input.py
@@ -39,6 +39,7 @@ def _make_pm(called, locked=None):
         last_activity=time.time(),
         nostr_client=SimpleNamespace(close_client_pool=lambda: None),
         handle_add_password=add,
+        handle_add_totp=lambda: None,
         handle_retrieve_entry=retrieve,
         handle_modify_entry=modify,
         update_activity=update,
@@ -76,7 +77,7 @@ def test_out_of_range_menu(monkeypatch, capsys):
 def test_invalid_add_entry_submenu(monkeypatch, capsys):
     called = {"add": False, "retrieve": False, "modify": False}
     pm, _ = _make_pm(called)
-    inputs = iter(["1", "3", "2", "5"])
+    inputs = iter(["1", "4", "3", "5"])
     monkeypatch.setattr(main, "timed_input", lambda *_: next(inputs))
     monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
     with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary
- extend the interactive menu with a `2FA (TOTP)` option
- implement `handle_add_totp` in `PasswordManager`
- document the new workflow in the README
- update CLI tests for the new submenu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866051959d8832ba68f1d3258b38bab