### PR TITLE
Update docs totp example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,10 +4,12 @@ This directory contains supplementary guides for using SeedPass.
 
 ## Quick Example: Get a TOTP Code
 
-Run `seedpass get-code` to retrieve a time-based one-time password (TOTP). A progress bar shows the remaining seconds in the current period.
+Run `seedpass totp <query>` to retrieve a time-based one-time password (TOTP). The
+`<query>` can be a label, title, or index. A progress bar shows the remaining
+seconds in the current period.
 
 ```bash
-$ seedpass get-code --index 0
+$ seedpass totp "email"
 [##########----------] 15s
 Code: 123456
 ```


### PR DESCRIPTION
## Summary
- correct docs to use `seedpass totp <query>` instead of the obsolete `get-code`

## Testing
- `black . --exclude venv`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686c27f3435c832b901f324db72cbb8c