### PR TITLE
Add 2FA codes menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,11 @@ python src/main.py
    1. Add Entry
    2. Retrieve Entry
    3. Modify an Existing Entry
-   4. Settings
-   5. Exit
+   4. 2FA Codes
+   5. Settings
+   6. Exit
 
-   Enter your choice (1-5):
+   Enter your choice (1-6):
    ```
 
    When choosing **Add Entry**, you can now select **Password** or **2FA (TOTP)**.

--- a/landing/index.html
+++ b/landing/index.html
@@ -101,10 +101,11 @@ Select an option:
 1. Add Entry
 2. Retrieve Entry
 3. Modify an Existing Entry
-4. Settings
-5. Exit
+4. 2FA Codes
+5. Settings
+6. Exit
 
-Enter your choice (1-5):
+Enter your choice (1-6):
                     </pre>
                 </div>
             </section>

--- a/src/main.py
+++ b/src/main.py
@@ -548,8 +548,9 @@ def display_menu(
     1. Add Entry
     2. Retrieve Entry
     3. Modify an Existing Entry
-    4. Settings
-    5. Exit
+    4. 2FA Codes
+    5. Settings
+    6. Exit
     """
     while True:
         if time.time() - password_manager.last_activity > inactivity_timeout:
@@ -571,7 +572,7 @@ def display_menu(
         print(colored(menu, "cyan"))
         try:
             choice = timed_input(
-                "Enter your choice (1-5): ", inactivity_timeout
+                "Enter your choice (1-6): ", inactivity_timeout
             ).strip()
         except TimeoutError:
             print(colored("Session timed out. Vault locked.", "yellow"))
@@ -582,7 +583,7 @@ def display_menu(
         if not choice:
             print(
                 colored(
-                    "No input detected. Please enter a number between 1 and 5.",
+                    "No input detected. Please enter a number between 1 and 6.",
                     "yellow",
                 )
             )
@@ -613,8 +614,11 @@ def display_menu(
             password_manager.handle_modify_entry()
         elif choice == "4":
             password_manager.update_activity()
-            handle_settings(password_manager)
+            password_manager.handle_display_totp_codes()
         elif choice == "5":
+            password_manager.update_activity()
+            handle_settings(password_manager)
+        elif choice == "6":
             logging.info("Exiting the program.")
             print(colored("Exiting the program.", "green"))
             password_manager.nostr_client.close_client_pool()

--- a/src/tests/test_auto_sync.py
+++ b/src/tests/test_auto_sync.py
@@ -31,7 +31,7 @@ def test_auto_sync_triggers_post(monkeypatch):
         called = True
 
     monkeypatch.setattr(main, "handle_post_to_nostr", fake_post)
-    monkeypatch.setattr(main, "timed_input", lambda *_: "5")
+    monkeypatch.setattr(main, "timed_input", lambda *_: "6")
 
     with pytest.raises(SystemExit):
         main.display_menu(pm, sync_interval=0.1)

--- a/src/tests/test_cli_invalid_input.py
+++ b/src/tests/test_cli_invalid_input.py
@@ -52,7 +52,7 @@ def _make_pm(called, locked=None):
 def test_empty_and_non_numeric_choice(monkeypatch, capsys):
     called = {"add": False, "retrieve": False, "modify": False}
     pm, _ = _make_pm(called)
-    inputs = iter(["", "abc", "5"])
+    inputs = iter(["", "abc", "6"])
     monkeypatch.setattr(main, "timed_input", lambda *_: next(inputs))
     with pytest.raises(SystemExit):
         main.display_menu(pm, sync_interval=1000, inactivity_timeout=1000)
@@ -65,7 +65,7 @@ def test_empty_and_non_numeric_choice(monkeypatch, capsys):
 def test_out_of_range_menu(monkeypatch, capsys):
     called = {"add": False, "retrieve": False, "modify": False}
     pm, _ = _make_pm(called)
-    inputs = iter(["9", "5"])
+    inputs = iter(["9", "6"])
     monkeypatch.setattr(main, "timed_input", lambda *_: next(inputs))
     with pytest.raises(SystemExit):
         main.display_menu(pm, sync_interval=1000, inactivity_timeout=1000)
@@ -77,7 +77,7 @@ def test_out_of_range_menu(monkeypatch, capsys):
 def test_invalid_add_entry_submenu(monkeypatch, capsys):
     called = {"add": False, "retrieve": False, "modify": False}
     pm, _ = _make_pm(called)
-    inputs = iter(["1", "4", "3", "5"])
+    inputs = iter(["1", "4", "3", "6"])
     monkeypatch.setattr(main, "timed_input", lambda *_: next(inputs))
     monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
     with pytest.raises(SystemExit):
@@ -92,7 +92,7 @@ def test_inactivity_timeout_loop(monkeypatch, capsys):
     pm, locked = _make_pm(called)
     pm.last_activity = 0
     monkeypatch.setattr(time, "time", lambda: 100.0)
-    monkeypatch.setattr(main, "timed_input", lambda *_: "5")
+    monkeypatch.setattr(main, "timed_input", lambda *_: "6")
     with pytest.raises(SystemExit):
         main.display_menu(pm, sync_interval=1000, inactivity_timeout=0.1)
     out = capsys.readouterr().out

--- a/src/tests/test_inactivity_lock.py
+++ b/src/tests/test_inactivity_lock.py
@@ -36,7 +36,7 @@ def test_inactivity_triggers_lock(monkeypatch):
         unlock_vault=unlock_vault,
     )
 
-    monkeypatch.setattr(main, "timed_input", lambda *_: "5")
+    monkeypatch.setattr(main, "timed_input", lambda *_: "6")
 
     with pytest.raises(SystemExit):
         main.display_menu(pm, sync_interval=1000, inactivity_timeout=0.1)
@@ -72,7 +72,7 @@ def test_input_timeout_triggers_lock(monkeypatch):
         unlock_vault=unlock_vault,
     )
 
-    responses = iter([TimeoutError(), "5"])
+    responses = iter([TimeoutError(), "6"])
 
     def fake_input(*_args, **_kwargs):
         val = next(responses)


### PR DESCRIPTION
## Summary
- add `handle_display_totp_codes` to show all TOTP codes with progress bars
- extend main menu with a new **2FA Codes** option
- update README and landing page examples for the new menu layout
- adjust tests for the updated menu numbering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68667624ec40832ba889065b4b17d192