### PR TITLE
Add managed_account entry type

### DIFF
--- a/docs/json_entries.md
+++ b/docs/json_entries.md
@@ -252,6 +252,21 @@ Each entry is stored within `seedpass_entries_db.json.enc` under the `entries` d
 }
 ```
 
+#### 8. Managed Account
+
+```json
+{
+  "entry_num": 7,
+  "fingerprint": "a1b2c3d4",
+  "kind": "managed_account",
+  "data": {
+    "account": "alice@example.com",
+    "password": "<encrypted_password>"
+  },
+  "timestamp": "2024-04-27T12:41:56Z"
+}
+```
+
 The `key` field is purely descriptive, while `value` holds the sensitive string
 such as an API token. Notes and custom fields may also be included alongside the
 standard metadata.

--- a/src/password_manager/entry_management.py
+++ b/src/password_manager/entry_management.py
@@ -533,7 +533,11 @@ class EntryManager:
 
             if entry:
                 etype = entry.get("type", entry.get("kind"))
-                if etype in (EntryType.PASSWORD.value, EntryType.KEY_VALUE.value):
+                if etype in (
+                    EntryType.PASSWORD.value,
+                    EntryType.KEY_VALUE.value,
+                    EntryType.MANAGED_ACCOUNT.value,
+                ):
                     entry.setdefault("custom_fields", [])
                 logger.debug(f"Retrieved entry at index {index}: {entry}")
                 return entry
@@ -620,7 +624,10 @@ class EntryManager:
                     if url is not None:
                         entry["url"] = url
                         logger.debug(f"Updated URL to '{url}' for index {index}.")
-                elif entry_type == EntryType.KEY_VALUE.value:
+                elif entry_type in (
+                    EntryType.KEY_VALUE.value,
+                    EntryType.MANAGED_ACCOUNT.value,
+                ):
                     if value is not None:
                         entry["value"] = value
                         logger.debug(f"Updated value for index {index}.")
@@ -837,7 +844,7 @@ class EntryManager:
                             entry.get("archived", entry.get("blacklisted", False)),
                         )
                     )
-            elif etype == EntryType.KEY_VALUE.value:
+            elif etype in (EntryType.KEY_VALUE.value, EntryType.MANAGED_ACCOUNT.value):
                 value_field = str(entry.get("value", ""))
                 custom_fields = entry.get("custom_fields", [])
                 custom_match = any(

--- a/src/password_manager/entry_types.py
+++ b/src/password_manager/entry_types.py
@@ -14,3 +14,4 @@ class EntryType(str, Enum):
     PGP = "pgp"
     NOSTR = "nostr"
     KEY_VALUE = "key_value"
+    MANAGED_ACCOUNT = "managed_account"

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1629,7 +1629,10 @@ class PasswordManager:
                 pause()
                 return
 
-            if entry_type == EntryType.KEY_VALUE.value:
+            if entry_type in (
+                EntryType.KEY_VALUE.value,
+                EntryType.MANAGED_ACCOUNT.value,
+            ):
                 label = entry.get("label", "")
                 value = entry.get("value", "")
                 notes = entry.get("notes", "")
@@ -1904,7 +1907,10 @@ class PasswordManager:
                     digits=new_digits,
                     custom_fields=custom_fields,
                 )
-            elif entry_type == EntryType.KEY_VALUE.value:
+            elif entry_type in (
+                EntryType.KEY_VALUE.value,
+                EntryType.MANAGED_ACCOUNT.value,
+            ):
                 label = entry.get("label", "")
                 value = entry.get("value", "")
                 blacklisted = entry.get("archived", False)


### PR DESCRIPTION
## Summary
- define `MANAGED_ACCOUNT` in `EntryType`
- handle `MANAGED_ACCOUNT` entries like key/value pairs
- document example JSON snippet for managed accounts

## Testing
- `black src/password_manager/entry_types.py src/password_manager/entry_management.py src/password_manager/manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c68975868832b8d1dfdfe38048c00