### PR TITLE
Add restore prompt after editing archived entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ When choosing **Add Entry**, you can now select **Password**, **2FA (TOTP)**,
 3. Enter new values or press **Enter** to keep the existing settings.
 4. The updated entry is saved back to your encrypted vault.
 5. Archived entries are hidden from lists but can be viewed or restored from the **List Archived** menu.
+6. When editing an archived entry you'll be prompted to restore it after saving your changes.
 
 ### Using Secret Mode
 

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -2096,6 +2096,11 @@ class PasswordManager:
                     exc_info=True,
                 )
 
+            updated_entry = self.entry_manager.retrieve_entry(index)
+            if updated_entry:
+                self._prompt_toggle_archive(updated_entry, index)
+            pause()
+
         except Exception as e:
             logging.error(f"Error during modifying entry: {e}", exc_info=True)
             print(colored(f"Error: Failed to modify entry: {e}", "red"))


### PR DESCRIPTION
## Summary
- prompt to unarchive when editing archived entries
- document the restore prompt in README

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686c5903e334832bad2a34c0fb55d128