### PR TITLE
Adjust warning colors

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -142,7 +142,7 @@ class PasswordManager:
                 colored(
                     "Warning: script checksum mismatch. "
                     "Run 'Generate Script Checksum' in Settings if you've updated the app.",
-                    "red",
+                    "yellow",
                 )
             )
 
@@ -1507,7 +1507,7 @@ class PasswordManager:
                 print(
                     colored(
                         f"Warning: This password is blacklisted and should not be used.",
-                        "red",
+                        "yellow",
                     )
                 )
 
@@ -2320,13 +2320,13 @@ class PasswordManager:
             print(
                 colored(
                     "Warning: Revealing your parent seed is a highly sensitive operation.",
-                    "red",
+                    "yellow",
                 )
             )
             print(
                 colored(
                     "Ensure you're in a secure, private environment and no one is watching your screen.",
-                    "red",
+                    "yellow",
                 )
             )
 


### PR DESCRIPTION
## Summary
- change warning color for checksum mismatch to yellow
- change parent seed warning messages to yellow
- change blacklisted password warning to yellow

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6869ba75b69c832b97f4f2e03a0ac914