### PR TITLE
Move Back option to end of settings menu

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -584,8 +584,8 @@ def handle_settings(password_manager: PasswordManager) -> None:
         print("9. Set additional backup location")
         print("10. Set inactivity timeout")
         print("11. Lock Vault")
-        print("12. Back")
-        print("13. Stats")
+        print("12. Stats")
+        print("13. Back")
         choice = input("Select an option: ").strip()
         if choice == "1":
             handle_profiles_menu(password_manager)
@@ -614,9 +614,9 @@ def handle_settings(password_manager: PasswordManager) -> None:
             print(colored("Vault locked. Please re-enter your password.", "yellow"))
             password_manager.unlock_vault()
         elif choice == "12":
-            break
-        elif choice == "13":
             handle_display_stats(password_manager)
+        elif choice == "13":
+            break
         else:
             print(colored("Invalid choice.", "red"))
 

--- a/src/tests/test_settings_menu.py
+++ b/src/tests/test_settings_menu.py
@@ -93,7 +93,7 @@ def test_settings_menu_additional_backup(monkeypatch):
         tmp_path = Path(tmpdir)
         pm, cfg_mgr, fp_mgr = setup_pm(tmp_path, monkeypatch)
 
-        inputs = iter(["9", "12"])
+        inputs = iter(["9", "13"])
         with patch("main.handle_set_additional_backup_location") as handler:
             with patch("builtins.input", side_effect=lambda *_: next(inputs)):
                 main.handle_settings(pm)


### PR DESCRIPTION
## Summary
- place the Back option at the end of the Settings menu
- update settings menu test to use the new numbering

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68673403dc90832b96082b9c0f1bb08a