### PR TITLE
Add extra tests for search and CLI

### DIFF
--- a/src/tests/test_cli_subcommands.py
+++ b/src/tests/test_cli_subcommands.py
@@ -65,3 +65,67 @@ def test_totp_command(monkeypatch, capsys):
     assert "123456" in out
     assert "copied to clipboard" in out.lower()
     assert called.get("val") == "123456"
+
+
+def test_search_command_no_results(monkeypatch, capsys):
+    pm = make_pm([])
+    monkeypatch.setattr(main, "PasswordManager", lambda: pm)
+    monkeypatch.setattr(main, "configure_logging", lambda: None)
+    monkeypatch.setattr(main, "initialize_app", lambda: None)
+    monkeypatch.setattr(main.signal, "signal", lambda *a, **k: None)
+    rc = main.main(["search", "none"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "No matching entries found" in out
+
+
+def test_get_command_multiple_matches(monkeypatch, capsys):
+    matches = [(0, "Example", "user", "", False), (1, "Ex2", "bob", "", False)]
+    pm = make_pm(matches)
+    monkeypatch.setattr(main, "PasswordManager", lambda: pm)
+    monkeypatch.setattr(main, "configure_logging", lambda: None)
+    monkeypatch.setattr(main, "initialize_app", lambda: None)
+    monkeypatch.setattr(main.signal, "signal", lambda *a, **k: None)
+    rc = main.main(["get", "ex"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Matches" in out
+
+
+def test_get_command_wrong_type(monkeypatch, capsys):
+    entry = {"type": EntryType.TOTP.value}
+    pm = make_pm([(0, "Example", "user", "", False)], entry=entry)
+    monkeypatch.setattr(main, "PasswordManager", lambda: pm)
+    monkeypatch.setattr(main, "configure_logging", lambda: None)
+    monkeypatch.setattr(main, "initialize_app", lambda: None)
+    monkeypatch.setattr(main.signal, "signal", lambda *a, **k: None)
+    rc = main.main(["get", "ex"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Entry is not a password entry" in out
+
+
+def test_totp_command_multiple_matches(monkeypatch, capsys):
+    matches = [(0, "GH", None, None, False), (1, "Git", None, None, False)]
+    pm = make_pm(matches)
+    monkeypatch.setattr(main, "PasswordManager", lambda: pm)
+    monkeypatch.setattr(main, "configure_logging", lambda: None)
+    monkeypatch.setattr(main, "initialize_app", lambda: None)
+    monkeypatch.setattr(main.signal, "signal", lambda *a, **k: None)
+    rc = main.main(["totp", "g"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Matches" in out
+
+
+def test_totp_command_wrong_type(monkeypatch, capsys):
+    entry = {"type": EntryType.PASSWORD.value, "length": 8}
+    pm = make_pm([(0, "Example", "user", "", False)], entry=entry)
+    monkeypatch.setattr(main, "PasswordManager", lambda: pm)
+    monkeypatch.setattr(main, "configure_logging", lambda: None)
+    monkeypatch.setattr(main, "initialize_app", lambda: None)
+    monkeypatch.setattr(main.signal, "signal", lambda *a, **k: None)
+    rc = main.main(["totp", "ex"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Entry is not a TOTP entry" in out

--- a/src/tests/test_search_entries.py
+++ b/src/tests/test_search_entries.py
@@ -40,3 +40,42 @@ def test_search_by_username():
 
         result = entry_mgr.search_entries("bob")
         assert result == [(idx1, "Test.com", "Bob", "", False)]
+
+
+def test_search_by_url():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        entry_mgr = setup_entry_manager(tmp_path)
+
+        idx = entry_mgr.add_entry("Example", 12, url="https://ex.com/login")
+        entry_mgr.add_entry("Other", 8)
+
+        result = entry_mgr.search_entries("login")
+        assert result == [(idx, "Example", "", "https://ex.com/login", False)]
+
+
+def test_search_by_notes_and_totp():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        entry_mgr = setup_entry_manager(tmp_path)
+
+        idx_pw = entry_mgr.add_entry("Site", 8, notes="secret note")
+        entry_mgr.add_totp("GH", TEST_SEED)
+        idx_totp = entry_mgr.search_entries("GH")[0][0]
+        entry_mgr.modify_entry(idx_totp, notes="otp note")
+
+        res_notes = entry_mgr.search_entries("secret")
+        assert res_notes == [(idx_pw, "Site", "", "", False)]
+
+        res_totp = entry_mgr.search_entries("otp")
+        assert res_totp == [(idx_totp, "GH", None, None, False)]
+
+
+def test_search_no_results():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        entry_mgr = setup_entry_manager(tmp_path)
+
+        entry_mgr.add_entry("Example.com", 12, "alice")
+        result = entry_mgr.search_entries("missing")
+        assert result == []


### PR DESCRIPTION
## Summary
- increase coverage for entry search: url, notes, totp, and no results
- cover CLI commands error paths for search/get/totp

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866d089954c832ba5186179857f80a5