### PR TITLE
Add key-value entry type

### DIFF
--- a/src/password_manager/entry_types.py
+++ b/src/password_manager/entry_types.py
@@ -13,3 +13,4 @@ class EntryType(str, Enum):
     SEED = "seed"
     PGP = "pgp"
     NOSTR = "nostr"
+    KEY_VALUE = "key_value"


### PR DESCRIPTION
## Summary
- extend `EntryType` enumeration with `KEY_VALUE`
- format file with black

## Testing
- `pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686c422bad1c832b916e8431d0b5733a