### PR TITLE
Add TOTP export option

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -503,9 +503,10 @@ def handle_settings(password_manager: PasswordManager) -> None:
         print("5. Backup Parent Seed")
         print("6. Export database")
         print("7. Import database")
-        print("8. Set inactivity timeout")
-        print("9. Lock Vault")
-        print("10. Back")
+        print("8. Export 2FA codes")
+        print("9. Set inactivity timeout")
+        print("10. Lock Vault")
+        print("11. Back")
         choice = input("Select an option: ").strip()
         if choice == "1":
             handle_profiles_menu(password_manager)
@@ -524,12 +525,14 @@ def handle_settings(password_manager: PasswordManager) -> None:
             if path:
                 password_manager.handle_import_database(Path(path))
         elif choice == "8":
-            handle_set_inactivity_timeout(password_manager)
+            password_manager.handle_export_totp_codes()
         elif choice == "9":
+            handle_set_inactivity_timeout(password_manager)
+        elif choice == "10":
             password_manager.lock_vault()
             print(colored("Vault locked. Please re-enter your password.", "yellow"))
             password_manager.unlock_vault()
-        elif choice == "10":
+        elif choice == "11":
             break
         else:
             print(colored("Invalid choice.", "red"))

--- a/src/tests/test_export_totp_codes.py
+++ b/src/tests/test_export_totp_codes.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import json
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.backup import BackupManager
+from password_manager.manager import PasswordManager, EncryptionMode
+from password_manager.totp import TotpManager
+
+
+class FakeNostrClient:
+    def publish_snapshot(self, data: bytes):
+        return None, "abcd"
+
+
+def test_handle_export_totp_codes(monkeypatch, tmp_path):
+    vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+    entry_mgr = EntryManager(vault, tmp_path)
+    backup_mgr = BackupManager(tmp_path)
+
+    pm = PasswordManager.__new__(PasswordManager)
+    pm.encryption_mode = EncryptionMode.SEED_ONLY
+    pm.encryption_manager = enc_mgr
+    pm.vault = vault
+    pm.entry_manager = entry_mgr
+    pm.backup_manager = backup_mgr
+    pm.parent_seed = TEST_SEED
+    pm.nostr_client = FakeNostrClient()
+    pm.fingerprint_dir = tmp_path
+
+    # add totp entries
+    entry_mgr.add_totp("Example", TEST_SEED)
+    entry_mgr.add_totp("Imported", TEST_SEED, secret="JBSWY3DPEHPK3PXP")
+
+    export_path = tmp_path / "out.json"
+    monkeypatch.setattr("builtins.input", lambda *a, **k: str(export_path))
+    monkeypatch.setattr(
+        "password_manager.manager.confirm_action", lambda *_a, **_k: False
+    )
+
+    pm.handle_export_totp_codes()
+
+    data = json.loads(export_path.read_text())
+    assert len(data["entries"]) == 2
+    labels = {e["label"] for e in data["entries"]}
+    assert {"Example", "Imported"} == labels
+    # check URI format
+    uri = data["entries"][0]["uri"]
+    assert uri.startswith("otpauth://totp/")


### PR DESCRIPTION
## Summary
- add `handle_export_totp_codes` to export all TOTP entries
- extend Settings menu with "Export 2FA codes"
- implement test for exporting 2FA codes

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686691c821d8832ba025c181d752e5e5