### PR TITLE
Add CLI export/import tests

### DIFF
--- a/src/tests/test_cli_export_import.py
+++ b/src/tests/test_cli_export_import.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import main
+from password_manager.portable_backup import export_backup, import_backup
+from password_manager.config_manager import ConfigManager
+from password_manager.backup import BackupManager
+from helpers import create_vault, TEST_SEED
+
+
+def _setup_pm(tmp_path: Path):
+    vault, _ = create_vault(tmp_path, TEST_SEED)
+    cfg = ConfigManager(vault, tmp_path)
+    backup = BackupManager(tmp_path, cfg)
+    pm = SimpleNamespace(
+        handle_export_database=lambda p: export_backup(
+            vault, backup, p, parent_seed=TEST_SEED
+        ),
+        handle_import_database=lambda p: import_backup(
+            vault, backup, p, parent_seed=TEST_SEED
+        ),
+        nostr_client=SimpleNamespace(close_client_pool=lambda: None),
+    )
+    return pm, vault
+
+
+def test_cli_export_creates_file(monkeypatch, tmp_path):
+    pm, vault = _setup_pm(tmp_path)
+    data = {
+        "schema_version": 3,
+        "entries": {
+            "0": {
+                "label": "example",
+                "type": "password",
+                "notes": "",
+                "custom_fields": [],
+                "origin": "",
+            }
+        },
+    }
+    vault.save_index(data)
+
+    monkeypatch.setattr(main, "PasswordManager", lambda: pm)
+    monkeypatch.setattr(main, "configure_logging", lambda: None)
+    monkeypatch.setattr(main, "initialize_app", lambda: None)
+    monkeypatch.setattr(main.signal, "signal", lambda *a, **k: None)
+
+    export_path = tmp_path / "out.json"
+    rc = main.main(["export", "--file", str(export_path)])
+    assert rc == 0
+    assert export_path.exists()
+
+
+def test_cli_import_round_trip(monkeypatch, tmp_path):
+    pm, vault = _setup_pm(tmp_path)
+    original = {
+        "schema_version": 3,
+        "entries": {
+            "0": {
+                "label": "example",
+                "type": "password",
+                "notes": "",
+                "custom_fields": [],
+                "origin": "",
+            }
+        },
+    }
+    vault.save_index(original)
+
+    export_path = tmp_path / "out.json"
+    export_backup(
+        vault,
+        BackupManager(tmp_path, ConfigManager(vault, tmp_path)),
+        export_path,
+        parent_seed=TEST_SEED,
+    )
+
+    vault.save_index({"schema_version": 3, "entries": {}})
+
+    monkeypatch.setattr(main, "PasswordManager", lambda: pm)
+    monkeypatch.setattr(main, "configure_logging", lambda: None)
+    monkeypatch.setattr(main, "initialize_app", lambda: None)
+    monkeypatch.setattr(main.signal, "signal", lambda *a, **k: None)
+
+    rc = main.main(["import", "--file", str(export_path)])
+    assert rc == 0
+    assert vault.load_index() == original


### PR DESCRIPTION
## Summary
- add tests for export and import subcommands

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c326d41ec832bb49f46fb7efceb3b