### PR TITLE
Ensure retrieval output visible before clearing

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -52,7 +52,7 @@ from utils.password_prompt import (
 )
 from utils.memory_protection import InMemorySecret
 from utils.clipboard import copy_to_clipboard
-from utils.terminal_utils import clear_screen
+from utils.terminal_utils import clear_screen, pause
 from constants import MIN_HEALTHY_RELAYS
 
 from constants import (
@@ -1285,11 +1285,13 @@ class PasswordManager:
             ).strip()
             if not index_input.isdigit():
                 print(colored("Error: Index must be a number.", "red"))
+                pause()
                 return
             index = int(index_input)
 
             entry = self.entry_manager.retrieve_entry(index)
             if not entry:
+                pause()
                 return
 
             entry_type = entry.get("type", EntryType.PASSWORD.value)
@@ -1345,6 +1347,7 @@ class PasswordManager:
                 except Exception as e:
                     logging.error(f"Error generating TOTP code: {e}", exc_info=True)
                     print(colored(f"Error: Failed to generate TOTP code: {e}", "red"))
+                pause()
                 return
             if entry_type == EntryType.SSH.value:
                 notes = entry.get("notes", "")
@@ -1379,6 +1382,7 @@ class PasswordManager:
                 except Exception as e:
                     logging.error(f"Error deriving SSH key pair: {e}", exc_info=True)
                     print(colored(f"Error: Failed to derive SSH keys: {e}", "red"))
+                pause()
                 return
             if entry_type == EntryType.SEED.value:
                 notes = entry.get("notes", "")
@@ -1428,6 +1432,7 @@ class PasswordManager:
                 except Exception as e:
                     logging.error(f"Error deriving seed phrase: {e}", exc_info=True)
                     print(colored(f"Error: Failed to derive seed phrase: {e}", "red"))
+                pause()
                 return
             if entry_type == EntryType.PGP.value:
                 notes = entry.get("notes", "")
@@ -1460,6 +1465,7 @@ class PasswordManager:
                 except Exception as e:
                     logging.error(f"Error deriving PGP key: {e}", exc_info=True)
                     print(colored(f"Error: Failed to derive PGP key: {e}", "red"))
+                pause()
                 return
             if entry_type == EntryType.NOSTR.value:
                 label = entry.get("label", "")
@@ -1492,6 +1498,7 @@ class PasswordManager:
                 except Exception as e:
                     logging.error(f"Error deriving Nostr keys: {e}", exc_info=True)
                     print(colored(f"Error: Failed to derive Nostr keys: {e}", "red"))
+                pause()
                 return
 
             website_name = entry.get("website")
@@ -1578,9 +1585,11 @@ class PasswordManager:
                                         print(colored(f"  {label}: {value}", "cyan"))
             else:
                 print(colored("Error: Failed to retrieve the password.", "red"))
+            pause()
         except Exception as e:
             logging.error(f"Error during password retrieval: {e}", exc_info=True)
             print(colored(f"Error: Failed to retrieve password: {e}", "red"))
+            pause()
 
     def handle_modify_entry(self) -> None:
         """

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -28,7 +28,7 @@ try:
     from .input_utils import timed_input
     from .memory_protection import InMemorySecret
     from .clipboard import copy_to_clipboard
-    from .terminal_utils import clear_screen
+    from .terminal_utils import clear_screen, pause
 
     if logger.isEnabledFor(logging.DEBUG):
         logger.info("Modules imported successfully.")
@@ -57,4 +57,5 @@ __all__ = [
     "InMemorySecret",
     "copy_to_clipboard",
     "clear_screen",
+    "pause",
 ]

--- a/src/utils/terminal_utils.py
+++ b/src/utils/terminal_utils.py
@@ -1,6 +1,18 @@
 """Utility functions for terminal output."""
 
+import sys
+
 
 def clear_screen() -> None:
     """Clear the terminal screen using an ANSI escape code."""
     print("\033c", end="")
+
+
+def pause(message: str = "Press Enter to continue...") -> None:
+    """Wait for the user to press Enter before proceeding."""
+    if not sys.stdin or not sys.stdin.isatty():
+        return
+    try:
+        input(message)
+    except EOFError:
+        pass


### PR DESCRIPTION
## Summary
- add a `pause` helper for waiting on user input
- expose the new helper from `utils`
- pause within `handle_retrieve_entry` so the screen isn't cleared before the user can read the output

## Testing
- `black src/utils/terminal_utils.py src/utils/__init__.py src/password_manager/manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6869c66b1d28832ba656182e34478059