### PR TITLE
Add PGP key parsing test

### DIFF
--- a/src/tests/test_pgp_entry.py
+++ b/src/tests/test_pgp_entry.py
@@ -25,3 +25,15 @@ def test_pgp_key_determinism():
 
         assert fp1 == fp2
         assert key1 == key2
+
+        # parse returned armored key and verify fingerprint
+        from pgpy import PGPKey
+
+        parsed_key, _ = PGPKey.from_blob(key1)
+        assert parsed_key.fingerprint == fp1
+
+        # ensure the index file stores key_type and user_id
+        data = enc_mgr.load_json_data(entry_mgr.index_file)
+        entry = data["entries"][str(idx)]
+        assert entry["key_type"] == "ed25519"
+        assert entry["user_id"] == "Test"


### PR DESCRIPTION
## Summary
- parse `get_pgp_key` result using `PGPKey.from_blob`
- verify parsed fingerprint matches returned value
- check index file includes key_type and user_id

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6868807b457c832bb3205c45b0316835