### PR TITLE
Fix Windows file permissions error

### DIFF
--- a/src/password_manager/backup.py
+++ b/src/password_manager/backup.py
@@ -168,8 +168,11 @@ class BackupManager:
             return
 
         try:
-            with exclusive_lock(backup_file):
-                shutil.copy2(backup_file, self.index_file)
+            with exclusive_lock(backup_file) as fh_src, open(
+                self.index_file, "wb"
+            ) as dst:
+                fh_src.seek(0)
+                shutil.copyfileobj(fh_src, dst)
             logger.info(f"Restored the index file from backup '{backup_file}'.")
             print(
                 colored(


### PR DESCRIPTION
## Summary
- handle file locking with the existing handle to avoid PermissionError on Windows
- restore backups without reopening locked files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68694d4e20f4832bbfd88b37bd956898