### PR TITLE
Fix archived status for non-password entries

### DIFF
--- a/src/password_manager/entry_management.py
+++ b/src/password_manager/entry_management.py
@@ -694,7 +694,15 @@ class EntryManager:
                         )
                     )
                 else:
-                    entries.append((idx, label, None, None, False))
+                    entries.append(
+                        (
+                            idx,
+                            label,
+                            None,
+                            None,
+                            entry.get("archived", entry.get("blacklisted", False)),
+                        )
+                    )
 
             logger.debug(f"Total entries found: {len(entries)}")
             for idx, entry in filtered_items:
@@ -791,7 +799,15 @@ class EntryManager:
                     )
             else:
                 if label_match or notes_match:
-                    results.append((int(idx), label, None, None, False))
+                    results.append(
+                        (
+                            int(idx),
+                            label,
+                            None,
+                            None,
+                            entry.get("archived", entry.get("blacklisted", False)),
+                        )
+                    )
 
         return results
 

--- a/src/tests/test_archive_nonpassword.py
+++ b/src/tests/test_archive_nonpassword.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import sys
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.backup import BackupManager
+from password_manager.config_manager import ConfigManager
+
+
+def setup_entry_mgr(tmp_path: Path) -> EntryManager:
+    vault, _ = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+    cfg_mgr = ConfigManager(vault, tmp_path)
+    backup_mgr = BackupManager(tmp_path, cfg_mgr)
+    return EntryManager(vault, backup_mgr)
+
+
+def test_archive_nonpassword_list_search():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        em = setup_entry_mgr(tmp_path)
+        em.add_totp("Example", TEST_SEED)
+        idx = em.search_entries("Example")[0][0]
+
+        assert em.list_entries() == [(idx, "Example", None, None, False)]
+        assert em.search_entries("Example") == [(idx, "Example", None, None, False)]
+
+        em.archive_entry(idx)
+        assert em.retrieve_entry(idx)["archived"] is True
+        assert em.list_entries() == []
+        assert em.list_entries(include_archived=True) == [
+            (idx, "Example", None, None, True)
+        ]
+        assert em.search_entries("Example") == [(idx, "Example", None, None, True)]
+
+        em.restore_entry(idx)
+        assert em.retrieve_entry(idx)["archived"] is False
+        assert em.list_entries() == [(idx, "Example", None, None, False)]
+        assert em.search_entries("Example") == [(idx, "Example", None, None, False)]


### PR DESCRIPTION
## Summary
- ensure non-password entries include archived status when listing
- preserve archived flag for non-password search results
- add regression test for archived non-password entries

## Testing
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c1debfd3c832bbf2b0f6185714696