### PR TITLE
Improve checksum reporting in stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,9 @@ Back in the Settings menu you can:
 * Select `11` to change the inactivity timeout.
 * Choose `12` to lock the vault and require re-entry of your password.
 * Select `13` to view seed profile stats. The summary lists counts for
-  passwords, TOTP codes, SSH keys, seed phrases, and PGP keys.
+  passwords, TOTP codes, SSH keys, seed phrases, and PGP keys. It also shows
+  whether both the encrypted database and the script itself pass checksum
+  validation.
 * Choose `14` to toggle Secret Mode and set the clipboard clear delay.
 * Select `15` to return to the main menu.
 

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -2497,7 +2497,7 @@ class PasswordManager:
         stats["entries"] = counts
         stats["total_entries"] = len(entries)
 
-        # Schema version and checksum status
+        # Schema version and database checksum status
         stats["schema_version"] = data.get("schema_version")
         json_content = json.dumps(data, indent=4)
         current_checksum = hashlib.sha256(json_content.encode("utf-8")).hexdigest()
@@ -2509,6 +2509,19 @@ class PasswordManager:
             stored = None
             stats["checksum_ok"] = False
         stats["checksum"] = stored
+
+        # Script checksum status
+        script_path = Path(__file__).resolve()
+        try:
+            script_checksum = calculate_checksum(str(script_path))
+        except Exception:
+            script_checksum = None
+
+        if SCRIPT_CHECKSUM_FILE.exists() and script_checksum:
+            stored_script = SCRIPT_CHECKSUM_FILE.read_text().strip()
+            stats["script_checksum_ok"] = stored_script == script_checksum
+        else:
+            stats["script_checksum_ok"] = False
 
         # Relay info
         cfg = self.config_manager.load_config(require_pin=False)
@@ -2582,7 +2595,13 @@ class PasswordManager:
         print(colored(f"Schema version: {stats['schema_version']}", "cyan"))
         print(
             colored(
-                f"Checksum ok: {'yes' if stats['checksum_ok'] else 'no'}",
+                f"Database checksum ok: {'yes' if stats['checksum_ok'] else 'no'}",
+                "cyan",
+            )
+        )
+        print(
+            colored(
+                f"Script checksum ok: {'yes' if stats['script_checksum_ok'] else 'no'}",
                 "cyan",
             )
         )


### PR DESCRIPTION
## Summary
- show script checksum status in profile stats
- clarify README about database and script checksum validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6869808cfd98832bbefbf62fbfbe5e83