### PR TITLE
Add SSH and seed entry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 - **SeedPass 2FA:** Generate TOTP codes with a real-time countdown progress bar.
 - **2FA Secret Issuance & Import:** Derive new TOTP secrets from your seed or import existing `otpauth://` URIs.
 - **Export 2FA Codes:** Save all stored TOTP entries to an encrypted JSON file for use with other apps.
+- **SSH Key & Seed Derivation:** Generate deterministic SSH keys and new BIP-39 seed phrases from your master seed.
 - **Optional External Backup Location:** Configure a second directory where backups are automatically copied.
 - **Auto‑Lock on Inactivity:** Vault locks after a configurable timeout for additional security.
 - **Secret Mode:** Copy retrieved passwords directly to your clipboard and automatically clear it after a delay.
@@ -205,7 +206,8 @@ python src/main.py
    Enter your choice (1-7):
   ```
 
-   When choosing **Add Entry**, you can now select **Password** or **2FA (TOTP)**.
+   When choosing **Add Entry**, you can now select **Password**, **2FA (TOTP)**,
+   **SSH Key**, or **BIP-39 Seed**.
 
 ### Adding a 2FA Entry
 

--- a/src/main.py
+++ b/src/main.py
@@ -729,7 +729,9 @@ def display_menu(
                 print("\nAdd Entry:")
                 print("1. Password")
                 print("2. 2FA (TOTP)")
-                print("3. Back")
+                print("3. SSH Key")
+                print("4. BIP-39 Seed")
+                print("5. Back")
                 sub_choice = input("Select entry type: ").strip()
                 password_manager.update_activity()
                 if sub_choice == "1":
@@ -739,6 +741,12 @@ def display_menu(
                     password_manager.handle_add_totp()
                     break
                 elif sub_choice == "3":
+                    password_manager.handle_add_ssh_key()
+                    break
+                elif sub_choice == "4":
+                    password_manager.handle_add_seed()
+                    break
+                elif sub_choice == "5":
                     break
                 else:
                     print(colored("Invalid choice.", "red"))

--- a/src/password_manager/entry_management.py
+++ b/src/password_manager/entry_management.py
@@ -209,27 +209,68 @@ class EntryManager:
             logger.error(f"Failed to generate otpauth URI: {e}")
             raise
 
-    def add_ssh_key(self, notes: str = "") -> int:
-        """Placeholder for adding an SSH key entry."""
-        index = self.get_next_index()
+    def get_next_ssh_index(self) -> int:
+        """Return the next available derivation index for SSH keys."""
         data = self.vault.load_index()
-        data.setdefault("entries", {})
-        data["entries"][str(index)] = {"type": EntryType.SSH.value, "notes": notes}
-        self._save_index(data)
-        self.update_checksum()
-        self.backup_manager.create_backup()
-        raise NotImplementedError("SSH key entry support not implemented yet")
+        entries = data.get("entries", {})
+        indices = [
+            int(v.get("index", 0))
+            for v in entries.values()
+            if v.get("type") == EntryType.SSH.value
+        ]
+        return (max(indices) + 1) if indices else 0
 
-    def add_seed(self, notes: str = "") -> int:
-        """Placeholder for adding a seed entry."""
-        index = self.get_next_index()
+    def add_ssh_key(self, *, index: int | None = None, notes: str = "") -> int:
+        """Add an SSH key entry and return the entry id."""
+        entry_id = self.get_next_index()
         data = self.vault.load_index()
         data.setdefault("entries", {})
-        data["entries"][str(index)] = {"type": EntryType.SEED.value, "notes": notes}
+        if index is None:
+            index = self.get_next_ssh_index()
+        data["entries"][str(entry_id)] = {
+            "type": EntryType.SSH.value,
+            "index": index,
+            "notes": notes,
+        }
         self._save_index(data)
         self.update_checksum()
         self.backup_manager.create_backup()
-        raise NotImplementedError("Seed entry support not implemented yet")
+        return entry_id
+
+    def get_next_seed_index(self) -> int:
+        """Return the next available derivation index for seed phrases."""
+        data = self.vault.load_index()
+        entries = data.get("entries", {})
+        indices = [
+            int(v.get("index", 0))
+            for v in entries.values()
+            if v.get("type") == EntryType.SEED.value
+        ]
+        return (max(indices) + 1) if indices else 0
+
+    def add_seed(
+        self,
+        *,
+        index: int | None = None,
+        words: int = 24,
+        notes: str = "",
+    ) -> int:
+        """Add a BIP-39 seed phrase entry and return the entry id."""
+        entry_id = self.get_next_index()
+        data = self.vault.load_index()
+        data.setdefault("entries", {})
+        if index is None:
+            index = self.get_next_seed_index()
+        data["entries"][str(entry_id)] = {
+            "type": EntryType.SEED.value,
+            "index": index,
+            "words": words,
+            "notes": notes,
+        }
+        self._save_index(data)
+        self.update_checksum()
+        self.backup_manager.create_backup()
+        return entry_id
 
     def get_totp_code(
         self, index: int, parent_seed: str | None = None, timestamp: int | None = None

--- a/src/tests/test_cli_invalid_input.py
+++ b/src/tests/test_cli_invalid_input.py
@@ -77,7 +77,7 @@ def test_out_of_range_menu(monkeypatch, capsys):
 def test_invalid_add_entry_submenu(monkeypatch, capsys):
     called = {"add": False, "retrieve": False, "modify": False}
     pm, _ = _make_pm(called)
-    inputs = iter(["1", "4", "3", "7"])
+    inputs = iter(["1", "6", "5", "7"])
     monkeypatch.setattr(main, "timed_input", lambda *_: next(inputs))
     monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
     with pytest.raises(SystemExit):

--- a/src/tests/test_entry_add.py
+++ b/src/tests/test_entry_add.py
@@ -60,10 +60,10 @@ def test_round_trip_entry_types(method, expected_type):
         elif method == "add_totp":
             entry_mgr.add_totp("example", TEST_SEED)
             index = 0
-        else:
-            with pytest.raises(NotImplementedError):
-                getattr(entry_mgr, method)()
-            index = 0
+        elif method == "add_ssh_key":
+            index = entry_mgr.add_ssh_key()
+        elif method == "add_seed":
+            index = entry_mgr.add_seed()
 
         entry = entry_mgr.retrieve_entry(index)
         assert entry["type"] == expected_type

--- a/src/tests/test_manager_retrieve_ssh_seed.py
+++ b/src/tests/test_manager_retrieve_ssh_seed.py
@@ -1,0 +1,75 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.backup import BackupManager
+from password_manager.manager import PasswordManager, EncryptionMode
+from password_manager.config_manager import ConfigManager
+
+
+class FakeNostrClient:
+    def __init__(self, *args, **kwargs):
+        self.published = []
+
+    def publish_snapshot(self, data: bytes):
+        self.published.append(data)
+        return None, "abcd"
+
+
+def _setup(tmp_path: Path) -> PasswordManager:
+    vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+    cfg_mgr = ConfigManager(vault, tmp_path)
+    backup_mgr = BackupManager(tmp_path, cfg_mgr)
+    entry_mgr = EntryManager(vault, backup_mgr)
+
+    pm = PasswordManager.__new__(PasswordManager)
+    pm.encryption_mode = EncryptionMode.SEED_ONLY
+    pm.encryption_manager = enc_mgr
+    pm.vault = vault
+    pm.entry_manager = entry_mgr
+    pm.backup_manager = backup_mgr
+    pm.parent_seed = TEST_SEED
+    pm.nostr_client = FakeNostrClient()
+    pm.fingerprint_dir = tmp_path
+    pm.is_dirty = False
+    pm.secret_mode_enabled = False
+    pm.password_generator = SimpleNamespace(bip85=object())
+    return pm
+
+
+def test_retrieve_ssh(monkeypatch, capsys):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        pm = _setup(tmp_path)
+        idx = pm.entry_manager.add_ssh_key()
+        monkeypatch.setattr(
+            "password_manager.manager.derive_ssh_key",
+            lambda b, i: bytes.fromhex("11" * 32),
+        )
+        monkeypatch.setattr("builtins.input", lambda *a, **k: str(idx))
+        pm.handle_retrieve_entry()
+        out = capsys.readouterr().out
+        assert "SSH key" in out
+        assert "11" * 32 in out
+
+
+def test_retrieve_seed(monkeypatch, capsys):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        pm = _setup(tmp_path)
+        idx = pm.entry_manager.add_seed()
+        monkeypatch.setattr(
+            "password_manager.manager.derive_seed_phrase",
+            lambda b, i, w: "word " * w,
+        )
+        monkeypatch.setattr("builtins.input", lambda *a, **k: str(idx))
+        pm.handle_retrieve_entry()
+        out = capsys.readouterr().out
+        assert "Seed Phrase" in out or "seed" in out.lower()
+        assert "word" in out


### PR DESCRIPTION
## Summary
- implement support for SSH key and BIP-39 seed entries
- expose new add/retrieve menu items
- update docs to describe new entry choices
- cover new behaviour with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68683b7a7fc4832ba6a75088b0c35572