### PR TITLE
Fix menu option numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,14 @@ python src/main.py
    Select an option:
    1. Add Entry
    2. Retrieve Entry
-   3. Modify an Existing Entry
-   4. 2FA Codes
-   5. Settings
-   6. Exit
+   3. Search Entries
+   4. Modify an Existing Entry
+   5. 2FA Codes
+   6. Settings
+   7. Exit
 
-   Enter your choice (1-6):
-   ```
+   Enter your choice (1-7):
+  ```
 
    When choosing **Add Entry**, you can now select **Password** or **2FA (TOTP)**.
 
@@ -244,7 +245,7 @@ wss://relay.primal.net
 
 You can manage your relays and sync with Nostr from the **Settings** menu:
 
-1. From the main menu choose `4` (**Settings**).
+1. From the main menu choose `6` (**Settings**).
 2. Select `2` (**Nostr**) to open the Nostr submenu.
 3. Choose `1` to back up your encrypted index to Nostr.
 4. Select `2` to restore the index from Nostr.

--- a/src/main.py
+++ b/src/main.py
@@ -707,10 +707,10 @@ def display_menu(
             password_manager.handle_modify_entry()
         elif choice == "5":
             password_manager.update_activity()
-            handle_settings(password_manager)
+            password_manager.handle_display_totp_codes()
         elif choice == "6":
             password_manager.update_activity()
-            password_manager.handle_display_totp_codes()
+            handle_settings(password_manager)
         elif choice == "7":
             logging.info("Exiting the program.")
             print(colored("Exiting the program.", "green"))

--- a/src/tests/test_menu_options.py
+++ b/src/tests/test_menu_options.py
@@ -1,0 +1,49 @@
+import time
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import main
+
+
+def _make_pm(calls):
+    return SimpleNamespace(
+        is_dirty=False,
+        last_update=time.time(),
+        last_activity=time.time(),
+        nostr_client=SimpleNamespace(close_client_pool=lambda: None),
+        handle_add_password=lambda: None,
+        handle_add_totp=lambda: None,
+        handle_retrieve_entry=lambda: None,
+        handle_search_entries=lambda: None,
+        handle_modify_entry=lambda: None,
+        handle_display_totp_codes=lambda: calls.append("totp"),
+        update_activity=lambda: None,
+        lock_vault=lambda: None,
+        unlock_vault=lambda: None,
+    )
+
+
+def test_menu_totp_option(monkeypatch):
+    calls = []
+    pm = _make_pm(calls)
+    inputs = iter(["5", "7"])
+    monkeypatch.setattr(main, "timed_input", lambda *_: next(inputs))
+    monkeypatch.setattr(main, "handle_settings", lambda *_: None)
+    with pytest.raises(SystemExit):
+        main.display_menu(pm, sync_interval=1000, inactivity_timeout=1000)
+    assert calls == ["totp"]
+
+
+def test_menu_settings_option(monkeypatch):
+    calls = []
+    pm = _make_pm(calls)
+    inputs = iter(["6", "7"])
+    monkeypatch.setattr(main, "timed_input", lambda *_: next(inputs))
+    monkeypatch.setattr(main, "handle_settings", lambda *_: calls.append("settings"))
+    with pytest.raises(SystemExit):
+        main.display_menu(pm, sync_interval=1000, inactivity_timeout=1000)
+    assert calls == ["settings"]


### PR DESCRIPTION
## Summary
- fix main menu option mapping
- document correct menu numbering in README
- update instructions for accessing settings
- add regression tests for TOTP and Settings menu options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866eb5ed820832bbd3b54569c100edc