### PR TITLE
Fix TOTP display import and add regression test

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -26,6 +26,7 @@ from password_manager.backup import BackupManager
 from password_manager.vault import Vault
 from password_manager.portable_backup import export_backup, import_backup
 from password_manager.totp import TotpManager
+from password_manager.entry_types import EntryType
 from utils.key_derivation import (
     derive_key_from_parent_seed,
     derive_key_from_password,

--- a/src/tests/test_manager_display_totp_codes.py
+++ b/src/tests/test_manager_display_totp_codes.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.backup import BackupManager
+from password_manager.manager import PasswordManager, EncryptionMode
+
+
+class FakeNostrClient:
+    def __init__(self, *args, **kwargs):
+        self.published = []
+
+    def publish_snapshot(self, data: bytes):
+        self.published.append(data)
+        return None, "abcd"
+
+
+def test_handle_display_totp_codes(monkeypatch, capsys):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        entry_mgr = EntryManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path)
+
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+        pm.encryption_manager = enc_mgr
+        pm.vault = vault
+        pm.entry_manager = entry_mgr
+        pm.backup_manager = backup_mgr
+        pm.parent_seed = TEST_SEED
+        pm.nostr_client = FakeNostrClient()
+        pm.fingerprint_dir = tmp_path
+        pm.is_dirty = False
+
+        entry_mgr.add_totp("Example", TEST_SEED)
+
+        monkeypatch.setattr(pm.entry_manager, "get_totp_code", lambda *a, **k: "123456")
+        monkeypatch.setattr(
+            pm.entry_manager, "get_totp_time_remaining", lambda *a, **k: 30
+        )
+
+        def interrupt(_):
+            raise KeyboardInterrupt()
+
+        monkeypatch.setattr("password_manager.manager.time.sleep", interrupt)
+
+        pm.handle_display_totp_codes()
+        out = capsys.readouterr().out
+        assert "Example" in out
+        assert "123456" in out


### PR DESCRIPTION
## Summary
- fix missing EntryType import in manager
- add regression test covering handle_display_totp_codes

## Testing
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68667c398178832b940157a79a83d85d