### PR TITLE
Add KeyManager helper test

### DIFF
--- a/src/tests/test_key_manager_helpers.py
+++ b/src/tests/test_key_manager_helpers.py
@@ -1,0 +1,29 @@
+import pytest
+from bech32 import bech32_encode, convertbits
+
+from nostr.key_manager import KeyManager
+
+
+def test_key_manager_getters(monkeypatch):
+    priv_hex = "1" * 64
+    pub_hex = "2" * 64
+
+    class DummyKeys:
+        def public_key_hex(self):
+            return pub_hex
+
+        def private_key_hex(self):
+            return priv_hex
+
+    monkeypatch.setattr(KeyManager, "initialize_bip85", lambda self: None)
+    monkeypatch.setattr(KeyManager, "generate_nostr_keys", lambda self: DummyKeys())
+
+    km = KeyManager("seed", "fp")
+
+    assert km.get_public_key_hex() == pub_hex
+    assert km.get_private_key_hex() == priv_hex
+
+    expected_npub = bech32_encode(
+        "npub", convertbits(bytes.fromhex(pub_hex), 8, 5, True)
+    )
+    assert km.get_npub() == expected_npub


### PR DESCRIPTION
## Summary
- test KeyManager helper getters and npub computation
- patch key generation to return dummy keys

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866c6d35bd8832b916e4d247802bd0f