### PR TITLE
Add custom fields to password entries

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -867,6 +867,18 @@ class PasswordManager:
             url = input("Enter the URL (optional): ").strip()
             notes = input("Enter notes (optional): ").strip()
 
+            custom_fields: list[dict[str, object]] = []
+            while True:
+                add_field = input("Add custom field? (y/N): ").strip().lower()
+                if add_field != "y":
+                    break
+                label = input("  Field label: ").strip()
+                value = input("  Field value: ").strip()
+                hidden = input("  Hidden field? (y/N): ").strip().lower() == "y"
+                custom_fields.append(
+                    {"label": label, "value": value, "is_hidden": hidden}
+                )
+
             length_input = input(
                 f"Enter desired password length (default {DEFAULT_PASSWORD_LENGTH}): "
             ).strip()
@@ -893,6 +905,7 @@ class PasswordManager:
                 url,
                 blacklisted=False,
                 notes=notes,
+                custom_fields=custom_fields,
             )
 
             # Mark database as dirty for background sync
@@ -1429,6 +1442,20 @@ class PasswordManager:
                     or notes
                 )
 
+                edit_fields = input("Edit custom fields? (y/N): ").strip().lower()
+                custom_fields = None
+                if edit_fields == "y":
+                    custom_fields = []
+                    while True:
+                        label = input("  Field label (leave blank to finish): ").strip()
+                        if not label:
+                            break
+                        value = input("  Field value: ").strip()
+                        hidden = input("  Hidden field? (y/N): ").strip().lower() == "y"
+                        custom_fields.append(
+                            {"label": label, "value": value, "is_hidden": hidden}
+                        )
+
                 self.entry_manager.modify_entry(
                     index,
                     blacklisted=new_blacklisted,
@@ -1436,6 +1463,7 @@ class PasswordManager:
                     label=new_label,
                     period=new_period,
                     digits=new_digits,
+                    custom_fields=custom_fields,
                 )
             else:
                 website_name = entry.get("website")
@@ -1500,12 +1528,27 @@ class PasswordManager:
                     or notes
                 )
 
+                edit_fields = input("Edit custom fields? (y/N): ").strip().lower()
+                custom_fields = None
+                if edit_fields == "y":
+                    custom_fields = []
+                    while True:
+                        label = input("  Field label (leave blank to finish): ").strip()
+                        if not label:
+                            break
+                        value = input("  Field value: ").strip()
+                        hidden = input("  Hidden field? (y/N): ").strip().lower() == "y"
+                        custom_fields.append(
+                            {"label": label, "value": value, "is_hidden": hidden}
+                        )
+
                 self.entry_manager.modify_entry(
                     index,
                     new_username,
                     new_url,
                     new_blacklisted,
                     new_notes,
+                    custom_fields=custom_fields,
                 )
 
             # Mark database as dirty for background sync

--- a/src/tests/test_entry_add.py
+++ b/src/tests/test_entry_add.py
@@ -21,7 +21,12 @@ def test_add_and_retrieve_entry():
         backup_mgr = BackupManager(Path(tmpdir), cfg_mgr)
         entry_mgr = EntryManager(vault, backup_mgr)
 
-        index = entry_mgr.add_entry("example.com", 12, "user")
+        custom = [
+            {"label": "api", "value": "123", "is_hidden": True},
+            {"label": "note", "value": "hello", "is_hidden": False},
+        ]
+
+        index = entry_mgr.add_entry("example.com", 12, "user", custom_fields=custom)
         entry = entry_mgr.retrieve_entry(index)
 
         assert entry == {
@@ -33,6 +38,7 @@ def test_add_and_retrieve_entry():
             "type": "password",
             "kind": "password",
             "notes": "",
+            "custom_fields": custom,
         }
 
         data = enc_mgr.load_json_data(entry_mgr.index_file)

--- a/src/tests/test_manager_workflow.py
+++ b/src/tests/test_manager_workflow.py
@@ -52,14 +52,16 @@ def test_manager_workflow(monkeypatch):
                 "example.com",
                 "",  # username
                 "",  # url
-                "",  # length (default)
                 "",  # notes
+                "n",  # add custom field
+                "",  # length (default)
                 "0",  # retrieve index
                 "0",  # modify index
                 "user",  # new username
                 "",  # new url
                 "",  # blacklist status
                 "",  # new notes
+                "n",  # edit custom fields
             ]
         )
         monkeypatch.setattr("builtins.input", lambda *args, **kwargs: next(inputs))

--- a/src/tests/test_search_entries.py
+++ b/src/tests/test_search_entries.py
@@ -71,6 +71,21 @@ def test_search_by_notes_and_totp():
         assert res_totp == [(idx_totp, "GH", None, None, False)]
 
 
+def test_search_by_custom_field():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        entry_mgr = setup_entry_manager(tmp_path)
+
+        custom = [
+            {"label": "api", "value": "secret123", "is_hidden": True},
+            {"label": "note", "value": "visible", "is_hidden": False},
+        ]
+        idx = entry_mgr.add_entry("Example", 8, custom_fields=custom)
+
+        result = entry_mgr.search_entries("secret123")
+        assert result == [(idx, "Example", "", "", False)]
+
+
 def test_search_no_results():
     with TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)


### PR DESCRIPTION
## Summary
- extend `EntryManager` with a `custom_fields` list on password entries
- prompt for custom fields in `handle_add_password` and `handle_modify_entry`
- include custom fields in search results
- update tests for new field and add custom field search coverage

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68685afbfcd8832b9fec207dcf0e9dba