### PR TITLE
Fix max entries limit in nostr size test

### DIFF
--- a/src/tests/test_nostr_index_size.py
+++ b/src/tests/test_nostr_index_size.py
@@ -88,12 +88,13 @@ def test_nostr_index_size_limits(pytestconfig: pytest.Config):
                         )
                         retrieved_ok = retrieved == encrypted
                     results.append((entry_count, payload_size, True, retrieved_ok))
-                    if (
-                        not retrieved_ok
-                        or payload_size > max_payload
-                        or (max_entries is not None and entry_count >= max_entries)
-                    ):
-                        break
+                    if max_entries is not None:
+                        if entry_count >= max_entries:
+                            break
+                    else:
+                        if not retrieved_ok or payload_size > max_payload:
+                            break
+
                     size *= 2
             except Exception:
                 results.append((entry_count + 1, None, False, False))


### PR DESCRIPTION
## Summary
- ensure `test_nostr_index_size_limits` only stops early when no limit is given

## Testing
- `pytest src/tests/test_nostr_index_size.py::test_nostr_index_size_limits --desktop --max-entries=1 -s -n 0`

------
https://chatgpt.com/codex/tasks/task_b_686738f3bda4832bb6f5029ec7a4f882