### PR TITLE
Improve Windows installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,12 @@ Once activated, your terminal prompt should be prefixed with `(venv)` indicating
 
 ### 4. Install Dependencies
 
-Install the required Python packages and build dependencies using `pip`:
+Install the required Python packages and build dependencies using `pip`.
+When upgrading pip, use `python -m pip` inside the virtual environment so that pip can update itself cleanly:
 
 ```bash
-pip install --upgrade pip
-pip install -r src/requirements.txt
+python -m pip install --upgrade pip
+python -m pip install -r src/requirements.txt
 ```
 
 #### Linux Clipboard Support


### PR DESCRIPTION
## Summary
- mention using `python -m pip` when upgrading pip
- ensure installer checks for Microsoft C++ Build Tools and installs them via winget
- use `python.exe -m pip` for dependency installation

## Testing
- `pip install -r src/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_686894f3a040832b90f1945daedcc0c1