### PR TITLE
Fix test profile script import

### DIFF
--- a/scripts/generate_test_profile.py
+++ b/scripts/generate_test_profile.py
@@ -11,9 +11,16 @@ from __future__ import annotations
 
 import argparse
 import random
+import sys
 from pathlib import Path
 
-from bip_utils import Bip39MnemonicGenerator, Bip39WordsNum, Bip39Languages
+from bip_utils import Bip39Languages, Bip39MnemonicGenerator, Bip39WordsNum
+
+# Ensure src directory is in sys.path for imports
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
 
 from constants import APP_DIR
 from utils.key_derivation import derive_key_from_password, derive_index_key


### PR DESCRIPTION
## Summary
- ensure `scripts/generate_test_profile.py` can import project modules by adding the `src` path to `sys.path`
- `black` format and run tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686ad1401074832b8e9b20ae0422599d