### PR TITLE
Clarify seed phrase QR prompt

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1099,7 +1099,7 @@ class PasswordManager:
                 print(colored(f"Notes: {notes}", "cyan"))
             print(colored("Seed Phrase:", "cyan"))
             print(colored(phrase, "yellow"))
-            if confirm_action("Show QR? (Y/N): "):
+            if confirm_action("Show Compact Seed QR? (Y/N): "):
                 from password_manager.seedqr import encode_seedqr
 
                 TotpManager.print_qr_code(encode_seedqr(phrase))
@@ -1328,7 +1328,7 @@ class PasswordManager:
                         )
                     else:
                         print(colored(phrase, "yellow"))
-                    if confirm_action("Show QR? (Y/N): "):
+                    if confirm_action("Show Compact Seed QR? (Y/N): "):
                         from password_manager.seedqr import encode_seedqr
 
                         TotpManager.print_qr_code(encode_seedqr(phrase))


### PR DESCRIPTION
## Summary
- clarify the prompt for showing a seed phrase as a QR code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68692574b32c832b97b987e041c3328f