### PR TITLE
Add archived flag to password entries

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -939,7 +939,7 @@ class PasswordManager:
                 length,
                 username,
                 url,
-                blacklisted=False,
+                archived=False,
                 notes=notes,
                 custom_fields=custom_fields,
             )
@@ -1545,7 +1545,7 @@ class PasswordManager:
             length = entry.get("length")
             username = entry.get("username")
             url = entry.get("url")
-            blacklisted = entry.get("blacklisted")
+            blacklisted = entry.get("archived", entry.get("blacklisted"))
             notes = entry.get("notes", "")
 
             print(
@@ -1660,7 +1660,7 @@ class PasswordManager:
                 label = entry.get("label", "")
                 period = int(entry.get("period", 30))
                 digits = int(entry.get("digits", 6))
-                blacklisted = entry.get("blacklisted", False)
+                blacklisted = entry.get("archived", entry.get("blacklisted", False))
                 notes = entry.get("notes", "")
 
                 print(
@@ -1751,7 +1751,7 @@ class PasswordManager:
 
                 self.entry_manager.modify_entry(
                     index,
-                    blacklisted=new_blacklisted,
+                    archived=new_blacklisted,
                     notes=new_notes,
                     label=new_label,
                     period=new_period,
@@ -1762,7 +1762,7 @@ class PasswordManager:
                 website_name = entry.get("label", entry.get("website"))
                 username = entry.get("username")
                 url = entry.get("url")
-                blacklisted = entry.get("blacklisted")
+                blacklisted = entry.get("archived", entry.get("blacklisted"))
                 notes = entry.get("notes", "")
 
                 print(
@@ -1847,8 +1847,8 @@ class PasswordManager:
                     index,
                     new_username,
                     new_url,
-                    new_blacklisted,
-                    new_notes,
+                    archived=new_blacklisted,
+                    notes=new_notes,
                     label=new_label,
                     custom_fields=custom_fields,
                 )
@@ -1992,7 +1992,7 @@ class PasswordManager:
             website = entry.get("label", entry.get("website", ""))
             username = entry.get("username", "")
             url = entry.get("url", "")
-            blacklisted = entry.get("blacklisted", False)
+            blacklisted = entry.get("archived", entry.get("blacklisted", False))
             print(color_text(f"  Label: {website}", "index"))
             print(color_text(f"  Username: {username or 'N/A'}", "index"))
             print(color_text(f"  URL: {url or 'N/A'}", "index"))
@@ -2115,7 +2115,7 @@ class PasswordManager:
             totp_list: list[tuple[str, int, int, bool]] = []
             for idx_str, entry in entries.items():
                 if entry.get("type") == EntryType.TOTP.value and not entry.get(
-                    "blacklisted", False
+                    "archived", entry.get("blacklisted", False)
                 ):
                     label = entry.get("label", "")
                     period = int(entry.get("period", 30))

--- a/src/tests/test_entry_add.py
+++ b/src/tests/test_entry_add.py
@@ -34,7 +34,7 @@ def test_add_and_retrieve_entry():
             "length": 12,
             "username": "user",
             "url": "",
-            "blacklisted": False,
+            "archived": False,
             "type": "password",
             "kind": "password",
             "notes": "",

--- a/src/tests/test_manager_add_totp.py
+++ b/src/tests/test_manager_add_totp.py
@@ -63,5 +63,6 @@ def test_handle_add_totp(monkeypatch, capsys):
             "index": 0,
             "period": 30,
             "digits": 6,
+            "archived": False,
         }
         assert "ID 0" in out

--- a/src/tests/test_manager_display_totp_codes.py
+++ b/src/tests/test_manager_display_totp_codes.py
@@ -61,7 +61,7 @@ def test_handle_display_totp_codes(monkeypatch, capsys):
         assert "123456" in out
 
 
-def test_display_totp_codes_excludes_blacklisted(monkeypatch, capsys):
+def test_display_totp_codes_excludes_archived(monkeypatch, capsys):
     with TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
         vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
@@ -83,7 +83,7 @@ def test_display_totp_codes_excludes_blacklisted(monkeypatch, capsys):
 
         entry_mgr.add_totp("Visible", TEST_SEED)
         entry_mgr.add_totp("Hidden", TEST_SEED)
-        entry_mgr.modify_entry(1, blacklisted=True)
+        entry_mgr.modify_entry(1, archived=True)
 
         monkeypatch.setattr(pm.entry_manager, "get_totp_code", lambda *a, **k: "123456")
         monkeypatch.setattr(

--- a/src/tests/test_nostr_entry.py
+++ b/src/tests/test_nostr_entry.py
@@ -30,6 +30,7 @@ def test_nostr_key_determinism():
             "index": idx,
             "label": "main",
             "notes": "",
+            "archived": False,
         }
 
         npub1, nsec1 = entry_mgr.get_nostr_key_pair(idx, TEST_SEED)

--- a/src/tests/test_ssh_entry.py
+++ b/src/tests/test_ssh_entry.py
@@ -28,6 +28,7 @@ def test_add_and_retrieve_ssh_key_pair():
             "index": index,
             "label": "ssh",
             "notes": "",
+            "archived": False,
         }
 
         priv1, pub1 = entry_mgr.get_ssh_key_pair(index, TEST_SEED)

--- a/src/tests/test_totp_entry.py
+++ b/src/tests/test_totp_entry.py
@@ -35,6 +35,7 @@ def test_add_totp_and_get_code():
             "index": 0,
             "period": 30,
             "digits": 6,
+            "archived": False,
         }
 
         code = entry_mgr.get_totp_code(0, TEST_SEED, timestamp=0)
@@ -72,6 +73,7 @@ def test_add_totp_imported(tmp_path):
         "secret": secret,
         "period": 30,
         "digits": 6,
+        "archived": False,
     }
     code = em.get_totp_code(0, timestamp=0)
     assert code == pyotp.TOTP(secret).at(0)


### PR DESCRIPTION
## Summary
- support archiving entries in `entry_management`
- handle legacy `blacklisted` flag when loading
- update manager to work with `archived`
- adjust unit tests for new field

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `black .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686bd36d9c80832b8bc249c0020120c3