### PR TITLE
Add key/value entry tests

### DIFF
--- a/src/tests/test_entry_add.py
+++ b/src/tests/test_entry_add.py
@@ -53,6 +53,7 @@ def test_add_and_retrieve_entry():
         ("add_totp", "totp"),
         ("add_ssh_key", "ssh"),
         ("add_seed", "seed"),
+        ("add_key_value", "key_value"),
     ],
 )
 def test_round_trip_entry_types(method, expected_type):
@@ -67,6 +68,8 @@ def test_round_trip_entry_types(method, expected_type):
         elif method == "add_totp":
             entry_mgr.add_totp("example", TEST_SEED)
             index = 0
+        elif method == "add_key_value":
+            index = entry_mgr.add_key_value("label", "val")
         else:
             if method == "add_ssh_key":
                 index = entry_mgr.add_ssh_key("ssh", TEST_SEED)
@@ -109,6 +112,7 @@ def test_legacy_entry_defaults_to_password():
         ("add_pgp_key", ("pgp", TEST_SEED)),
         ("add_nostr_key", ("nostr",)),
         ("add_seed", ("seed", TEST_SEED)),
+        ("add_key_value", ("label", "val")),
     ],
 )
 def test_add_default_archived_false(method, args):

--- a/src/tests/test_manager_list_entries.py
+++ b/src/tests/test_manager_list_entries.py
@@ -33,6 +33,7 @@ def test_handle_list_entries(monkeypatch, capsys):
 
         entry_mgr.add_totp("Example", TEST_SEED)
         entry_mgr.add_entry("example.com", 12)
+        entry_mgr.add_key_value("API", "abc123")
 
         inputs = iter(["1", ""])  # list all, then exit
         monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
@@ -41,6 +42,7 @@ def test_handle_list_entries(monkeypatch, capsys):
         out = capsys.readouterr().out
         assert "Example" in out
         assert "example.com" in out
+        assert "API" in out
 
 
 def test_list_entries_show_details(monkeypatch, capsys):
@@ -63,6 +65,7 @@ def test_list_entries_show_details(monkeypatch, capsys):
         pm.secret_mode_enabled = False
 
         entry_mgr.add_totp("Example", TEST_SEED)
+        entry_mgr.add_key_value("API", "val")
 
         monkeypatch.setattr(pm.entry_manager, "get_totp_code", lambda *a, **k: "123456")
         monkeypatch.setattr(
@@ -81,3 +84,4 @@ def test_list_entries_show_details(monkeypatch, capsys):
         out = capsys.readouterr().out
         assert "Retrieved 2FA Code" in out
         assert "123456" in out
+        assert "API" in out

--- a/src/tests/test_search_entries.py
+++ b/src/tests/test_search_entries.py
@@ -86,6 +86,17 @@ def test_search_by_custom_field():
         assert result == [(idx, "Example", "", "", False)]
 
 
+def test_search_key_value_value():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        entry_mgr = setup_entry_manager(tmp_path)
+
+        idx = entry_mgr.add_key_value("API", "token123")
+
+        result = entry_mgr.search_entries("token123")
+        assert result == [(idx, "API", None, None, False)]
+
+
 def test_search_no_results():
     with TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)


### PR DESCRIPTION
## Summary
- validate EntryManager.add_key_value via new test
- include key/value type in generic entry tests
- ensure listing and search handle key/value entries

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c4c7edee8832b8cb6de145b86b874