### PR TITLE
Add option to configure additional backup directory

### DIFF
--- a/src/tests/test_settings_menu.py
+++ b/src/tests/test_settings_menu.py
@@ -86,3 +86,15 @@ def test_relay_and_profile_actions(monkeypatch, capsys):
         out = capsys.readouterr().out
         assert fp1 in out
         assert fp2 in out
+
+
+def test_settings_menu_additional_backup(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        pm, cfg_mgr, fp_mgr = setup_pm(tmp_path, monkeypatch)
+
+        inputs = iter(["9", "12"])
+        with patch("main.handle_set_additional_backup_location") as handler:
+            with patch("builtins.input", side_effect=lambda *_: next(inputs)):
+                main.handle_settings(pm)
+        handler.assert_called_once_with(pm)


### PR DESCRIPTION
## Summary
- allow configuring an extra backup location via new `handle_set_additional_backup_location`
- expose this option in the settings menu
- test that the settings menu calls the handler

## Testing
- `python3 -m venv venv`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866a8a6b770832bbd9b9ea58808f67e