### PR TITLE
Improve TOTP management output

### DIFF
--- a/src/tests/test_manager_add_totp.py
+++ b/src/tests/test_manager_add_totp.py
@@ -21,7 +21,7 @@ class FakeNostrClient:
         return None, "abcd"
 
 
-def test_handle_add_totp(monkeypatch):
+def test_handle_add_totp(monkeypatch, capsys):
     with TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
         vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
@@ -51,6 +51,7 @@ def test_handle_add_totp(monkeypatch):
         monkeypatch.setattr(pm, "sync_vault", lambda: None)
 
         pm.handle_add_totp()
+        out = capsys.readouterr().out
 
         entry = entry_mgr.retrieve_entry(0)
         assert entry == {
@@ -60,3 +61,4 @@ def test_handle_add_totp(monkeypatch):
             "period": 30,
             "digits": 6,
         }
+        assert "ID 0" in out

--- a/src/tests/test_manager_display_totp_codes.py
+++ b/src/tests/test_manager_display_totp_codes.py
@@ -45,12 +45,14 @@ def test_handle_display_totp_codes(monkeypatch, capsys):
             pm.entry_manager, "get_totp_time_remaining", lambda *a, **k: 30
         )
 
-        def interrupt(_):
-            raise KeyboardInterrupt()
-
-        monkeypatch.setattr("password_manager.manager.time.sleep", interrupt)
+        # interrupt the loop after first iteration
+        monkeypatch.setattr(
+            "password_manager.manager.select.select",
+            lambda *a, **k: (_ for _ in ()).throw(KeyboardInterrupt()),
+        )
 
         pm.handle_display_totp_codes()
         out = capsys.readouterr().out
-        assert "Example" in out
+        assert "Generated 2FA Codes" in out
+        assert "[0] Example" in out
         assert "123456" in out


### PR DESCRIPTION
## Summary
- show entry indices when importing 2FA codes
- add back/exit handling to the TOTP display screen
- group generated vs imported TOTP codes and show their indices
- update tests for new output

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68667fb52fb4832b89d290893434351d