### PR TITLE
Enhance list entry navigation

### DIFF
--- a/src/password_manager/entry_management.py
+++ b/src/password_manager/entry_management.py
@@ -874,13 +874,13 @@ class EntryManager:
 
     def get_entry_summaries(
         self, filter_kind: str | None = None
-    ) -> list[tuple[int, str]]:
-        """Return a list of entry index and display labels."""
+    ) -> list[tuple[int, str, str]]:
+        """Return a list of entry index, type, and display labels."""
         try:
             data = self.vault.load_index()
             entries_data = data.get("entries", {})
 
-            summaries: list[tuple[int, str]] = []
+            summaries: list[tuple[int, str, str]] = []
             for idx_str, entry in entries_data.items():
                 etype = entry.get("type", entry.get("kind", EntryType.PASSWORD.value))
                 if filter_kind and etype != filter_kind:
@@ -889,7 +889,7 @@ class EntryManager:
                     label = entry.get("label", entry.get("website", ""))
                 else:
                     label = entry.get("label", etype)
-                summaries.append((int(idx_str), label))
+                summaries.append((int(idx_str), etype, label))
 
             summaries.sort(key=lambda x: x[0])
             return summaries

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1895,19 +1895,23 @@ class PasswordManager:
                 summaries = self.entry_manager.get_entry_summaries(filter_kind)
                 if not summaries:
                     continue
-                print(colored("\n[+] Entries:\n", "green"))
-                for idx, label in summaries:
-                    print(colored(f"{idx}. {label}", "cyan"))
-                idx_input = input(
-                    "Enter index to view details or press Enter to return: "
-                ).strip()
-                if not idx_input:
-                    return
-                if not idx_input.isdigit():
-                    print(colored("Invalid index.", "red"))
-                    continue
-                self.show_entry_details_by_index(int(idx_input))
-                return
+                while True:
+                    print(colored("\n[+] Entries:\n", "green"))
+                    for idx, etype, label in summaries:
+                        if filter_kind is None:
+                            display_type = etype.capitalize()
+                            print(colored(f"{idx}. {display_type} - {label}", "cyan"))
+                        else:
+                            print(colored(f"{idx}. {label}", "cyan"))
+                    idx_input = input(
+                        "Enter index to view details or press Enter to go back: "
+                    ).strip()
+                    if not idx_input:
+                        break
+                    if not idx_input.isdigit():
+                        print(colored("Invalid index.", "red"))
+                        continue
+                    self.show_entry_details_by_index(int(idx_input))
         except Exception as e:
             logging.error(f"Failed to list entries: {e}", exc_info=True)
             print(colored(f"Error: Failed to list entries: {e}", "red"))


### PR DESCRIPTION
## Summary
- show entry type for `All` listings
- keep the list menu active after viewing an entry so multiple details can be checked

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6869358becd0832bbc0187375d68cb76