### PR TITLE
Add key-value entry support

### DIFF
--- a/src/tests/test_key_value_entry.py
+++ b/src/tests/test_key_value_entry.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.backup import BackupManager
+from password_manager.config_manager import ConfigManager
+
+
+def setup_entry_mgr(tmp_path: Path) -> EntryManager:
+    vault, _ = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+    cfg_mgr = ConfigManager(vault, tmp_path)
+    backup_mgr = BackupManager(tmp_path, cfg_mgr)
+    return EntryManager(vault, backup_mgr)
+
+
+def test_add_and_modify_key_value():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        em = setup_entry_mgr(tmp_path)
+
+        idx = em.add_key_value("API", "abc123", notes="token")
+        entry = em.retrieve_entry(idx)
+        assert entry == {
+            "type": "key_value",
+            "kind": "key_value",
+            "label": "API",
+            "value": "abc123",
+            "notes": "token",
+            "archived": False,
+            "custom_fields": [],
+        }
+
+        em.modify_entry(idx, value="def456")
+        updated = em.retrieve_entry(idx)
+        assert updated["value"] == "def456"
+
+        results = em.search_entries("def456")
+        assert results == [(idx, "API", None, None, False)]


### PR DESCRIPTION
## Summary
- implement key-value entry type with add_key_value
- allow retrieval and modification of key-value entries
- extend search logic for value field
- include tests for new entry type

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c4444d254832b9b5c8ddcba981a25