### PR TITLE
Add Stats option

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ Back in the Settings menu you can:
 * Choose `9` to set an additional backup location.
 * Select `10` to change the inactivity timeout.
 * Choose `11` to lock the vault and require re-entry of your password.
+* Select `12` to return to the main menu.
+* Choose `13` to view seed profile stats.
 
 ## Running Tests
 

--- a/src/main.py
+++ b/src/main.py
@@ -222,6 +222,17 @@ def handle_display_npub(password_manager: PasswordManager):
         print(colored(f"Error: Failed to display npub: {e}", "red"))
 
 
+def handle_display_stats(password_manager: PasswordManager) -> None:
+    """Print seed profile statistics."""
+    try:
+        display_fn = getattr(password_manager, "display_stats", None)
+        if callable(display_fn):
+            display_fn()
+    except Exception as e:  # pragma: no cover - display best effort
+        logging.error(f"Failed to display stats: {e}", exc_info=True)
+        print(colored(f"Error: Failed to display stats: {e}", "red"))
+
+
 def handle_post_to_nostr(
     password_manager: PasswordManager, alt_summary: str | None = None
 ):
@@ -556,6 +567,7 @@ def handle_settings(password_manager: PasswordManager) -> None:
         print("10. Set inactivity timeout")
         print("11. Lock Vault")
         print("12. Back")
+        print("13. Stats")
         choice = input("Select an option: ").strip()
         if choice == "1":
             handle_profiles_menu(password_manager)
@@ -585,6 +597,8 @@ def handle_settings(password_manager: PasswordManager) -> None:
             password_manager.unlock_vault()
         elif choice == "12":
             break
+        elif choice == "13":
+            handle_display_stats(password_manager)
         else:
             print(colored("Invalid choice.", "red"))
 
@@ -606,6 +620,9 @@ def display_menu(
     5. Settings
     6. Exit
     """
+    display_fn = getattr(password_manager, "display_stats", None)
+    if callable(display_fn):
+        display_fn()
     while True:
         if time.time() - password_manager.last_activity > inactivity_timeout:
             print(colored("Session timed out. Vault locked.", "yellow"))


### PR DESCRIPTION
## Summary
- show seed profile stats at login
- add stats option to the settings menu
- implement PasswordManager.get_profile_stats() and display_stats()
- document the new menu option

## Testing
- `black src/main.py src/password_manager/manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6866c845a560832bb5af9842446b8aa3