### PR TITLE
Update docs for key/value entries

### DIFF
--- a/docs/advanced_cli.md
+++ b/docs/advanced_cli.md
@@ -38,9 +38,10 @@ The **Advanced CLI Commands** document provides an in-depth guide to the various
    - [24. Show All Passwords](#22-show-all-passwords)
    - [23. Add Notes to an Entry](#23-add-notes-to-an-entry)
    - [24. Add Tags to an Entry](#24-add-tags-to-an-entry)
-   - [25. Search by Tag or Title](#25-search-by-tag-or-title)
-   - [26. Automatically Post Deltas to Nostr After Edit](#26-automatically-post-deltas-to-nostr-after-edit)
-   - [27. Initial Setup Prompt for Seed Generation/Import](#27-initial-setup-prompt-for-seed-generationimport)
+   - [25. Add Key/Value Entry](#25-add-keyvalue-entry)
+   - [26. Search by Tag or Title](#26-search-by-tag-or-title)
+   - [27. Automatically Post Deltas to Nostr After Edit](#27-automatically-post-deltas-to-nostr-after-edit)
+   - [28. Initial Setup Prompt for Seed Generation/Import](#28-initial-setup-prompt-for-seed-generationimport)
 3. [Notes on New CLI Commands](#notes-on-new-cli-commands)
 
 ---
@@ -78,6 +79,7 @@ The following table provides a quick reference to all available advanced CLI com
 | Show All Passwords                        | `show-all`             | `-SA`          | `--show-all`                      | `seedpass show-all`                                                                                                                                                                                |
 | Add Notes to an Entry                     | `add-notes`            | `-AN`          | `--add-notes`                     | `seedpass add-notes --index 3 --notes "This is a secured account"`                                                                                                                                  |
 | Add Tags to an Entry                      | `add-tags`             | `-AT`          | `--add-tags`                      | `seedpass add-tags --index 3 --tags "personal,finance"`                                                                                                                                              |
+| Add Key/Value entry                      | `add-kv`             | `-KV`      | `--add-kv`                      | `seedpass add-kv --label "API" --value "secret"`
 | Search by Tag or Title                    | `search-by`            | `-SB`          | `--search-by`                     | `seedpass search-by --tag "work"` or `seedpass search-by --title "GitHub"`                                                                                                                          |
 | Automatically Post Deltas After Edit      | `auto-post`            | `-AP`          | `--auto-post`                     | `seedpass auto-post --enable` or `seedpass auto-post --disable` |
 | Initial Setup Prompt for Seed Generation/Import | `setup`                | `-ST`          | `--setup`                         | `seedpass setup`                                                                                                                                                                                   |
@@ -578,7 +580,28 @@ seedpass add-tags --index 3 --tags "personal,finance"
 
 ---
 
-### 25. Search by Tag or Title
+### 25. Add Key/Value Entry
+
+**Command:** `add-kv`
+**Short Flag:** `-KV`
+**Long Flag:** `--add-kv`
+
+**Description:**
+Creates a simple key/value entry for storing items like API keys or configuration snippets. The value can be copied to the clipboard when secret mode is enabled.
+
+**Usage Example:**
+```bash
+seedpass add-kv --label "API" --value "secret" --notes "Service token"
+```
+
+**Options:**
+- `--label` (`-L`): Descriptive label for the entry.
+- `--value` (`-V`): The secret value to store.
+- `--notes` (`-N`): Optional notes about the entry.
+
+---
+
+### 26. Search by Tag or Title
 
 **Command:** `search-by`  
 **Short Flag:** `-SB`  
@@ -599,7 +622,7 @@ seedpass search-by --title "GitHub"
 
 ---
 
-### 26. Automatically Post Deltas to Nostr After Edit
+### 27. Automatically Post Deltas to Nostr After Edit
 
 **Command:** `auto-post`  
 **Short Flag:** `-AP`  
@@ -620,7 +643,7 @@ seedpass auto-post --disable
 
 ---
 
-### 27. Initial Setup Prompt for Seed Generation/Import
+### 28. Initial Setup Prompt for Seed Generation/Import
 
 **Command:** `setup`  
 **Short Flag:** `-ST`  

--- a/docs/json_entries.md
+++ b/docs/json_entries.md
@@ -93,6 +93,7 @@ Each entry is stored within `seedpass_entries_db.json.enc` under the `entries` d
 - **notes** (`string`): Free-form notes.
 - **custom_fields** (`array`, optional): Additional user-defined fields.
 - **origin** (`string`, optional): Source identifier for imported data.
+- **value** (`string`, optional): For `key_value` entries, stores the secret value.
 - **index** (`integer`, optional): BIP-85 derivation index for entries that derive material from a seed.
   Example:
 
@@ -250,6 +251,10 @@ Each entry is stored within `seedpass_entries_db.json.enc` under the `entries` d
   "timestamp": "2024-04-27T12:40:56Z"
 }
 ```
+
+The `key` field is purely descriptive, while `value` holds the sensitive string
+such as an API token. Notes and custom fields may also be included alongside the
+standard metadata.
 
 ---
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -69,6 +69,7 @@ flowchart TB
     seed --> pgp["🔒 PGP Key"]
     seed --> mn["🌱 Seed Phrase"]
     seed --> nostr["⚡ Nostr Keys"]
+    seed --> kv["🔑 Key/Value"]
     classDef default fill:#ffffff,stroke:#e94a39,stroke-width:2px,color:#283c4f;
                     </pre>
                     <a href="https://github.com/PR0M3TH3AN/SeedPass" class="btn-primary cta-button"><i class="fas fa-download" aria-hidden="true"></i> Get Started</a>
@@ -110,13 +111,14 @@ flowchart TD
   end
     A["Parent Seed<br>(BIP-39 Mnemonic)"] --> B["Seed Bytes<br>(BIP-39 → 512-bit)"]
     B --> C["BIP-85 Derivation<br>(local_bip85.BIP85)"]
-    C --> D1["Password Entropy<br>(password_generation)"] & D2["TOTP Secret<br>(utils.key_derivation.derive_totp_secret)"] & D3["SSH Key Entropy<br>(password_generation.derive_ssh_key)"] & D4["PGP Key Entropy<br>(entry_management.add_pgp_key)"] & D5["Child Mnemonic<br>(BIP-85 derive_mnemonic)"] & D6["Nostr Key Entropy<br>(nostr.KeyManager)"]
+    C --> D1["Password Entropy<br>(password_generation)"] & D2["TOTP Secret<br>(utils.key_derivation.derive_totp_secret)"] & D3["SSH Key Entropy<br>(password_generation.derive_ssh_key)"] & D4["PGP Key Entropy<br>(entry_management.add_pgp_key)"] & D5["Child Mnemonic<br>(BIP-85 derive_mnemonic)"] & D6["Nostr Key Entropy<br>(nostr.KeyManager)"] & D7["Key/Value Data<br>(entry_management.add_key_value)"]
     D1 --> E1["Passwords"]
     D2 --> E2["2FA Codes"]
     D3 --> E3["SSH Key Pair"]
     D4 --> E4["PGP Key"]
     D5 --> E5["Seed Phrase"]
     D6 --> E6["Nostr Keys<br>(npub / nsec)"]
+    D7 --> E7["Key/Value"]
     E1 --> V
     E2 --> V
     E3 --> V
@@ -129,7 +131,7 @@ flowchart TD
     R3 --> R4
     R4 --> V
     A -. "Same seed ⇒ re-derive any artifact on demand" .- E1
-    A -.-> E2 & E3 & E4 & E5 & E6
+    A -.-> E2 & E3 & E4 & E5 & E6 & E7
                 </pre>
             </div>
         </section>
@@ -145,6 +147,7 @@ flowchart TD
                         <li><i class="fas fa-check" aria-hidden="true"></i> Checksum verification to ensure script integrity</li>
                         <li><i class="fas fa-terminal" aria-hidden="true"></i> Interactive TUI for managing entries and settings</li>
                         <li><i class="fas fa-shield-alt" aria-hidden="true"></i> Issue or import TOTP secrets for 2FA</li>
+                        <li><i class="fas fa-key" aria-hidden="true"></i> Store arbitrary secrets as key/value pairs</li>
                         <li><i class="fas fa-file-export" aria-hidden="true"></i> Export your 2FA codes to an encrypted file</li>
                         <li><i class="fas fa-folder-open" aria-hidden="true"></i> Optional external backup location</li>
                         <li><i class="fas fa-lock" aria-hidden="true"></i> Auto-lock after inactivity</li>


### PR DESCRIPTION
## Summary
- document new `add-kv` command in advanced CLI docs
- clarify `key_value` fields in JSON schema docs
- add key/value entry type in landing page diagrams and feature list

## Testing
- `black .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686c3b989b94832b8436b9392b93acae