### PR TITLE
Fix event handler timestamp timezone bug

### DIFF
--- a/src/nostr/event_handler.py
+++ b/src/nostr/event_handler.py
@@ -36,7 +36,7 @@ class EventHandler:
             # Assuming evt.created_at is always an integer Unix timestamp
             if isinstance(evt.created_at, int):
                 created_at_str = time.strftime(
-                    "%Y-%m-%d %H:%M:%S", time.localtime(evt.created_at)
+                    "%Y-%m-%d %H:%M:%S", time.gmtime(evt.created_at)
                 )
             else:
                 # Handle unexpected types gracefully


### PR DESCRIPTION
## Summary
- use `time.gmtime` instead of `time.localtime` in `EventHandler` to log timestamps in UTC
- fix failing `test_handle_new_event_logs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866cd87f3d0832b88ba84251d71c996