### PR TITLE
Run backup after configuring location

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ Back in the Settings menu you can:
 * Select `7` to export the database to an encrypted file.
 * Choose `8` to import a database from a backup file.
 * Select `9` to export all 2FA codes.
-* Choose `10` to set an additional backup location.
+* Choose `10` to set an additional backup location. A backup is created
+  immediately after the directory is configured.
 * Select `11` to change the inactivity timeout.
 * Choose `12` to lock the vault and require re-entry of your password.
 * Select `13` to view seed profile stats. The summary lists counts for

--- a/src/main.py
+++ b/src/main.py
@@ -514,6 +514,8 @@ def handle_set_additional_backup_location(pm: PasswordManager) -> None:
     try:
         cfg_mgr.set_additional_backup_path(str(path))
         print(colored(f"Additional backups will be copied to {path}", "green"))
+        if pm.backup_manager is not None:
+            pm.backup_manager.create_backup()
     except Exception as e:
         logging.error(f"Error saving backup path: {e}")
         print(colored(f"Error: {e}", "red"))


### PR DESCRIPTION
## Summary
- trigger a backup immediately after configuring the secondary backup directory
- document this behavior in the README

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6869a68ec2f8832b902050d12b6ea273