### PR TITLE
Fix missing index error noise

### DIFF
--- a/src/password_manager/encryption.py
+++ b/src/password_manager/encryption.py
@@ -376,13 +376,9 @@ class EncryptionManager:
         try:
             relative_path = Path("seedpass_entries_db.json.enc")
             if not (self.fingerprint_dir / relative_path).exists():
-                logger.error(
+                # Missing index is normal on first run
+                logger.info(
                     f"Index file '{relative_path}' does not exist in '{self.fingerprint_dir}'."
-                )
-                print(
-                    colored(
-                        f"Error: Index file '{relative_path}' does not exist.", "red"
-                    )
                 )
                 return None
 


### PR DESCRIPTION
## Summary
- avoid printing a scary error when the index is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686affc67fc4832b9a736e1697d03d6f