### PR TITLE
Fix archived listing error

### DIFF
--- a/src/password_manager/entry_management.py
+++ b/src/password_manager/entry_management.py
@@ -728,7 +728,8 @@ class EntryManager:
                     print(colored(f"  Label: {entry.get('label', '')}", "cyan"))
                     print(
                         colored(
-                            f"  Derivation Index: {entry.get('index', index)}", "cyan"
+                            f"  Derivation Index: {entry.get('index', idx)}",
+                            "cyan",
                         )
                     )
                 print("-" * 40)


### PR DESCRIPTION
## Summary
- fix undefined variable when listing archived entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c0d34b8f4832bb3b515473feae738