### PR TITLE
Improve TUI interaction timing

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -188,6 +188,13 @@ class PasswordManager:
         self.locked = False
         self.update_activity()
 
+    def pause(self, prompt: str = "Press Enter to continue...") -> None:
+        """Wait for the user to press Enter before proceeding."""
+        try:
+            input(colored(prompt, "cyan"))
+        except (EOFError, KeyboardInterrupt):
+            print()
+
     def initialize_fingerprint_manager(self):
         """
         Initializes the FingerprintManager.
@@ -936,6 +943,7 @@ class PasswordManager:
                     f"Failed to post updated index to Nostr: {nostr_error}",
                     exc_info=True,
                 )
+            self.pause()
 
         except Exception as e:
             logging.error(f"Error during password generation: {e}", exc_info=True)
@@ -1027,6 +1035,7 @@ class PasswordManager:
                                 f"Failed to post updated index to Nostr: {nostr_error}",
                                 exc_info=True,
                             )
+                        self.pause()
                         break
                     except ValueError as err:
                         print(colored(f"Error: {err}", "red"))
@@ -1073,6 +1082,7 @@ class PasswordManager:
                     f"Failed to post updated index to Nostr: {nostr_error}",
                     exc_info=True,
                 )
+            self.pause()
         except Exception as e:
             logging.error(f"Error during SSH key setup: {e}", exc_info=True)
             print(colored(f"Error: Failed to add SSH key: {e}", "red"))
@@ -1119,6 +1129,7 @@ class PasswordManager:
                     f"Failed to post updated index to Nostr: {nostr_error}",
                     exc_info=True,
                 )
+            self.pause()
         except Exception as e:
             logging.error(f"Error during seed phrase setup: {e}", exc_info=True)
             print(colored(f"Error: Failed to add seed phrase: {e}", "red"))
@@ -1169,6 +1180,7 @@ class PasswordManager:
                     f"Failed to post updated index to Nostr: {nostr_error}",
                     exc_info=True,
                 )
+            self.pause()
         except Exception as e:
             logging.error(f"Error during PGP key setup: {e}", exc_info=True)
             print(colored(f"Error: Failed to add PGP key: {e}", "red"))
@@ -1210,6 +1222,7 @@ class PasswordManager:
                     f"Failed to post updated index to Nostr: {nostr_error}",
                     exc_info=True,
                 )
+            self.pause()
         except Exception as e:
             logging.error(f"Error during Nostr key setup: {e}", exc_info=True)
             print(colored(f"Error: Failed to add Nostr key: {e}", "red"))

--- a/src/tests/test_manager_add_totp.py
+++ b/src/tests/test_manager_add_totp.py
@@ -51,6 +51,7 @@ def test_handle_add_totp(monkeypatch, capsys):
         )
         monkeypatch.setattr("builtins.input", lambda *args, **kwargs: next(inputs))
         monkeypatch.setattr(pm, "sync_vault", lambda: None)
+        monkeypatch.setattr(pm, "pause", lambda *a, **k: None)
 
         pm.handle_add_totp()
         out = capsys.readouterr().out

--- a/src/tests/test_manager_workflow.py
+++ b/src/tests/test_manager_workflow.py
@@ -66,6 +66,7 @@ def test_manager_workflow(monkeypatch):
             ]
         )
         monkeypatch.setattr("builtins.input", lambda *args, **kwargs: next(inputs))
+        monkeypatch.setattr(pm, "pause", lambda *a, **k: None)
 
         pm.handle_add_password()
         assert pm.is_dirty is False


### PR DESCRIPTION
## Summary
- add `PasswordManager.pause` helper to wait for user input
- pause after adding any new entry so details remain visible
- adjust tests to patch the new pause method

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6869dd588dc4832bb0446d6e3bf0bdf9