### PR TITLE
Migrate seed word field

### DIFF
--- a/src/password_manager/entry_management.py
+++ b/src/password_manager/entry_management.py
@@ -75,6 +75,9 @@ class EntryManager:
                     if "archived" not in entry and "blacklisted" in entry:
                         entry["archived"] = entry["blacklisted"]
                     entry.pop("blacklisted", None)
+                    if "word_count" not in entry and "words" in entry:
+                        entry["word_count"] = entry["words"]
+                        entry.pop("words", None)
                 logger.debug("Index loaded successfully.")
                 return data
             except Exception as e:
@@ -407,7 +410,7 @@ class EntryManager:
             "kind": EntryType.SEED.value,
             "index": index,
             "label": label,
-            "words": words_num,
+            "word_count": words_num,
             "notes": notes,
             "archived": archived,
         }
@@ -434,7 +437,7 @@ class EntryManager:
         seed_bytes = Bip39SeedGenerator(parent_seed).Generate()
         bip85 = BIP85(seed_bytes)
 
-        words = int(entry.get("words", 24))
+        words = int(entry.get("word_count", entry.get("words", 24)))
         seed_index = int(entry.get("index", index))
         return derive_seed_phrase(bip85, seed_index, words)
 

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1458,7 +1458,7 @@ class PasswordManager:
                         from local_bip85.bip85 import BIP85
                         from bip_utils import Bip39SeedGenerator
 
-                        words = int(entry.get("words", 24))
+                        words = int(entry.get("word_count", entry.get("words", 24)))
                         bytes_len = {12: 16, 18: 24, 24: 32}.get(words, 32)
                         seed_bytes = Bip39SeedGenerator(self.parent_seed).Generate()
                         bip85 = BIP85(seed_bytes)

--- a/src/tests/test_seed_entry.py
+++ b/src/tests/test_seed_entry.py
@@ -45,5 +45,5 @@ def test_seed_phrase_determinism():
         assert len(phrase24_a.split()) == 24
         assert Mnemonic("english").check(phrase12_a)
         assert Mnemonic("english").check(phrase24_a)
-        assert entry12.get("words") == 12
-        assert entry24.get("words") == 24
+        assert entry12.get("word_count") == 12
+        assert entry24.get("word_count") == 24


### PR DESCRIPTION
## Summary
- store `word_count` instead of `words` for seed entries
- migrate old indexes when loading
- update seed retrieval logic and related CLI output
- adjust seed entry tests

## Testing
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686bda516368832bb68239326dc7af3b