### PR TITLE
Add Key/Value entry documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ SeedPass supports storing more than just passwords and 2FA secrets. You can also
   When you retrieve one of these entries, SeedPass can display QR codes for the
   keys. The `npub` is wrapped in the `nostr:` URI scheme so any client can scan
   it, while the `nsec` QR is shown only after a security warning.
+- **Key/Value** – store a simple key and value for miscellaneous secrets or configuration data.
 
 The table below summarizes the extra fields stored for each entry type. Every
 entry includes a `label`, while only password entries track a `url`.
@@ -289,6 +290,7 @@ entry includes a `label`, while only password entries track a `url`.
 | Seed Phrase   | `index`, `word_count` *(mnemonic regenerated; never stored)*, `archived`, optional `notes` |
 | PGP Key       | `index`, `key_type`, `archived`, optional `user_id`, optional `notes` |
 | Nostr Key Pair| `index`, `archived`, optional `notes` |
+| Key/Value     | `value`, `archived`, optional `notes`, optional `custom_fields` |
 
 
 ### Managing Multiple Seeds

--- a/docs/json_entries.md
+++ b/docs/json_entries.md
@@ -88,7 +88,7 @@ Each entry is stored within `seedpass_entries_db.json.enc` under the `entries` d
 - **username** (`string`, optional): Username associated with the entry.
 - **url** (`string`, optional): Website or service URL.
 - **archived** (`boolean`): Marks the entry as archived when `true`.
-- **type** (`string`): The entry type (`password`, `totp`, `ssh`, `seed`, `pgp`, `nostr`, `note`).
+- **type** (`string`): The entry type (`password`, `totp`, `ssh`, `seed`, `pgp`, `nostr`, `note`, `key_value`).
 - **kind** (`string`): Synonym for `type` kept for backward compatibility.
 - **notes** (`string`): Free-form notes.
 - **custom_fields** (`array`, optional): Additional user-defined fields.
@@ -233,6 +233,21 @@ Each entry is stored within `seedpass_entries_db.json.enc` under the `entries` d
     "updated_at": "2024-04-27T12:39:56Z",
     "checksum": "pqr345stu678"
   }
+}
+```
+
+#### 7. Key/Value
+
+```json
+{
+  "entry_num": 6,
+  "fingerprint": "a1b2c3d4",
+  "kind": "key_value",
+  "data": {
+    "key": "api_key",
+    "value": "<encrypted_value>"
+  },
+  "timestamp": "2024-04-27T12:40:56Z"
 }
 ```
 


### PR DESCRIPTION
## Summary
- document new Key/Value entry in README
- note key_value type in JSON entry docs and show example snippet

## Testing
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c4b0c7f14832bbbccf9ed50717e5f