### PR TITLE
Fix Windows stress arg step

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -72,6 +72,7 @@ jobs:
           pip install pip-audit
           pip-audit -r requirements.lock
       - name: Determine stress args
+        shell: bash
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
             echo "STRESS_ARGS=--stress" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- fix the `Determine stress args` step on Windows by specifying bash

## Testing
- `black .`
- `pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68694fcb4158832bb5070c3fb756596e