### PR TITLE
Fix profile generator creating missing app directory

### DIFF
--- a/scripts/generate_test_profile.py
+++ b/scripts/generate_test_profile.py
@@ -22,7 +22,7 @@ SRC_DIR = PROJECT_ROOT / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
-from constants import APP_DIR
+from constants import APP_DIR, initialize_app
 from utils.key_derivation import derive_key_from_password, derive_index_key
 from password_manager.encryption import EncryptionManager
 from password_manager.vault import Vault
@@ -39,6 +39,7 @@ DEFAULT_PASSWORD = "testpassword"
 
 def initialize_profile(profile_name: str) -> tuple[str, EntryManager, Path, str]:
     """Create or load a profile and return the seed phrase, manager, directory and fingerprint."""
+    initialize_app()
     seed_txt = APP_DIR / f"{profile_name}_seed.txt"
     if seed_txt.exists():
         seed_phrase = seed_txt.read_text().strip()

--- a/src/tests/test_generate_test_profile.py
+++ b/src/tests/test_generate_test_profile.py
@@ -1,0 +1,32 @@
+import importlib
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import importlib.util
+
+
+def test_initialize_profile_creates_directories(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        # Mock home directory so APP_DIR is within tmp_path
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        # Reload constants to use the mocked home directory
+        constants = importlib.import_module("constants")
+        importlib.reload(constants)
+        # Load the script module directly from its path
+        script_path = (
+            Path(__file__).resolve().parents[2] / "scripts" / "generate_test_profile.py"
+        )
+        spec = importlib.util.spec_from_file_location(
+            "generate_test_profile", script_path
+        )
+        gtp = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(gtp)
+
+        seed, mgr, dir_path, fingerprint = gtp.initialize_profile("test")
+
+        assert constants.APP_DIR.exists()
+        assert (constants.APP_DIR / "test_seed.txt").exists()
+        assert dir_path.exists()
+        assert dir_path.name == fingerprint


### PR DESCRIPTION
## Summary
- ensure `scripts/generate_test_profile.py` creates `~/.seedpass` when needed
- cover this scenario with a regression test

## Testing
- `black scripts/generate_test_profile.py src/tests/test_generate_test_profile.py`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686af7ee9cf4832ba3375e5a857e8c58