### PR TITLE
Improve TUI interaction timing

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1982,7 +1982,8 @@ class PasswordManager:
             totp_list.sort(key=lambda t: t[0].lower())
             print(colored("Press 'b' then Enter to return to the menu.", "cyan"))
             while True:
-                print("\033c", end="")
+                # Clear screen while preserving scrollback
+                print("\033[2J\033[H", end="")
                 print(colored("Press 'b' then Enter to return to the menu.", "cyan"))
                 generated = [t for t in totp_list if not t[3]]
                 imported_list = [t for t in totp_list if t[3]]


### PR DESCRIPTION
## Summary
- remove interactive `pause` helper
- keep TOTP screen refresh from wiping terminal scrollback
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6869dd588dc4832bb0446d6e3bf0bdf9