### PR TITLE
Display QR code for new 2FA entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ python src/main.py
 3. Provide a label for the account (for example, `GitHub`).
 4. SeedPass automatically chooses the next available derivation index when deriving.
 5. Optionally specify the TOTP period and digit count.
-6. SeedPass will display the URI and secret so you can add it to your authenticator app.
+6. SeedPass displays the URI and secret, along with a QR code you can scan to import it into your authenticator app.
 
 ### Modifying a 2FA Entry
 

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -979,6 +979,7 @@ class PasswordManager:
                     )
                     print(colored("Add this URI to your authenticator app:", "cyan"))
                     print(colored(uri, "yellow"))
+                    TotpManager.print_qr_code(uri)
                     print(colored(f"Secret: {secret}\n", "cyan"))
                     try:
                         self.sync_vault()
@@ -1016,6 +1017,7 @@ class PasswordManager:
                                 "green",
                             )
                         )
+                        TotpManager.print_qr_code(uri)
                         try:
                             self.sync_vault()
                         except Exception as nostr_error:

--- a/src/password_manager/totp.py
+++ b/src/password_manager/totp.py
@@ -7,6 +7,8 @@ import time
 from urllib.parse import quote
 from urllib.parse import urlparse, parse_qs, unquote
 
+import qrcode
+
 import pyotp
 
 from utils import key_derivation
@@ -81,3 +83,11 @@ class TotpManager:
             remaining -= 1
         sys.stdout.write("\n")
         sys.stdout.flush()
+
+    @staticmethod
+    def print_qr_code(uri: str) -> None:
+        """Display a QR code representing the provided URI in the terminal."""
+        qr = qrcode.QRCode(border=1)
+        qr.add_data(uri)
+        qr.make()
+        qr.print_ascii(invert=True)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -23,3 +23,4 @@ pyotp>=2.8.0
 
 freezegun
 pyperclip
+qrcode>=8.2


### PR DESCRIPTION
## Summary
- add `qrcode` dependency
- show QR code when adding a new TOTP entry
- expose `TotpManager.print_qr_code`
- document QR code scanning in README

## Testing
- `python3 -m venv venv`
- `pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68686b17a108832baceef4d9031f14d9