### PR TITLE
Add clipboard copy to totp command

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -42,6 +42,7 @@ pycoin==0.92.20241201
 pycparser==2.22
 pycryptodome==3.23.0
 pycryptodomex==3.23.0
+pyperclip==1.9.0
 Pygments==2.19.2
 PyNaCl==1.5.0
 PySocks==1.7.1

--- a/src/main.py
+++ b/src/main.py
@@ -809,6 +809,7 @@ def main(argv: list[str] | None = None) -> int:
         print(code)
         try:
             pyperclip.copy(code)
+            print(colored("Code copied to clipboard", "green"))
         except Exception as exc:
             logging.warning(f"Clipboard copy failed: {exc}")
         return 0

--- a/src/tests/test_cli_subcommands.py
+++ b/src/tests/test_cli_subcommands.py
@@ -63,4 +63,5 @@ def test_totp_command(monkeypatch, capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert "123456" in out
+    assert "copied to clipboard" in out.lower()
     assert called.get("val") == "123456"


### PR DESCRIPTION
## Summary
- lock pyperclip version
- notify user when `totp` command copies a code
- test clipboard copy message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866e3d6e510832ba6d6806ab67524ee