### PR TITLE
Prevent search results from being immediately cleared

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,7 @@ from nostr.client import NostrClient
 from password_manager.entry_types import EntryType
 from constants import INACTIVITY_TIMEOUT, initialize_app
 from utils.password_prompt import PasswordPromptError
-from utils import timed_input, copy_to_clipboard, clear_screen
+from utils import timed_input, copy_to_clipboard, clear_screen, pause
 from local_bip85.bip85 import Bip85Error
 
 
@@ -202,6 +202,7 @@ def handle_list_fingerprints(password_manager: PasswordManager):
         print(colored("Available Seed Profiles:", "cyan"))
         for fp in fingerprints:
             print(colored(f"- {fp}", "cyan"))
+        pause()
     except Exception as e:
         logging.error(f"Error listing seed profiles: {e}", exc_info=True)
         print(colored(f"Error: Failed to list seed profiles: {e}", "red"))
@@ -219,6 +220,7 @@ def handle_display_npub(password_manager: PasswordManager):
         else:
             print(colored("Nostr public key not available.", "red"))
             logging.error("Nostr public key not available.")
+        pause()
     except Exception as e:
         logging.error(f"Failed to display npub: {e}", exc_info=True)
         print(colored(f"Error: Failed to display npub: {e}", "red"))
@@ -341,6 +343,7 @@ def handle_view_relays(cfg_mgr: "ConfigManager") -> None:
         print(colored("\nCurrent Relays:", "cyan"))
         for idx, relay in enumerate(relays, start=1):
             print(colored(f"{idx}. {relay}", "cyan"))
+        pause()
     except Exception as e:
         logging.error(f"Error displaying relays: {e}")
         print(colored(f"Error: {e}", "red"))
@@ -718,6 +721,7 @@ def display_menu(
     display_fn = getattr(password_manager, "display_stats", None)
     if callable(display_fn):
         display_fn()
+        pause()
     while True:
         clear_screen()
         if time.time() - password_manager.last_activity > inactivity_timeout:

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1849,6 +1849,7 @@ class PasswordManager:
             print(colored("\n[+] Search Results:\n", "green"))
             for match in results:
                 self.display_entry_details(match[0])
+            pause()
         except Exception as e:
             logging.error(f"Failed to search entries: {e}", exc_info=True)
             print(colored(f"Error: Failed to search entries: {e}", "red"))


### PR DESCRIPTION
## Summary
- show pause after searching entries so results stay visible
- add pauses for listing seed profiles, displaying relays and npub
- pause after displaying stats at program start

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686a54c81388832ba65097263ba94756