### PR TITLE
Document managed accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ SeedPass supports storing more than just passwords and 2FA secrets. You can also
   keys. The `npub` is wrapped in the `nostr:` URI scheme so any client can scan
   it, while the `nsec` QR is shown only after a security warning.
 - **Key/Value** – store a simple key and value for miscellaneous secrets or configuration data.
+- **Managed Account** – derive a child seed under the current profile. Loading a managed account switches to a nested profile and the header shows `<parent_fp> > Managed Account > <child_fp>`. Press Enter on the main menu to return to the parent profile.
 
 The table below summarizes the extra fields stored for each entry type. Every
 entry includes a `label`, while only password entries track a `url`.
@@ -292,6 +293,7 @@ entry includes a `label`, while only password entries track a `url`.
 | PGP Key       | `index`, `key_type`, `archived`, optional `user_id`, optional `notes` |
 | Nostr Key Pair| `index`, `archived`, optional `notes` |
 | Key/Value     | `value`, `archived`, optional `notes`, optional `custom_fields` |
+| Managed Account | `index`, `word_count`, `fingerprint`, `archived`, optional `notes` |
 
 
 ### Managing Multiple Seeds

--- a/docs/advanced_cli.md
+++ b/docs/advanced_cli.md
@@ -39,9 +39,10 @@ The **Advanced CLI Commands** document provides an in-depth guide to the various
    - [23. Add Notes to an Entry](#23-add-notes-to-an-entry)
    - [24. Add Tags to an Entry](#24-add-tags-to-an-entry)
    - [25. Add Key/Value Entry](#25-add-keyvalue-entry)
-   - [26. Search by Tag or Title](#26-search-by-tag-or-title)
-   - [27. Automatically Post Deltas to Nostr After Edit](#27-automatically-post-deltas-to-nostr-after-edit)
-   - [28. Initial Setup Prompt for Seed Generation/Import](#28-initial-setup-prompt-for-seed-generationimport)
+   - [26. Add Managed Account](#26-add-managed-account)
+   - [27. Search by Tag or Title](#26-search-by-tag-or-title)
+   - [28. Automatically Post Deltas to Nostr After Edit](#27-automatically-post-deltas-to-nostr-after-edit)
+   - [29. Initial Setup Prompt for Seed Generation/Import](#28-initial-setup-prompt-for-seed-generationimport)
 3. [Notes on New CLI Commands](#notes-on-new-cli-commands)
 
 ---
@@ -80,6 +81,7 @@ The following table provides a quick reference to all available advanced CLI com
 | Add Notes to an Entry                     | `add-notes`            | `-AN`          | `--add-notes`                     | `seedpass add-notes --index 3 --notes "This is a secured account"`                                                                                                                                  |
 | Add Tags to an Entry                      | `add-tags`             | `-AT`          | `--add-tags`                      | `seedpass add-tags --index 3 --tags "personal,finance"`                                                                                                                                              |
 | Add Key/Value entry                      | `add-kv`             | `-KV`      | `--add-kv`                      | `seedpass add-kv --label "API" --value "secret"`
+| Add Managed Account                      | `add-managed`        | `-AM`      | `--add-managed`                 | `seedpass add-managed --label "Account" --words 12`
 | Search by Tag or Title                    | `search-by`            | `-SB`          | `--search-by`                     | `seedpass search-by --tag "work"` or `seedpass search-by --title "GitHub"`                                                                                                                          |
 | Automatically Post Deltas After Edit      | `auto-post`            | `-AP`          | `--auto-post`                     | `seedpass auto-post --enable` or `seedpass auto-post --disable` |
 | Initial Setup Prompt for Seed Generation/Import | `setup`                | `-ST`          | `--setup`                         | `seedpass setup`                                                                                                                                                                                   |
@@ -601,7 +603,23 @@ seedpass add-kv --label "API" --value "secret" --notes "Service token"
 
 ---
 
-### 26. Search by Tag or Title
+### 26. Add Managed Account
+
+**Command:** `add-managed`
+**Short Flag:** `-AM`
+**Long Flag:** `--add-managed`
+
+**Description:**
+Creates a managed account derived from the current seed profile. The child profile is stored in `.seedpass/<parent_fp>/accounts/<child_fp>`.
+
+**Usage Example:**
+```bash
+seedpass add-managed --label "Account" --words 12
+```
+
+When loaded, the breadcrumb shows `<parent_fp> > Managed Account > <child_fp>`. Press Enter on the main menu to return to the parent profile.
+
+### 27. Search by Tag or Title
 
 **Command:** `search-by`  
 **Short Flag:** `-SB`  
@@ -622,7 +640,7 @@ seedpass search-by --title "GitHub"
 
 ---
 
-### 27. Automatically Post Deltas to Nostr After Edit
+### 28. Automatically Post Deltas to Nostr After Edit
 
 **Command:** `auto-post`  
 **Short Flag:** `-AP`  
@@ -643,7 +661,7 @@ seedpass auto-post --disable
 
 ---
 
-### 28. Initial Setup Prompt for Seed Generation/Import
+### 29. Initial Setup Prompt for Seed Generation/Import
 
 **Command:** `setup`  
 **Short Flag:** `-ST`  

--- a/docs/json_entries.md
+++ b/docs/json_entries.md
@@ -95,6 +95,8 @@ Each entry is stored within `seedpass_entries_db.json.enc` under the `entries` d
 - **origin** (`string`, optional): Source identifier for imported data.
 - **value** (`string`, optional): For `key_value` entries, stores the secret value.
 - **index** (`integer`, optional): BIP-85 derivation index for entries that derive material from a seed.
+- **word_count** (`integer`, managed_account only): Number of words when deriving the child seed (12 or 24).
+- **fingerprint** (`string`, managed_account only): Identifier of the child profile, used for its directory name.
   Example:
 
   ```json
@@ -266,6 +268,11 @@ Each entry is stored within `seedpass_entries_db.json.enc` under the `entries` d
   "timestamp": "2024-04-27T12:41:56Z"
 }
 ```
+
+Managed accounts store a child seed derived from the parent profile. The entry is saved under
+`.seedpass/<parent_fp>/accounts/<child_fp>` where `<child_fp>` is the managed account's
+fingerprint. When loaded, the CLI displays a breadcrumb like `<parent_fp> > Managed Account > <child_fp>`.
+Press **Enter** on the main menu to exit back to the parent profile.
 
 The `key` field is purely descriptive, while `value` holds the sensitive string
 such as an API token. Notes and custom fields may also be included alongside the


### PR DESCRIPTION
## Summary
- describe managed accounts in README
- expand field descriptions for managed_account entries
- note breadcrumb format and exit mechanism
- document managed account CLI command

## Testing
- `pip install -r src/requirements.txt`
- `pytest -q`
- `black .`

------
https://chatgpt.com/codex/tasks/task_b_686c79fa0294832bbeb4b04bc0fe8f3e