### PR TITLE
Remove archive entry menu and fix navigation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -683,10 +683,8 @@ def handle_settings(password_manager: PasswordManager) -> None:
         choice = input("Select an option or press Enter to go back: ").strip()
         if choice == "1":
             handle_profiles_menu(password_manager)
-            pause()
         elif choice == "2":
             handle_nostr_menu(password_manager)
-            pause()
         elif choice == "3":
             password_manager.change_password()
             pause()
@@ -750,8 +748,7 @@ def display_menu(
     5. Modify an Existing Entry
     6. 2FA Codes
     7. Settings
-    8. Archive Entry
-    9. List Archived
+    8. List Archived
     """
     display_fn = getattr(password_manager, "display_stats", None)
     if callable(display_fn):
@@ -781,7 +778,7 @@ def display_menu(
         print(color_text(menu, "menu"))
         try:
             choice = timed_input(
-                "Enter your choice (1-9) or press Enter to exit: ",
+                "Enter your choice (1-8) or press Enter to exit: ",
                 inactivity_timeout,
             ).strip()
         except TimeoutError:
@@ -857,9 +854,6 @@ def display_menu(
             password_manager.update_activity()
             handle_settings(password_manager)
         elif choice == "8":
-            password_manager.update_activity()
-            password_manager.handle_archive_entry()
-        elif choice == "9":
             password_manager.update_activity()
             password_manager.handle_view_archived_entries()
         else:

--- a/src/tests/test_menu_navigation.py
+++ b/src/tests/test_menu_navigation.py
@@ -1,0 +1,55 @@
+import time
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import main
+
+
+def _make_pm(calls):
+    return SimpleNamespace(
+        is_dirty=False,
+        last_update=time.time(),
+        last_activity=time.time(),
+        nostr_client=SimpleNamespace(close_client_pool=lambda: None),
+        handle_add_password=lambda: calls.append("add"),
+        handle_add_totp=lambda: calls.append("totp"),
+        handle_add_ssh_key=lambda: calls.append("ssh"),
+        handle_add_seed=lambda: calls.append("seed"),
+        handle_add_nostr_key=lambda: calls.append("nostr"),
+        handle_add_pgp=lambda: calls.append("pgp"),
+        handle_retrieve_entry=lambda: calls.append("retrieve"),
+        handle_search_entries=lambda: calls.append("search"),
+        handle_list_entries=lambda: calls.append("list"),
+        handle_modify_entry=lambda: calls.append("modify"),
+        handle_display_totp_codes=lambda: calls.append("show_totp"),
+        handle_view_archived_entries=lambda: calls.append("view_archived"),
+        update_activity=lambda: None,
+        lock_vault=lambda: None,
+        unlock_vault=lambda: None,
+    )
+
+
+def test_navigate_all_main_menu_options(monkeypatch):
+    calls = []
+    pm = _make_pm(calls)
+    # Sequence through all main menu options then exit
+    inputs = iter(["1", "2", "3", "4", "5", "6", "7", "8", ""])
+    monkeypatch.setattr(main, "timed_input", lambda *_: next(inputs))
+    # Submenus immediately return
+    monkeypatch.setattr("builtins.input", lambda *_: "")
+    monkeypatch.setattr(main, "handle_settings", lambda *_: calls.append("settings"))
+    with pytest.raises(SystemExit):
+        main.display_menu(pm, sync_interval=1000, inactivity_timeout=1000)
+    assert calls == [
+        "retrieve",
+        "search",
+        "list",
+        "modify",
+        "show_totp",
+        "settings",
+        "view_archived",
+    ]


### PR DESCRIPTION
## Summary
- remove "Archive Entry" option from the main menu
- fix navigation pause when leaving profile and nostr menus
- add regression test ensuring all menu options can be visited

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c135553cc832b98d057cc10a15737