### PR TITLE
Add Python auto-install support to Windows installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ bash -c "$(curl -sSL https://raw.githubusercontent.com/PR0M3TH3AN/SeedPass/main/
 ```powershell
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; $scriptContent = (New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/PR0M3TH3AN/SeedPass/main/scripts/install.ps1'); & ([scriptblock]::create($scriptContent))
 ```
-The Windows installer will attempt to install Git automatically if it is not already available.
+The Windows installer will attempt to install Git automatically if it is not already available. It also tries to
+install Python 3 using `winget`, `choco`, or `scoop` when Python is missing.
 **Note:** If you are using Python 3.13 or newer, install the [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) and reopen PowerShell before rerunning the installer.
 *Install the beta branch:*
 ```powershell


### PR DESCRIPTION
## Summary
- improve installer to attempt Python installation on Windows
- document auto-install behavior for Git and Python

## Testing
- `pip install -r src/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_686b117dff50832b9195b1789b2ccdb2