### PR TITLE
Fix list selection shows entry details

### DIFF
--- a/src/tests/test_manager_list_entries.py
+++ b/src/tests/test_manager_list_entries.py
@@ -41,3 +41,44 @@ def test_handle_list_entries(monkeypatch, capsys):
         out = capsys.readouterr().out
         assert "Example" in out
         assert "example.com" in out
+
+
+def test_list_entries_show_details(monkeypatch, capsys):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+        pm.encryption_manager = enc_mgr
+        pm.vault = vault
+        pm.entry_manager = entry_mgr
+        pm.backup_manager = backup_mgr
+        pm.parent_seed = TEST_SEED
+        pm.nostr_client = SimpleNamespace()
+        pm.fingerprint_dir = tmp_path
+        pm.secret_mode_enabled = False
+
+        entry_mgr.add_totp("Example", TEST_SEED)
+
+        monkeypatch.setattr(pm.entry_manager, "get_totp_code", lambda *a, **k: "123456")
+        monkeypatch.setattr(
+            pm.entry_manager, "get_totp_time_remaining", lambda *a, **k: 1
+        )
+        monkeypatch.setattr("password_manager.manager.time.sleep", lambda *a, **k: None)
+        monkeypatch.setattr(sys.stdin, "readline", lambda *a, **k: "b\n")
+        monkeypatch.setattr(
+            "password_manager.manager.select.select",
+            lambda *a, **k: ([sys.stdin], [], []),
+        )
+
+        inputs = iter(["1", "0"])
+        monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
+
+        pm.handle_list_entries()
+        out = capsys.readouterr().out
+        assert "Retrieved 2FA Code" in out
+        assert "123456" in out


### PR DESCRIPTION
## Summary
- add `show_entry_details_by_index` helper using handle_retrieve_entry
- call new helper from `handle_list_entries`
- test list entries detail retrieval works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686930718d10832b944e069bf669905b