### PR TITLE
Add entry archiving support

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -276,9 +276,7 @@ def print_matches(
                 print(color_text(f"  Username: {username}", "index"))
             if url:
                 print(color_text(f"  URL: {url}", "index"))
-            print(
-                color_text(f"  Blacklisted: {'Yes' if blacklisted else 'No'}", "index")
-            )
+            print(color_text(f"  Archived: {'Yes' if blacklisted else 'No'}", "index"))
         print("-" * 40)
 
 
@@ -752,6 +750,8 @@ def display_menu(
     5. Modify an Existing Entry
     6. 2FA Codes
     7. Settings
+    8. Archive Entry
+    9. View Archived Entries
     """
     display_fn = getattr(password_manager, "display_stats", None)
     if callable(display_fn):
@@ -781,7 +781,7 @@ def display_menu(
         print(color_text(menu, "menu"))
         try:
             choice = timed_input(
-                "Enter your choice (1-7) or press Enter to exit: ",
+                "Enter your choice (1-9) or press Enter to exit: ",
                 inactivity_timeout,
             ).strip()
         except TimeoutError:
@@ -856,6 +856,12 @@ def display_menu(
         elif choice == "7":
             password_manager.update_activity()
             handle_settings(password_manager)
+        elif choice == "8":
+            password_manager.update_activity()
+            password_manager.handle_archive_entry()
+        elif choice == "9":
+            password_manager.update_activity()
+            password_manager.handle_view_archived_entries()
         else:
             print(colored("Invalid choice. Please select a valid option.", "red"))
 

--- a/src/tests/test_cli_invalid_input.py
+++ b/src/tests/test_cli_invalid_input.py
@@ -64,7 +64,7 @@ def test_empty_and_non_numeric_choice(monkeypatch, capsys):
 def test_out_of_range_menu(monkeypatch, capsys):
     called = {"add": False, "retrieve": False, "modify": False}
     pm, _ = _make_pm(called)
-    inputs = iter(["9", ""])
+    inputs = iter(["10", ""])
     monkeypatch.setattr(main, "timed_input", lambda *_: next(inputs))
     with pytest.raises(SystemExit):
         main.display_menu(pm, sync_interval=1000, inactivity_timeout=1000)


### PR DESCRIPTION
## Summary
- implement archive & restore flow in manager
- filter archived items from default listing
- adjust CLI menu to include Archive options
- update wording from "blacklisted" to "archived"
- fix CLI invalid input test for new menu

## Testing
- `black src/tests/test_cli_invalid_input.py src/main.py src/password_manager/entry_management.py src/password_manager/manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686be41814b0832b892b67a3c54da3e4