### PR TITLE
Implement entry actions menu

### DIFF
--- a/src/tests/test_archive_from_retrieve.py
+++ b/src/tests/test_archive_from_retrieve.py
@@ -40,7 +40,7 @@ def test_archive_entry_from_retrieve(monkeypatch):
 
         index = entry_mgr.add_entry("example.com", 8)
 
-        inputs = iter([str(index), "y"])
+        inputs = iter([str(index), "a", ""])
         monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
 
         pm.handle_retrieve_entry()
@@ -72,7 +72,7 @@ def test_restore_entry_from_retrieve(monkeypatch):
         index = entry_mgr.add_entry("example.com", 8)
         entry_mgr.archive_entry(index)
 
-        inputs = iter([str(index), "y"])
+        inputs = iter([str(index), "u", ""])
         monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
 
         pm.handle_retrieve_entry()

--- a/src/tests/test_manager_workflow.py
+++ b/src/tests/test_manager_workflow.py
@@ -57,7 +57,7 @@ def test_manager_workflow(monkeypatch):
                 "n",  # add custom field
                 "",  # length (default)
                 "0",  # retrieve index
-                "n",  # archive entry prompt
+                "",  # no action in entry menu
                 "0",  # modify index
                 "",  # new label
                 "user",  # new username


### PR DESCRIPTION
## Summary
- add `_entry_actions_menu` and `_entry_edit_menu`
- integrate new action menu in `handle_retrieve_entry`
- route archived entry view through new retrieve method
- update tests for new workflow

## Testing
- `black src/password_manager/manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686d2efd1f98832bb79890fe3fab93aa