### PR TITLE
Fix portable export additional backup

### DIFF
--- a/src/password_manager/portable_backup.py
+++ b/src/password_manager/portable_backup.py
@@ -82,6 +82,7 @@ def export_backup(
     json_bytes = json.dumps(wrapper, indent=2).encode("utf-8")
     dest_path.write_bytes(json_bytes)
     os.chmod(dest_path, 0o600)
+    backup_manager._create_additional_backup(dest_path)
 
     if publish:
         encrypted = vault.encryption_manager.encrypt_data(json_bytes)


### PR DESCRIPTION
## Summary
- copy portable export files to the additional backup location
- test that exports are written to the extra location and can be imported

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68672fd6ca4c832ba9e057352cb995a8