### PR TITLE
Add PGP option to UI menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ python src/main.py
   ```
 
    When choosing **Add Entry**, you can now select **Password**, **2FA (TOTP)**,
-   **SSH Key**, or **Seed Phrase**.
+   **SSH Key**, **Seed Phrase**, or **PGP Key**.
 
 ### Adding a 2FA Entry
 
@@ -288,7 +288,8 @@ Back in the Settings menu you can:
 * Choose `10` to set an additional backup location.
 * Select `11` to change the inactivity timeout.
 * Choose `12` to lock the vault and require re-entry of your password.
-* Select `13` to view seed profile stats.
+* Select `13` to view seed profile stats. The summary lists counts for
+  passwords, TOTP codes, SSH keys, seed phrases, and PGP keys.
 * Choose `14` to toggle Secret Mode and set the clipboard clear delay.
 * Select `15` to return to the main menu.
 

--- a/src/main.py
+++ b/src/main.py
@@ -731,7 +731,8 @@ def display_menu(
                 print("2. 2FA (TOTP)")
                 print("3. SSH Key")
                 print("4. Seed Phrase")
-                print("5. Back")
+                print("5. PGP Key")
+                print("6. Back")
                 sub_choice = input("Select entry type: ").strip()
                 password_manager.update_activity()
                 if sub_choice == "1":
@@ -747,6 +748,9 @@ def display_menu(
                     password_manager.handle_add_seed()
                     break
                 elif sub_choice == "5":
+                    password_manager.handle_add_pgp()
+                    break
+                elif sub_choice == "6":
                     break
                 else:
                     print(colored("Invalid choice.", "red"))

--- a/src/tests/test_cli_invalid_input.py
+++ b/src/tests/test_cli_invalid_input.py
@@ -77,7 +77,7 @@ def test_out_of_range_menu(monkeypatch, capsys):
 def test_invalid_add_entry_submenu(monkeypatch, capsys):
     called = {"add": False, "retrieve": False, "modify": False}
     pm, _ = _make_pm(called)
-    inputs = iter(["1", "6", "5", "7"])
+    inputs = iter(["1", "7", "6", "7"])
     monkeypatch.setattr(main, "timed_input", lambda *_: next(inputs))
     monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
     with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary
- support PGP key entries from the UI
- include PGP counts in stats output
- update Add Entry menu and retrieval prompt
- document PGP support in README
- adjust tests for updated submenu options

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686853c31c68832b9b28c63d2a04a81e