### PR TITLE
sync on login

### DIFF
--- a/src/tests/test_password_unlock_after_change.py
+++ b/src/tests/test_password_unlock_after_change.py
@@ -81,6 +81,7 @@ def test_password_change_and_unlock(monkeypatch):
         )
         monkeypatch.setattr(PasswordManager, "initialize_bip85", lambda self: None)
         monkeypatch.setattr(PasswordManager, "initialize_managers", lambda self: None)
+        monkeypatch.setattr(PasswordManager, "sync_index_from_nostr", lambda self: None)
 
         pm.unlock_vault()
 

--- a/src/tests/test_unlock_sync.py
+++ b/src/tests/test_unlock_sync.py
@@ -1,0 +1,26 @@
+import time
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.manager import PasswordManager
+
+
+def test_unlock_triggers_sync(monkeypatch, tmp_path):
+    pm = PasswordManager.__new__(PasswordManager)
+    pm.fingerprint_dir = tmp_path
+    pm.setup_encryption_manager = lambda *a, **k: None
+    pm.initialize_bip85 = lambda: None
+    pm.initialize_managers = lambda: None
+    called = {"sync": False}
+
+    def fake_sync(self):
+        called["sync"] = True
+
+    monkeypatch.setattr(PasswordManager, "sync_index_from_nostr", fake_sync)
+
+    pm.unlock_vault()
+
+    assert called["sync"]


### PR DESCRIPTION
## Summary
- fetch latest vault data from Nostr after unlocking a vault
- patch `PasswordManager` tests for new sync call
- add regression test ensuring unlock triggers sync

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6869a941e2f4832b82915a5753585be1