### PR TITLE
Improve search entry display

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1694,15 +1694,88 @@ class PasswordManager:
                 return
 
             print(colored("\n[+] Search Results:\n", "green"))
-            for entry in results:
-                index, website, username, url, blacklisted = entry
+            for match in results:
+                index, website, username, url, blacklisted = match
+                entry = self.entry_manager.retrieve_entry(index)
+                if not entry:
+                    continue
+                etype = entry.get("type", entry.get("kind", EntryType.PASSWORD.value))
                 print(colored(f"Index: {index}", "cyan"))
-                print(colored(f"  Website: {website}", "cyan"))
-                print(colored(f"  Username: {username or 'N/A'}", "cyan"))
-                print(colored(f"  URL: {url or 'N/A'}", "cyan"))
-                print(
-                    colored(f"  Blacklisted: {'Yes' if blacklisted else 'No'}", "cyan")
-                )
+                if etype == EntryType.TOTP.value:
+                    print(colored(f"  Label: {entry.get('label', website)}", "cyan"))
+                    print(
+                        colored(
+                            f"  Derivation Index: {entry.get('index', index)}", "cyan"
+                        )
+                    )
+                    print(
+                        colored(
+                            f"  Period: {entry.get('period', 30)}s  Digits: {entry.get('digits', 6)}",
+                            "cyan",
+                        )
+                    )
+                    notes = entry.get("notes", "")
+                    if notes:
+                        print(colored(f"  Notes: {notes}", "cyan"))
+                elif etype == EntryType.SEED.value:
+                    print(colored("  Type: Seed Phrase", "cyan"))
+                    print(colored(f"  Words: {entry.get('words', 24)}", "cyan"))
+                    print(
+                        colored(
+                            f"  Derivation Index: {entry.get('index', index)}", "cyan"
+                        )
+                    )
+                    notes = entry.get("notes", "")
+                    if notes:
+                        print(colored(f"  Notes: {notes}", "cyan"))
+                elif etype == EntryType.SSH.value:
+                    print(colored("  Type: SSH Key", "cyan"))
+                    print(
+                        colored(
+                            f"  Derivation Index: {entry.get('index', index)}", "cyan"
+                        )
+                    )
+                    notes = entry.get("notes", "")
+                    if notes:
+                        print(colored(f"  Notes: {notes}", "cyan"))
+                elif etype == EntryType.PGP.value:
+                    print(colored("  Type: PGP Key", "cyan"))
+                    print(
+                        colored(
+                            f"  Key Type: {entry.get('key_type', 'ed25519')}", "cyan"
+                        )
+                    )
+                    uid = entry.get("user_id", "")
+                    if uid:
+                        print(colored(f"  User ID: {uid}", "cyan"))
+                    print(
+                        colored(
+                            f"  Derivation Index: {entry.get('index', index)}", "cyan"
+                        )
+                    )
+                    notes = entry.get("notes", "")
+                    if notes:
+                        print(colored(f"  Notes: {notes}", "cyan"))
+                elif etype == EntryType.NOSTR.value:
+                    print(colored("  Type: Nostr Key", "cyan"))
+                    print(colored(f"  Label: {entry.get('label', '')}", "cyan"))
+                    print(
+                        colored(
+                            f"  Derivation Index: {entry.get('index', index)}", "cyan"
+                        )
+                    )
+                    notes = entry.get("notes", "")
+                    if notes:
+                        print(colored(f"  Notes: {notes}", "cyan"))
+                else:
+                    print(colored(f"  Website: {website}", "cyan"))
+                    print(colored(f"  Username: {username or 'N/A'}", "cyan"))
+                    print(colored(f"  URL: {url or 'N/A'}", "cyan"))
+                    print(
+                        colored(
+                            f"  Blacklisted: {'Yes' if blacklisted else 'No'}", "cyan"
+                        )
+                    )
                 print("-" * 40)
 
         except Exception as e:

--- a/src/tests/test_manager_search_display.py
+++ b/src/tests/test_manager_search_display.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.backup import BackupManager
+from password_manager.manager import PasswordManager, EncryptionMode
+from password_manager.config_manager import ConfigManager
+
+
+def test_search_entries_shows_totp_details(monkeypatch, capsys):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+        pm.encryption_manager = enc_mgr
+        pm.vault = vault
+        pm.entry_manager = entry_mgr
+        pm.backup_manager = backup_mgr
+        pm.nostr_client = SimpleNamespace()
+        pm.fingerprint_dir = tmp_path
+        pm.secret_mode_enabled = False
+
+        entry_mgr.add_totp("Example", TEST_SEED)
+
+        monkeypatch.setattr("builtins.input", lambda *a, **k: "Example")
+
+        pm.handle_search_entries()
+        out = capsys.readouterr().out
+        assert "Label: Example" in out
+        assert "Derivation Index" in out


### PR DESCRIPTION
## Summary
- show full entry information in `handle_search_entries`
- update CLI `print_matches` helper
- add regression test for searching TOTP entries

## Testing
- `black src/password_manager/manager.py src/main.py src/tests/test_manager_search_display.py`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68691995a35c832b8af57472707d527f