### PR TITLE
Add PGP key generation

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -33,6 +33,7 @@ mutmut==2.4.4
 nostr-sdk==0.42.1
 packaging==25.0
 parso==0.8.4
+pgpy==0.6.0
 pluggy==1.6.0
 pony==0.7.19
 portalocker==3.2.0

--- a/src/password_manager/entry_types.py
+++ b/src/password_manager/entry_types.py
@@ -11,3 +11,4 @@ class EntryType(str, Enum):
     TOTP = "totp"
     SSH = "ssh"
     SEED = "seed"
+    PGP = "pgp"

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1212,6 +1212,30 @@ class PasswordManager:
                     logging.error(f"Error deriving seed phrase: {e}", exc_info=True)
                     print(colored(f"Error: Failed to derive seed phrase: {e}", "red"))
                 return
+            if entry_type == EntryType.PGP.value:
+                notes = entry.get("notes", "")
+                try:
+                    priv_key, fingerprint = self.entry_manager.get_pgp_key(
+                        index, self.parent_seed
+                    )
+                    if self.secret_mode_enabled:
+                        copy_to_clipboard(priv_key, self.clipboard_clear_delay)
+                        print(
+                            colored(
+                                f"[+] PGP key copied to clipboard. Will clear in {self.clipboard_clear_delay} seconds.",
+                                "green",
+                            )
+                        )
+                    else:
+                        print(colored("\n[+] Retrieved PGP Key:\n", "green"))
+                        print(colored(f"Fingerprint: {fingerprint}", "cyan"))
+                        print(priv_key)
+                    if notes:
+                        print(colored(f"Notes: {notes}", "cyan"))
+                except Exception as e:
+                    logging.error(f"Error deriving PGP key: {e}", exc_info=True)
+                    print(colored(f"Error: Failed to derive PGP key: {e}", "red"))
+                return
 
             website_name = entry.get("website")
             length = entry.get("length")

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -18,6 +18,7 @@ websockets>=15.0.0
 tomli
 hypothesis
 mutmut==2.4.4
+pgpy==0.6.0
 pyotp>=2.8.0
 
 freezegun

--- a/src/tests/test_pgp_entry.py
+++ b/src/tests/test_pgp_entry.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.backup import BackupManager
+from password_manager.config_manager import ConfigManager
+
+
+def test_pgp_key_determinism():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        idx = entry_mgr.add_pgp_key(TEST_SEED, key_type="ed25519", user_id="Test")
+        key1, fp1 = entry_mgr.get_pgp_key(idx, TEST_SEED)
+        key2, fp2 = entry_mgr.get_pgp_key(idx, TEST_SEED)
+
+        assert fp1 == fp2
+        assert key1 == key2


### PR DESCRIPTION
## Summary
- support PGP entry type
- derive deterministic PGP keys
- add entry management helpers for PGP keys
- display PGP key info when retrieving entries
- include pgpy dependency
- test PGP key determinism

## Testing
- `pytest -q src/tests/test_pgp_entry.py`

------
https://chatgpt.com/codex/tasks/task_b_68684fa0aa80832ba39f20e8e046c10c