### PR TITLE
Enable viewing archived entry details

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ When choosing **Add Entry**, you can now select **Password**, **2FA (TOTP)**,
 2. SeedPass will show the current label, period, digit count, and archived status.
 3. Enter new values or press **Enter** to keep the existing settings.
 4. The updated entry is saved back to your encrypted vault.
-5. Archived entries are hidden from lists but can be restored from the **List Archived** menu.
+5. Archived entries are hidden from lists but can be viewed or restored from the **List Archived** menu.
 
 ### Using Secret Mode
 

--- a/src/tests/test_archive_restore.py
+++ b/src/tests/test_archive_restore.py
@@ -74,7 +74,40 @@ def test_view_archived_entries_cli(monkeypatch):
         pm.handle_archive_entry()
         assert entry_mgr.retrieve_entry(idx)["archived"] is True
 
-        inputs = iter([str(idx), ""])
+        inputs = iter([str(idx), "r", "", ""])
         monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
         pm.handle_view_archived_entries()
         assert entry_mgr.retrieve_entry(idx)["archived"] is False
+
+
+def test_view_archived_entries_view_only(monkeypatch, capsys):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+        pm.encryption_manager = enc_mgr
+        pm.vault = vault
+        pm.entry_manager = entry_mgr
+        pm.backup_manager = backup_mgr
+        pm.parent_seed = TEST_SEED
+        pm.nostr_client = SimpleNamespace()
+        pm.fingerprint_dir = tmp_path
+        pm.is_dirty = False
+
+        idx = entry_mgr.add_entry("example.com", 8)
+
+        monkeypatch.setattr("builtins.input", lambda *_: str(idx))
+        pm.handle_archive_entry()
+        assert entry_mgr.retrieve_entry(idx)["archived"] is True
+
+        inputs = iter([str(idx), "v", "", "", ""])
+        monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
+        pm.handle_view_archived_entries()
+        assert entry_mgr.retrieve_entry(idx)["archived"] is True
+        out = capsys.readouterr().out
+        assert "example.com" in out


### PR DESCRIPTION
## Summary
- allow inspecting details from the **List Archived** menu
- update documentation for the new view feature
- test new interactions when listing archived entries

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt >/tmp/pip.log && pytest -q >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_b_686c0f7f0218832bbad50bab1f933d78