### PR TITLE
Fix label retrieval for passwords

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1891,7 +1891,7 @@ class PasswordManager:
                 pause()
                 return
 
-            website_name = entry.get("website")
+            website_name = entry.get("label", entry.get("website"))
             length = entry.get("length")
             username = entry.get("username")
             url = entry.get("url")


### PR DESCRIPTION
## Summary
- use the `label` field when retrieving password entries instead of the old `website` key

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686d21f47620832ba2cf783cbc8a442e