### PR TITLE
Validate BIP‑39 seed entries

### DIFF
--- a/src/tests/test_seed_entry.py
+++ b/src/tests/test_seed_entry.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+from mnemonic import Mnemonic
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -30,6 +31,9 @@ def test_seed_phrase_determinism():
         phrase24_a = entry_mgr.get_seed_phrase(idx_24, TEST_SEED)
         phrase24_b = entry_mgr.get_seed_phrase(idx_24, TEST_SEED)
 
+        entry12 = entry_mgr.retrieve_entry(idx_12)
+        entry24 = entry_mgr.retrieve_entry(idx_24)
+
         seed_bytes = Bip39SeedGenerator(TEST_SEED).Generate()
         bip85 = BIP85(seed_bytes)
         expected12 = derive_seed_phrase(bip85, idx_12, 12)
@@ -39,3 +43,7 @@ def test_seed_phrase_determinism():
         assert phrase24_a == phrase24_b == expected24
         assert len(phrase12_a.split()) == 12
         assert len(phrase24_a.split()) == 24
+        assert Mnemonic("english").check(phrase12_a)
+        assert Mnemonic("english").check(phrase24_a)
+        assert entry12.get("words") == 12
+        assert entry24.get("words") == 24


### PR DESCRIPTION
## Summary
- check seed phrases are valid BIP‑39 mnemonics
- verify seed index entries store word counts

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686888d8dca8832bae6f022e0f0aabdd