### PR TITLE
Add SeedQR display option

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1273,6 +1273,10 @@ class PasswordManager:
                     else:
                         print(colored("\n[+] Retrieved Seed Phrase:\n", "green"))
                         print(colored(phrase, "yellow"))
+                    if confirm_action("Show SeedQR? (Y/N): "):
+                        from password_manager.seedqr import encode_seedqr
+
+                        TotpManager.print_qr_code(encode_seedqr(phrase))
                     if confirm_action("Show derived entropy as hex? (Y/N): "):
                         from local_bip85.bip85 import BIP85
                         from bip_utils import Bip39SeedGenerator

--- a/src/password_manager/seedqr.py
+++ b/src/password_manager/seedqr.py
@@ -1,0 +1,14 @@
+"""SeedQR encoding utilities."""
+
+from __future__ import annotations
+
+from bip_utils.bip.bip39.bip39_mnemonic import Bip39Languages
+from bip_utils.bip.bip39.bip39_mnemonic_utils import Bip39WordsListGetter
+
+
+def encode_seedqr(mnemonic: str) -> str:
+    """Return SeedQR digit stream for a BIP-39 mnemonic."""
+    wordlist = Bip39WordsListGetter().GetByLanguage(Bip39Languages.ENGLISH)
+    words = mnemonic.strip().split()
+    indices = [wordlist.GetWordIdx(word.lower()) for word in words]
+    return "".join(f"{idx:04d}" for idx in indices)

--- a/src/tests/test_seedqr_encoding.py
+++ b/src/tests/test_seedqr_encoding.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.seedqr import encode_seedqr
+
+
+def test_seedqr_standard_example():
+    phrase = (
+        "vacuum bridge buddy supreme exclude milk consider tail "
+        "expand wasp pattern nuclear"
+    )
+    expected = "192402220235174306311124037817700641198012901210"
+    assert encode_seedqr(phrase) == expected


### PR DESCRIPTION
## Summary
- show BIP39 seeds as SeedSigner-compatible SeedQRs
- add utility to encode SeedQR digit streams
- test compatibility with example from SeedSigner docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68690b19088c832ba8927e5b5a634c7e