### PR TITLE
Fix test profile Nostr sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,8 +364,10 @@ python scripts/generate_test_profile.py --profile my_profile --count 100
 ```
 
 This command creates `~/.seedpass/my_profile` if needed and adds 100 example entries.
-After populating the vault, the script now automatically publishes the encrypted
-index to Nostr so the data can be retrieved on other devices.
+After populating the vault, the script prints the derived **fingerprint** and
+automatically publishes the encrypted index to Nostr under that fingerprint.
+Use the same seed phrase when loading SeedPass so it can retrieve the data from
+Nostr.
 
 ### Automatically Updating the Script Checksum
 

--- a/scripts/generate_test_profile.py
+++ b/scripts/generate_test_profile.py
@@ -30,6 +30,7 @@ from password_manager.config_manager import ConfigManager
 from password_manager.backup import BackupManager
 from password_manager.entry_management import EntryManager
 from nostr.client import NostrClient
+from utils.fingerprint import generate_fingerprint
 import asyncio
 
 DEFAULT_PASSWORD = "testpassword"
@@ -125,8 +126,11 @@ def main() -> None:
     args = parser.parse_args()
 
     seed, entry_mgr, dir_path = initialize_profile(args.profile)
+    fingerprint = generate_fingerprint(seed)
     print(f"Using profile directory: {dir_path}")
     print(f"Parent seed: {seed}")
+    if fingerprint:
+        print(f"Fingerprint: {fingerprint}")
     populate(entry_mgr, seed, args.count)
     print(f"Added {args.count} entries.")
 
@@ -134,7 +138,7 @@ def main() -> None:
     if encrypted:
         client = NostrClient(
             entry_mgr.vault.encryption_manager,
-            dir_path.name,
+            fingerprint or dir_path.name,
             parent_seed=seed,
         )
         asyncio.run(client.publish_snapshot(encrypted))


### PR DESCRIPTION
## Summary
- ensure generate_test_profile.py uses fingerprint derived from seed
- clarify README about the fingerprint when generating a test profile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686adc890dc8832b92c6ce9cd74f1aa4