### PR TITLE
Add imported TOTP support

### DIFF
--- a/src/password_manager/totp.py
+++ b/src/password_manager/totp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 import time
 from urllib.parse import quote
+from urllib.parse import urlparse, parse_qs, unquote
 
 import pyotp
 
@@ -27,6 +28,27 @@ class TotpManager:
         if timestamp is None:
             return totp.now()
         return totp.at(timestamp)
+
+    @staticmethod
+    def current_code_from_secret(secret: str, timestamp: int | None = None) -> str:
+        """Return the TOTP code for a raw secret."""
+        totp = pyotp.TOTP(secret)
+        return totp.now() if timestamp is None else totp.at(timestamp)
+
+    @staticmethod
+    def parse_otpauth(uri: str) -> tuple[str, str, int, int]:
+        """Parse an otpauth URI and return (label, secret, period, digits)."""
+        if not uri.startswith("otpauth://"):
+            raise ValueError("Not an otpauth URI")
+        parsed = urlparse(uri)
+        label = unquote(parsed.path.lstrip("/"))
+        qs = parse_qs(parsed.query)
+        secret = qs.get("secret", [""])[0].upper()
+        period = int(qs.get("period", ["30"])[0])
+        digits = int(qs.get("digits", ["6"])[0])
+        if not secret:
+            raise ValueError("Missing secret in URI")
+        return label, secret, period, digits
 
     @staticmethod
     def make_otpauth_uri(

--- a/src/tests/test_manager_add_totp.py
+++ b/src/tests/test_manager_add_totp.py
@@ -41,6 +41,7 @@ def test_handle_add_totp(monkeypatch):
 
         inputs = iter(
             [
+                "1",  # choose derive
                 "Example",  # label
                 "",  # period
                 "",  # digits


### PR DESCRIPTION
## Summary
- allow TOTP entries to store either a derived index or an imported secret
- parse `otpauth://` URIs and compute codes from secrets
- extend manager CLI to import or derive TOTP entries
- add tests for importing secrets and update existing TOTP tests

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686672a6a994832ba85e77fe948ea91c