### PR TITLE
Add test for archiving via retrieve

### DIFF
--- a/src/tests/test_archive_from_retrieve.py
+++ b/src/tests/test_archive_from_retrieve.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.backup import BackupManager
+from password_manager.manager import PasswordManager, EncryptionMode
+from password_manager.config_manager import ConfigManager
+
+
+class FakePasswordGenerator:
+    def generate_password(self, length: int, index: int) -> str:  # noqa: D401
+        return "pw"
+
+
+def test_archive_entry_from_retrieve(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+        pm.encryption_manager = enc_mgr
+        pm.vault = vault
+        pm.entry_manager = entry_mgr
+        pm.backup_manager = backup_mgr
+        pm.password_generator = FakePasswordGenerator()
+        pm.parent_seed = TEST_SEED
+        pm.nostr_client = SimpleNamespace()
+        pm.fingerprint_dir = tmp_path
+        pm.secret_mode_enabled = False
+
+        index = entry_mgr.add_entry("example.com", 8)
+
+        inputs = iter([str(index), "y"])
+        monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+
+        pm.handle_retrieve_entry()
+
+        assert entry_mgr.retrieve_entry(index)["archived"] is True


### PR DESCRIPTION
## Summary
- add `test_archive_from_retrieve` to ensure retrieving an entry and selecting archive marks it as archived

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c03e1b050832b952bf73f7144e989