### PR TITLE
Fix TOTP index generation and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ python src/main.py
 
 1. From the main menu choose **Add Entry** and select **2FA (TOTP)**.
 2. Provide a label for the account (for example, `GitHub`).
-3. Enter the derivation index you wish to use for this 2FA code.
+3. SeedPass automatically chooses the next available derivation index.
 4. Optionally specify the TOTP period and digit count.
 5. SeedPass will display an `otpauth://` URI and secret that you can manually
    enter into your authenticator app.

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -870,11 +870,7 @@ class PasswordManager:
                 print(colored("Error: Label cannot be empty.", "red"))
                 return
 
-            index_input = input("Enter derivation index (number): ").strip()
-            if not index_input.isdigit():
-                print(colored("Error: Index must be a number.", "red"))
-                return
-            totp_index = int(index_input)
+            totp_index = self.entry_manager.get_next_totp_index()
 
             period_input = input("TOTP period in seconds (default 30): ").strip()
             period = 30
@@ -893,7 +889,13 @@ class PasswordManager:
                 digits = int(digits_input)
 
             entry_id = self.entry_manager.get_next_index()
-            uri = self.entry_manager.add_totp(label, totp_index, period, digits)
+            uri = self.entry_manager.add_totp(
+                label,
+                self.parent_seed,
+                index=totp_index,
+                period=period,
+                digits=digits,
+            )
 
             self.is_dirty = True
             self.last_update = time.time()

--- a/src/tests/test_entry_add.py
+++ b/src/tests/test_entry_add.py
@@ -52,8 +52,7 @@ def test_round_trip_entry_types(method, expected_type):
         if method == "add_entry":
             index = entry_mgr.add_entry("example.com", 8)
         elif method == "add_totp":
-            with patch.object(enc_mgr, "decrypt_parent_seed", return_value=TEST_SEED):
-                entry_mgr.add_totp("example", 0)
+            entry_mgr.add_totp("example", TEST_SEED)
             index = 0
         else:
             with pytest.raises(NotImplementedError):

--- a/src/tests/test_totp_entry.py
+++ b/src/tests/test_totp_entry.py
@@ -19,9 +19,8 @@ def test_add_totp_and_get_code():
         vault, enc_mgr = create_vault(Path(tmpdir), TEST_SEED, TEST_PASSWORD)
         entry_mgr = EntryManager(vault, Path(tmpdir))
 
-        with patch.object(enc_mgr, "decrypt_parent_seed", return_value=TEST_SEED):
-            uri = entry_mgr.add_totp("Example", 0)
-            assert uri.startswith("otpauth://totp/")
+        uri = entry_mgr.add_totp("Example", TEST_SEED)
+        assert uri.startswith("otpauth://totp/")
 
         entry = entry_mgr.retrieve_entry(0)
         assert entry == {
@@ -32,8 +31,7 @@ def test_add_totp_and_get_code():
             "digits": 6,
         }
 
-        with patch.object(enc_mgr, "decrypt_parent_seed", return_value=TEST_SEED):
-            code = entry_mgr.get_totp_code(0, timestamp=0)
+        code = entry_mgr.get_totp_code(0, TEST_SEED, timestamp=0)
 
         expected = TotpManager.current_code(TEST_SEED, 0, timestamp=0)
         assert code == expected
@@ -44,8 +42,7 @@ def test_totp_time_remaining(monkeypatch):
         vault, enc_mgr = create_vault(Path(tmpdir), TEST_SEED, TEST_PASSWORD)
         entry_mgr = EntryManager(vault, Path(tmpdir))
 
-        with patch.object(enc_mgr, "decrypt_parent_seed", return_value=TEST_SEED):
-            entry_mgr.add_totp("Example", 0)
+        entry_mgr.add_totp("Example", TEST_SEED)
 
         monkeypatch.setattr(TotpManager, "time_remaining", lambda period: 7)
         remaining = entry_mgr.get_totp_time_remaining(0)


### PR DESCRIPTION
## Summary
- automatically assign next derivation index when adding TOTP entries
- require parent seed for TOTP secret derivation
- adjust manager to use new API and show derived index
- clarify documentation that SeedPass selects the next available derivation index
- update related unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866080d9588832b9dd2c057090f782e