### PR TITLE
Add Nostr key pair generation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -731,8 +731,9 @@ def display_menu(
                 print("2. 2FA (TOTP)")
                 print("3. SSH Key")
                 print("4. Seed Phrase")
-                print("5. PGP Key")
-                print("6. Back")
+                print("5. Nostr Key Pair")
+                print("6. PGP Key")
+                print("7. Back")
                 sub_choice = input("Select entry type: ").strip()
                 password_manager.update_activity()
                 if sub_choice == "1":
@@ -748,9 +749,12 @@ def display_menu(
                     password_manager.handle_add_seed()
                     break
                 elif sub_choice == "5":
-                    password_manager.handle_add_pgp()
+                    password_manager.handle_add_nostr_key()
                     break
                 elif sub_choice == "6":
+                    password_manager.handle_add_pgp()
+                    break
+                elif sub_choice == "7":
                     break
                 else:
                     print(colored("Invalid choice.", "red"))

--- a/src/nostr/key_manager.py
+++ b/src/nostr/key_manager.py
@@ -128,3 +128,14 @@ class KeyManager:
         except Exception as e:
             logger.error(f"Failed to generate npub: {e}", exc_info=True)
             raise
+
+    def get_nsec(self) -> str:
+        """Return the nsec (Bech32 encoded private key)."""
+        try:
+            priv_hex = self.get_private_key_hex()
+            priv_bytes = bytes.fromhex(priv_hex)
+            data = convertbits(priv_bytes, 8, 5, True)
+            return bech32_encode("nsec", data)
+        except Exception as e:
+            logger.error(f"Failed to generate nsec: {e}", exc_info=True)
+            raise

--- a/src/password_manager/entry_types.py
+++ b/src/password_manager/entry_types.py
@@ -12,3 +12,4 @@ class EntryType(str, Enum):
     SSH = "ssh"
     SEED = "seed"
     PGP = "pgp"
+    NOSTR = "nostr"

--- a/src/tests/test_cli_invalid_input.py
+++ b/src/tests/test_cli_invalid_input.py
@@ -77,7 +77,7 @@ def test_out_of_range_menu(monkeypatch, capsys):
 def test_invalid_add_entry_submenu(monkeypatch, capsys):
     called = {"add": False, "retrieve": False, "modify": False}
     pm, _ = _make_pm(called)
-    inputs = iter(["1", "7", "6", "7"])
+    inputs = iter(["1", "8", "7", "7"])
     monkeypatch.setattr(main, "timed_input", lambda *_: next(inputs))
     monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
     with pytest.raises(SystemExit):

--- a/src/tests/test_nostr_entry.py
+++ b/src/tests/test_nostr_entry.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.backup import BackupManager
+from password_manager.vault import Vault
+from password_manager.config_manager import ConfigManager
+
+
+def test_nostr_key_determinism():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        idx = entry_mgr.add_nostr_key("main")
+        entry = entry_mgr.retrieve_entry(idx)
+        assert entry == {
+            "type": "nostr",
+            "kind": "nostr",
+            "index": idx,
+            "label": "main",
+            "notes": "",
+        }
+
+        npub1, nsec1 = entry_mgr.get_nostr_key_pair(idx, TEST_SEED)
+        npub2, nsec2 = entry_mgr.get_nostr_key_pair(idx, TEST_SEED)
+        assert npub1 == npub2
+        assert nsec1 == nsec2
+        assert npub1.startswith("npub")
+        assert nsec1.startswith("nsec")


### PR DESCRIPTION
## Summary
- add new `NOSTR` entry type
- support storing and deriving Nostr npub/nsec pairs
- allow adding/retrieving Nostr keys in the UI
- expose nsec via clipboard or console
- test deterministic Nostr key generation
- update invalid menu test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68685ebe19a0832bae8d8bc49dd5c343