### PR TITLE
Add managed account functionality

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -588,7 +588,8 @@ def handle_profiles_menu(password_manager: PasswordManager) -> None:
     """Submenu for managing seed profiles."""
     while True:
         clear_and_print_fingerprint(
-            getattr(password_manager, "current_fingerprint", None),
+            getattr(password_manager, "header_fingerprint", None)
+            or getattr(password_manager, "current_fingerprint", None),
             "Main Menu > Settings > Profiles",
         )
         print(color_text("\nProfiles:", "menu"))
@@ -627,7 +628,8 @@ def handle_nostr_menu(password_manager: PasswordManager) -> None:
 
     while True:
         clear_and_print_fingerprint(
-            getattr(password_manager, "current_fingerprint", None),
+            getattr(password_manager, "header_fingerprint", None)
+            or getattr(password_manager, "current_fingerprint", None),
             "Main Menu > Settings > Nostr",
         )
         print(color_text("\nNostr Settings:", "menu"))
@@ -664,7 +666,8 @@ def handle_settings(password_manager: PasswordManager) -> None:
     """Interactive settings menu with submenus for profiles and Nostr."""
     while True:
         clear_and_print_fingerprint(
-            getattr(password_manager, "current_fingerprint", None),
+            getattr(password_manager, "header_fingerprint", None)
+            or getattr(password_manager, "current_fingerprint", None),
             "Main Menu > Settings",
         )
         print(color_text("\nSettings:", "menu"))
@@ -758,7 +761,8 @@ def display_menu(
         pause()
     while True:
         clear_and_print_fingerprint(
-            getattr(password_manager, "current_fingerprint", None),
+            getattr(password_manager, "header_fingerprint", None)
+            or getattr(password_manager, "current_fingerprint", None),
             "Main Menu",
         )
         if time.time() - password_manager.last_activity > inactivity_timeout:
@@ -790,6 +794,9 @@ def display_menu(
             continue
         password_manager.update_activity()
         if not choice:
+            if getattr(password_manager, "profile_stack", []):
+                password_manager.exit_managed_account()
+                continue
             logging.info("Exiting the program.")
             print(colored("Exiting the program.", "green"))
             password_manager.nostr_client.close_client_pool()
@@ -797,7 +804,8 @@ def display_menu(
         if choice == "1":
             while True:
                 clear_and_print_fingerprint(
-                    getattr(password_manager, "current_fingerprint", None),
+                    getattr(password_manager, "header_fingerprint", None)
+                    or getattr(password_manager, "current_fingerprint", None),
                     "Main Menu > Add Entry",
                 )
                 print(color_text("\nAdd Entry:", "menu"))
@@ -808,6 +816,7 @@ def display_menu(
                 print(color_text("5. Nostr Key Pair", "menu"))
                 print(color_text("6. PGP Key", "menu"))
                 print(color_text("7. Key/Value", "menu"))
+                print(color_text("8. Managed Account", "menu"))
                 sub_choice = input(
                     "Select entry type or press Enter to go back: "
                 ).strip()
@@ -833,6 +842,9 @@ def display_menu(
                 elif sub_choice == "7":
                     password_manager.handle_add_key_value()
                     break
+                elif sub_choice == "8":
+                    password_manager.handle_add_managed_account()
+                    break
                 elif not sub_choice:
                     break
                 else:
@@ -841,7 +853,8 @@ def display_menu(
             password_manager.update_activity()
             password_manager.handle_retrieve_entry()
             clear_and_print_fingerprint(
-                getattr(password_manager, "current_fingerprint", None),
+                getattr(password_manager, "header_fingerprint", None)
+                or getattr(password_manager, "current_fingerprint", None),
                 "Main Menu",
             )
         elif choice == "3":

--- a/src/tests/test_cli_invalid_input.py
+++ b/src/tests/test_cli_invalid_input.py
@@ -40,6 +40,7 @@ def _make_pm(called, locked=None):
         nostr_client=SimpleNamespace(close_client_pool=lambda: None),
         handle_add_password=add,
         handle_add_totp=lambda: None,
+        handle_add_managed_account=lambda: None,
         handle_retrieve_entry=retrieve,
         handle_modify_entry=modify,
         update_activity=update,
@@ -76,7 +77,7 @@ def test_out_of_range_menu(monkeypatch, capsys):
 def test_invalid_add_entry_submenu(monkeypatch, capsys):
     called = {"add": False, "retrieve": False, "modify": False}
     pm, _ = _make_pm(called)
-    inputs = iter(["1", "8", "", ""])
+    inputs = iter(["1", "9", "", ""])
     monkeypatch.setattr(main, "timed_input", lambda *_: next(inputs))
     monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
     with pytest.raises(SystemExit):

--- a/src/utils/terminal_utils.py
+++ b/src/utils/terminal_utils.py
@@ -23,6 +23,22 @@ def clear_and_print_fingerprint(
         print(colored(header, "green"))
 
 
+def clear_and_print_profile_chain(
+    fingerprints: list[str] | None, breadcrumb: str | None = None
+) -> None:
+    """Clear the screen and display a chain of fingerprints."""
+    clear_screen()
+    if not fingerprints:
+        return
+    chain = fingerprints[0]
+    for fp in fingerprints[1:]:
+        chain += f" > Managed Account > {fp}"
+    header = f"Seed Profile: {chain}"
+    if breadcrumb:
+        header += f" > {breadcrumb}"
+    print(colored(header, "green"))
+
+
 def pause(message: str = "Press Enter to continue...") -> None:
     """Wait for the user to press Enter before proceeding."""
     if not sys.stdin or not sys.stdin.isatty():


### PR DESCRIPTION
## Summary
- include managed account option in the Add Entry menu
- support displaying managed account breadcrumb chains
- implement `handle_add_managed_account`
- enhance managed account entry display with reveal/load options
- update CLI tests for new submenu option

## Testing
- `black .`
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt >/tmp/pip.log && pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c70f030f8832bb5ee72365a6071ab