### PR TITLE
Update Windows install error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 
 ## Prerequisites
 
-- **Python 3.8+**: Ensure you have Python installed on your system. You can download it from [python.org](https://www.python.org/downloads/).
+- **Python 3.8+** (3.11 or 3.12 recommended): Ensure you have Python installed on your system. You can download it from [python.org](https://www.python.org/downloads/). Using Python 3.13 is currently discouraged because some dependencies do not ship wheels for it yet, which can cause build failures on Windows unless you install the Visual C++ Build Tools.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- warn about Python 3.13 in install instructions
- stop the PowerShell installer if `pip install` fails
- check Python version in the installer and warn when 3.13+ is used

## Testing
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686890aca914832bbfb4fd686c1d360e