### PR TITLE
Improve Windows installer Python detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ bash -c "$(curl -sSL https://raw.githubusercontent.com/PR0M3TH3AN/SeedPass/main/
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; $scriptContent = (New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/PR0M3TH3AN/SeedPass/main/scripts/install.ps1'); & ([scriptblock]::create($scriptContent))
 ```
 The Windows installer will attempt to install Git automatically if it is not already available. It also tries to
-
 install Python 3 using `winget`, `choco`, or `scoop` when Python is missing and recognizes the `py` launcher if `python`
-isn't on your PATH.
+isn't on your PATH. If automatic installation fails, you'll be shown a link to download Python directly from
+<https://www.python.org/downloads/windows/>.
 
 **Note:** If you are using Python 3.13 or newer, install the [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) and reopen PowerShell before rerunning the installer.
 *Install the beta branch:*

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -88,9 +88,15 @@ if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
 # 🔧 merged conflicting changes from update-install-scripts-to-check-for-python vs main
 function Get-PythonCommand {
     $cmd = Get-Command python -ErrorAction SilentlyContinue
-    if ($cmd) { return ,('python') }
+    if ($cmd) {
+        $out = & $cmd --version 2>&1
+        if ($LASTEXITCODE -eq 0 -and $out -match '^Python') { return ,('python') }
+    }
     $cmd = Get-Command py -ErrorAction SilentlyContinue
-    if ($cmd) { return @('py','-3') }
+    if ($cmd) {
+        $out = & $cmd -3 --version 2>&1
+        if ($LASTEXITCODE -eq 0 -and $out -match '^Python') { return @('py','-3') }
+    }
     return $null
 }
 
@@ -104,7 +110,7 @@ if (-not $PythonCmd) {
     } elseif (Get-Command scoop -ErrorAction SilentlyContinue) {
         try { scoop install python } catch { Write-Warning "Failed to install Python via Scoop." }
     } else {
-        Write-Error "Python 3 is not installed. Please install it from https://www.python.org/ and ensure it's in your PATH."
+        Write-Error "Python 3 is not installed. Download it from https://www.python.org/downloads/windows/ and ensure it's in your PATH."
     }
 
     # 🔧 merged conflicting changes from update-install-scripts-to-check-for-python vs main
@@ -112,7 +118,7 @@ if (-not $PythonCmd) {
                  [System.Environment]::GetEnvironmentVariable('Path','User')
     $PythonCmd = Get-PythonCommand
     if (-not $PythonCmd) {
-        Write-Error "Python installation succeeded but python not found in PATH. Please open a new terminal or add Python to PATH manually."
+        Write-Error "Python installation failed or python not found in PATH. Download Python from https://www.python.org/downloads/windows/, install it, then reopen PowerShell and rerun this script."
     }
 }
 


### PR DESCRIPTION
## Summary
- make Windows installer verify the Python command works
- show a direct Python download link if automated install fails
- mention manual Python link in README

## Testing
- `black .`
- `python3 -m venv venv`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b1ad4cf20832bab40e7ed0a9ce93d