### PR TITLE
Add Secret Mode documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 - **Export 2FA Codes:** Save all stored TOTP entries to an encrypted JSON file for use with other apps.
 - **Optional External Backup Location:** Configure a second directory where backups are automatically copied.
 - **Auto‑Lock on Inactivity:** Vault locks after a configurable timeout for additional security.
+- **Secret Mode:** Copy retrieved passwords directly to your clipboard and automatically clear it after a delay.
 
 ## Prerequisites
 
@@ -211,6 +212,14 @@ python src/main.py
 2. SeedPass will show the current label, period, digit count, and blacklist status.
 3. Enter new values or press **Enter** to keep the existing settings.
 4. The updated entry is saved back to your encrypted vault.
+
+### Using Secret Mode
+
+When **Secret Mode** is enabled, SeedPass copies retrieved passwords directly to your clipboard instead of displaying them on screen. The clipboard clears automatically after the delay you choose.
+
+1. From the main menu open **Settings** and select **Toggle Secret Mode**.
+2. Choose how many seconds to keep passwords on the clipboard.
+3. Retrieve an entry and SeedPass will confirm the password was copied.
 
 
 ### Managing Multiple Seeds

--- a/landing/index.html
+++ b/landing/index.html
@@ -72,6 +72,7 @@
                         <li><i class="fas fa-file-export" aria-hidden="true"></i> Export your 2FA codes to an encrypted file</li>
                         <li><i class="fas fa-folder-open" aria-hidden="true"></i> Optional external backup location</li>
                         <li><i class="fas fa-lock" aria-hidden="true"></i> Auto-lock after inactivity</li>
+                        <li><i class="fas fa-user-secret" aria-hidden="true"></i> Secret Mode copies passwords to your clipboard</li>
                     </ul>
                 </div>
             </section>
@@ -111,6 +112,8 @@ Select an option:
 
 Enter your choice (1-6):
                     </pre>
+                    <h3 class="subsection-title">Secret Mode</h3>
+                    <p>When Secret Mode is enabled, retrieved passwords are copied directly to your clipboard instead of displayed. The clipboard clears automatically after a delay you set.</p>
                 </div>
             </section>
             <!-- Roadmap Section -->


### PR DESCRIPTION
## Summary
- document Secret Mode in README
- show how to use it from the UI
- mention Secret Mode on the landing page

## Testing
- `black . --exclude venv`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6867557ddac0832bb56073147b1898ae