### PR TITLE
Fix imghdr stub for Python 3.13

### DIFF
--- a/src/utils/imghdr_stub.py
+++ b/src/utils/imghdr_stub.py
@@ -11,7 +11,11 @@ import warnings
 
 __all__ = ["what"]
 
-warnings._deprecated(__name__, remove=(3, 13))
+warnings.warn(
+    "'imghdr' is deprecated and will be removed in Python 3.13",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 # -------------------------
 # Recognize image headers


### PR DESCRIPTION
## Summary
- replace `_deprecated` usage in imghdr stub to avoid runtime error on Python 3.13

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686972fa7838832bbe45f6a0b061af38