### PR TITLE
Add Nostr sync to test profile script

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ python scripts/generate_test_profile.py --profile my_profile --count 100
 ```
 
 This command creates `~/.seedpass/my_profile` if needed and adds 100 example entries.
+After populating the vault, the script now automatically publishes the encrypted
+index to Nostr so the data can be retrieved on other devices.
 
 ### Automatically Updating the Script Checksum
 

--- a/scripts/generate_test_profile.py
+++ b/scripts/generate_test_profile.py
@@ -29,6 +29,8 @@ from password_manager.vault import Vault
 from password_manager.config_manager import ConfigManager
 from password_manager.backup import BackupManager
 from password_manager.entry_management import EntryManager
+from nostr.client import NostrClient
+import asyncio
 
 DEFAULT_PASSWORD = "testpassword"
 
@@ -127,6 +129,18 @@ def main() -> None:
     print(f"Parent seed: {seed}")
     populate(entry_mgr, seed, args.count)
     print(f"Added {args.count} entries.")
+
+    encrypted = entry_mgr.vault.get_encrypted_index()
+    if encrypted:
+        client = NostrClient(
+            entry_mgr.vault.encryption_manager,
+            dir_path.name,
+            parent_seed=seed,
+        )
+        asyncio.run(client.publish_snapshot(encrypted))
+        print("[+] Data synchronized to Nostr.")
+    else:
+        print("[-] No encrypted index found to sync.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- sync generated test profiles to Nostr
- mention automatic Nostr sync in README

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686ad9ff6f80832b9f7ecf40015d1ab2