### PR TITLE
Add SSH key entry support

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1093,6 +1093,34 @@ class PasswordManager:
                     logging.error(f"Error generating TOTP code: {e}", exc_info=True)
                     print(colored(f"Error: Failed to generate TOTP code: {e}", "red"))
                 return
+            if entry_type == EntryType.SSH.value:
+                notes = entry.get("notes", "")
+                try:
+                    priv_pem, pub_pem = self.entry_manager.get_ssh_key_pair(
+                        index, self.parent_seed
+                    )
+                    if self.secret_mode_enabled:
+                        copy_to_clipboard(priv_pem, self.clipboard_clear_delay)
+                        print(
+                            colored(
+                                f"[+] SSH private key copied to clipboard. Will clear in {self.clipboard_clear_delay} seconds.",
+                                "green",
+                            )
+                        )
+                        print(colored("Public Key:", "cyan"))
+                        print(pub_pem)
+                    else:
+                        print(colored("\n[+] Retrieved SSH Key Pair:\n", "green"))
+                        print(colored("Public Key:", "cyan"))
+                        print(pub_pem)
+                        print(colored("Private Key:", "cyan"))
+                        print(priv_pem)
+                    if notes:
+                        print(colored(f"Notes: {notes}", "cyan"))
+                except Exception as e:
+                    logging.error(f"Error deriving SSH key pair: {e}", exc_info=True)
+                    print(colored(f"Error: Failed to derive SSH keys: {e}", "red"))
+                return
 
             website_name = entry.get("website")
             length = entry.get("length")

--- a/src/tests/test_entry_add.py
+++ b/src/tests/test_entry_add.py
@@ -61,9 +61,12 @@ def test_round_trip_entry_types(method, expected_type):
             entry_mgr.add_totp("example", TEST_SEED)
             index = 0
         else:
-            with pytest.raises(NotImplementedError):
-                getattr(entry_mgr, method)()
-            index = 0
+            if method == "add_ssh_key":
+                index = entry_mgr.add_ssh_key(TEST_SEED)
+            else:
+                with pytest.raises(NotImplementedError):
+                    getattr(entry_mgr, method)()
+                index = 0
 
         entry = entry_mgr.retrieve_entry(index)
         assert entry["type"] == expected_type

--- a/src/tests/test_ssh_entry.py
+++ b/src/tests/test_ssh_entry.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.backup import BackupManager
+from password_manager.vault import Vault
+from password_manager.config_manager import ConfigManager
+
+
+def test_add_and_retrieve_ssh_key_pair():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        index = entry_mgr.add_ssh_key(TEST_SEED)
+        entry = entry_mgr.retrieve_entry(index)
+        assert entry == {"type": "ssh", "index": index, "notes": ""}
+
+        priv1, pub1 = entry_mgr.get_ssh_key_pair(index, TEST_SEED)
+        priv2, pub2 = entry_mgr.get_ssh_key_pair(index, TEST_SEED)
+        assert priv1 == priv2
+        assert pub1 == pub2


### PR DESCRIPTION
## Summary
- implement SSH key entry storage and retrieval
- derive PEM-formatted Ed25519 keypairs using BIP-85
- surface SSH entry retrieval in PasswordManager
- test deterministic SSH key derivation
- update entry type round-trip test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6868371c1034832ba159d9b366aa7468