### PR TITLE
Fix screen clearing in Nostr settings

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -304,6 +304,8 @@ def handle_post_to_nostr(
     except Exception as e:
         logging.error(f"Failed to post to Nostr: {e}", exc_info=True)
         print(colored(f"Error: Failed to post to Nostr: {e}", "red"))
+    finally:
+        pause()
 
 
 def handle_retrieve_from_nostr(password_manager: PasswordManager):
@@ -336,6 +338,8 @@ def handle_retrieve_from_nostr(password_manager: PasswordManager):
     except Exception as e:
         logging.error(f"Failed to retrieve from Nostr: {e}", exc_info=True)
         print(colored(f"Error: Failed to retrieve from Nostr: {e}", "red"))
+    finally:
+        pause()
 
 
 def handle_view_relays(cfg_mgr: "ConfigManager") -> None:
@@ -395,6 +399,8 @@ def handle_add_relay(password_manager: PasswordManager) -> None:
     except Exception as e:
         logging.error(f"Error adding relay: {e}")
         print(colored(f"Error: {e}", "red"))
+    finally:
+        pause()
 
 
 def handle_remove_relay(password_manager: PasswordManager) -> None:
@@ -430,6 +436,8 @@ def handle_remove_relay(password_manager: PasswordManager) -> None:
     except Exception as e:
         logging.error(f"Error removing relay: {e}")
         print(colored(f"Error: {e}", "red"))
+    finally:
+        pause()
 
 
 def handle_reset_relays(password_manager: PasswordManager) -> None:
@@ -447,6 +455,8 @@ def handle_reset_relays(password_manager: PasswordManager) -> None:
     except Exception as e:
         logging.error(f"Error resetting relays: {e}")
         print(colored(f"Error: {e}", "red"))
+    finally:
+        pause()
 
 
 def handle_set_inactivity_timeout(password_manager: PasswordManager) -> None:


### PR DESCRIPTION
## Summary
- keep console output visible in Nostr settings actions
- add `pause()` calls after backup, restore, and relay management operations

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686ad372cb0c832bb9071e00071d41e8