### PR TITLE
Implement clear_screen helper for menu loops

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,7 @@ from nostr.client import NostrClient
 from password_manager.entry_types import EntryType
 from constants import INACTIVITY_TIMEOUT, initialize_app
 from utils.password_prompt import PasswordPromptError
-from utils import timed_input, copy_to_clipboard
+from utils import timed_input, copy_to_clipboard, clear_screen
 from local_bip85.bip85 import Bip85Error
 
 
@@ -568,6 +568,7 @@ def handle_toggle_secret_mode(pm: PasswordManager) -> None:
 def handle_profiles_menu(password_manager: PasswordManager) -> None:
     """Submenu for managing seed profiles."""
     while True:
+        clear_screen()
         print(color_text("\nProfiles:", "menu"))
         print(color_text("1. Switch Seed Profile", "menu"))
         print(color_text("2. Add a New Seed Profile", "menu"))
@@ -604,6 +605,7 @@ def handle_nostr_menu(password_manager: PasswordManager) -> None:
         return
 
     while True:
+        clear_screen()
         print(color_text("\nNostr Settings:", "menu"))
         print(color_text("1. Backup to Nostr", "menu"))
         print(color_text("2. Restore from Nostr", "menu"))
@@ -638,6 +640,7 @@ def handle_nostr_menu(password_manager: PasswordManager) -> None:
 def handle_settings(password_manager: PasswordManager) -> None:
     """Interactive settings menu with submenus for profiles and Nostr."""
     while True:
+        clear_screen()
         print(color_text("\nSettings:", "menu"))
         print(color_text("1. Profiles", "menu"))
         print(color_text("2. Nostr", "menu"))
@@ -716,6 +719,7 @@ def display_menu(
     if callable(display_fn):
         display_fn()
     while True:
+        clear_screen()
         if time.time() - password_manager.last_activity > inactivity_timeout:
             print(colored("Session timed out. Vault locked.", "yellow"))
             password_manager.lock_vault()
@@ -788,6 +792,7 @@ def display_menu(
         elif choice == "2":
             password_manager.update_activity()
             password_manager.handle_retrieve_entry()
+            clear_screen()
         elif choice == "3":
             password_manager.update_activity()
             password_manager.handle_search_entries()

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -52,6 +52,7 @@ from utils.password_prompt import (
 )
 from utils.memory_protection import InMemorySecret
 from utils.clipboard import copy_to_clipboard
+from utils.terminal_utils import clear_screen
 from constants import MIN_HEALTHY_RELAYS
 
 from constants import (
@@ -2029,7 +2030,7 @@ class PasswordManager:
             totp_list.sort(key=lambda t: t[0].lower())
             print(colored("Press 'b' then Enter to return to the menu.", "cyan"))
             while True:
-                print("\033c", end="")
+                clear_screen()
                 print(colored("Press 'b' then Enter to return to the menu.", "cyan"))
                 generated = [t for t in totp_list if not t[3]]
                 imported_list = [t for t in totp_list if t[3]]

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -28,6 +28,7 @@ try:
     from .input_utils import timed_input
     from .memory_protection import InMemorySecret
     from .clipboard import copy_to_clipboard
+    from .terminal_utils import clear_screen
 
     if logger.isEnabledFor(logging.DEBUG):
         logger.info("Modules imported successfully.")
@@ -55,4 +56,5 @@ __all__ = [
     "timed_input",
     "InMemorySecret",
     "copy_to_clipboard",
+    "clear_screen",
 ]

--- a/src/utils/terminal_utils.py
+++ b/src/utils/terminal_utils.py
@@ -1,0 +1,6 @@
+"""Utility functions for terminal output."""
+
+
+def clear_screen() -> None:
+    """Clear the terminal screen using an ANSI escape code."""
+    print("\033c", end="")


### PR DESCRIPTION
## Summary
- add new `clear_screen` helper in `utils` for wiping the terminal
- import and call `clear_screen` at the start of menu loops and after retrieving an entry
- use `clear_screen` inside `handle_display_totp_codes`

## Testing
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6869c081e5fc832bb3c1bdc366dc6a19