### PR TITLE
Improve seed phrase details

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1128,7 +1128,14 @@ class PasswordManager:
                 print(colored("Seed phrase display cancelled.", "yellow"))
                 return
 
-            print(colored(f"\n[+] Seed entry added with ID {index}.\n", "green"))
+            print(
+                colored(
+                    f"\n[+] Seed entry '{label}' added with ID {index}.\n",
+                    "green",
+                )
+            )
+            print(colored(f"Index: {index}", "cyan"))
+            print(colored(f"Label: {label}", "cyan"))
             if notes:
                 print(colored(f"Notes: {notes}", "cyan"))
             print(colored("Seed Phrase:", "cyan"))
@@ -1374,6 +1381,7 @@ class PasswordManager:
                 try:
                     phrase = self.entry_manager.get_seed_phrase(index, self.parent_seed)
                     print(colored("\n[+] Retrieved Seed Phrase:\n", "green"))
+                    print(colored(f"Index: {index}", "cyan"))
                     if label:
                         print(colored(f"Label: {label}", "cyan"))
                     if notes:
@@ -1407,8 +1415,6 @@ class PasswordManager:
                             words_len=words,
                         )
                         print(colored(f"Entropy: {entropy.hex()}", "cyan"))
-                    if notes:
-                        print(colored(f"Notes: {notes}", "cyan"))
                 except Exception as e:
                     logging.error(f"Error deriving seed phrase: {e}", exc_info=True)
                     print(colored(f"Error: Failed to derive seed phrase: {e}", "red"))


### PR DESCRIPTION
## Summary
- show index and label after adding a seed phrase
- display index, label and notes when retrieving a seed phrase

## Testing
- `python3 -m venv venv`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6869b19fb678832baaa3fc0f222f84bd