### PR TITLE
Add managed account tests

### DIFF
--- a/src/tests/test_entry_add.py
+++ b/src/tests/test_entry_add.py
@@ -54,6 +54,7 @@ def test_add_and_retrieve_entry():
         ("add_ssh_key", "ssh"),
         ("add_seed", "seed"),
         ("add_key_value", "key_value"),
+        ("add_managed_account", "managed_account"),
     ],
 )
 def test_round_trip_entry_types(method, expected_type):
@@ -75,6 +76,8 @@ def test_round_trip_entry_types(method, expected_type):
                 index = entry_mgr.add_ssh_key("ssh", TEST_SEED)
             elif method == "add_seed":
                 index = entry_mgr.add_seed("seed", TEST_SEED)
+            elif method == "add_managed_account":
+                index = entry_mgr.add_managed_account("acct", TEST_SEED)
             else:
                 index = getattr(entry_mgr, method)()
 
@@ -113,6 +116,7 @@ def test_legacy_entry_defaults_to_password():
         ("add_nostr_key", ("nostr",)),
         ("add_seed", ("seed", TEST_SEED)),
         ("add_key_value", ("label", "val")),
+        ("add_managed_account", ("acct", TEST_SEED)),
     ],
 )
 def test_add_default_archived_false(method, args):

--- a/src/tests/test_managed_account.py
+++ b/src/tests/test_managed_account.py
@@ -1,0 +1,87 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+from utils.fingerprint import generate_fingerprint
+import password_manager.manager as manager_module
+from password_manager.manager import EncryptionMode
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.backup import BackupManager
+from password_manager.config_manager import ConfigManager
+
+
+def setup_entry_manager(tmp_path: Path) -> EntryManager:
+    vault, _ = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+    cfg = ConfigManager(vault, tmp_path)
+    backup = BackupManager(tmp_path, cfg)
+    return EntryManager(vault, backup)
+
+
+def test_add_managed_account_fields_and_dir():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        mgr = setup_entry_manager(tmp_path)
+
+        idx = mgr.add_managed_account("acct", TEST_SEED, word_count=12)
+        entry = mgr.retrieve_entry(idx)
+
+        assert entry["type"] == "managed_account"
+        assert entry["kind"] == "managed_account"
+        assert entry["index"] == idx
+        assert entry["label"] == "acct"
+        assert entry["word_count"] == 12
+        assert entry["archived"] is False
+        fp = entry.get("fingerprint")
+        assert fp
+        assert (tmp_path / "accounts" / fp).exists()
+
+        seed = mgr.get_managed_account_seed(idx, TEST_SEED)
+        assert generate_fingerprint(seed) == fp
+
+
+def test_load_and_exit_managed_account(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        idx = entry_mgr.add_managed_account("acct", TEST_SEED)
+        seed = entry_mgr.get_managed_account_seed(idx, TEST_SEED)
+        fp = generate_fingerprint(seed)
+        acct_dir = tmp_path / "accounts" / fp
+
+        pm = manager_module.PasswordManager.__new__(manager_module.PasswordManager)
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+        pm.encryption_manager = enc_mgr
+        pm.vault = vault
+        pm.entry_manager = entry_mgr
+        pm.backup_manager = backup_mgr
+        pm.config_manager = cfg_mgr
+        pm.parent_seed = TEST_SEED
+        pm.current_fingerprint = "rootfp"
+        pm.fingerprint_dir = tmp_path
+        pm.profile_stack = []
+        monkeypatch.setattr(pm, "initialize_bip85", lambda: None)
+        monkeypatch.setattr(pm, "initialize_managers", lambda: None)
+        monkeypatch.setattr(pm, "sync_index_from_nostr_if_missing", lambda: None)
+        monkeypatch.setattr(pm, "sync_index_from_nostr", lambda: None)
+        monkeypatch.setattr(pm, "update_activity", lambda: None)
+
+        pm.load_managed_account(idx)
+
+        assert pm.current_fingerprint == fp
+        assert pm.fingerprint_dir == acct_dir
+        assert pm.profile_stack[-1][0] == "rootfp"
+        assert pm.profile_stack[-1][1] == tmp_path
+
+        pm.exit_managed_account()
+
+        assert pm.current_fingerprint == "rootfp"
+        assert pm.fingerprint_dir == tmp_path
+        assert pm.profile_stack == []

--- a/src/tests/test_manager_list_entries.py
+++ b/src/tests/test_manager_list_entries.py
@@ -34,6 +34,7 @@ def test_handle_list_entries(monkeypatch, capsys):
         entry_mgr.add_totp("Example", TEST_SEED)
         entry_mgr.add_entry("example.com", 12)
         entry_mgr.add_key_value("API", "abc123")
+        entry_mgr.add_managed_account("acct", TEST_SEED)
 
         inputs = iter(["1", ""])  # list all, then exit
         monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
@@ -43,6 +44,7 @@ def test_handle_list_entries(monkeypatch, capsys):
         assert "Example" in out
         assert "example.com" in out
         assert "API" in out
+        assert "acct" in out
 
 
 def test_list_entries_show_details(monkeypatch, capsys):
@@ -66,6 +68,7 @@ def test_list_entries_show_details(monkeypatch, capsys):
 
         entry_mgr.add_totp("Example", TEST_SEED)
         entry_mgr.add_key_value("API", "val")
+        entry_mgr.add_managed_account("acct", TEST_SEED)
 
         monkeypatch.setattr(pm.entry_manager, "get_totp_code", lambda *a, **k: "123456")
         monkeypatch.setattr(
@@ -85,3 +88,4 @@ def test_list_entries_show_details(monkeypatch, capsys):
         assert "Retrieved 2FA Code" in out
         assert "123456" in out
         assert "API" in out
+        assert "acct" in out


### PR DESCRIPTION
## Summary
- add new `test_managed_account.py`
- cover managed account creation and loading
- include `managed_account` type in parametrized entry tests
- list managed accounts in entry manager tests

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c77556fbc832bb38d44edffe2b3db