### PR TITLE
Improve nostr key test

### DIFF
--- a/src/tests/test_nostr_entry.py
+++ b/src/tests/test_nostr_entry.py
@@ -4,6 +4,8 @@ from tempfile import TemporaryDirectory
 
 from helpers import create_vault, TEST_SEED, TEST_PASSWORD
 
+from nostr.coincurve_keys import Keys
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from password_manager.entry_management import EntryManager
@@ -36,3 +38,11 @@ def test_nostr_key_determinism():
         assert nsec1 == nsec2
         assert npub1.startswith("npub")
         assert nsec1.startswith("nsec")
+
+        priv_hex = Keys.bech32_to_hex(nsec1)
+        derived = Keys(priv_k=priv_hex)
+        encoded_npub = Keys.hex_to_bech32(derived.public_key_hex(), "npub")
+        assert encoded_npub == npub1
+
+        data = enc_mgr.load_json_data(entry_mgr.index_file)
+        assert data["entries"][str(idx)]["label"] == "main"


### PR DESCRIPTION
## Summary
- verify Nostr private keys round-trip through bech32 correctly
- ensure npub/nsec conversions are deterministic
- check that entry label is stored in the index

## Testing
- `python3 -m venv venv`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68688a008ff0832b9c20749facd81933