### PR TITLE
Adjust inputs for entry action menu

### DIFF
--- a/src/tests/test_custom_fields_display.py
+++ b/src/tests/test_custom_fields_display.py
@@ -42,7 +42,7 @@ def test_retrieve_entry_shows_custom_fields(monkeypatch, capsys):
             ],
         )
 
-        inputs = iter(["0", "y", "", "n"])
+        inputs = iter(["0", "y", "", ""])
         monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
 
         pm.handle_retrieve_entry()

--- a/src/tests/test_manager_retrieve_totp.py
+++ b/src/tests/test_manager_retrieve_totp.py
@@ -43,7 +43,7 @@ def test_handle_retrieve_totp_entry(monkeypatch, capsys):
 
         entry_mgr.add_totp("Example", TEST_SEED)
 
-        inputs = iter(["0", "n"])
+        inputs = iter(["0", "n", ""])
         monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
         monkeypatch.setattr(pm.entry_manager, "get_totp_code", lambda *a, **k: "123456")
         monkeypatch.setattr(

--- a/src/tests/test_nostr_qr.py
+++ b/src/tests/test_nostr_qr.py
@@ -44,7 +44,7 @@ def test_show_qr_for_nostr_keys(monkeypatch):
         idx = entry_mgr.add_nostr_key("main")
         npub, _ = entry_mgr.get_nostr_key_pair(idx, TEST_SEED)
 
-        inputs = iter([str(idx), "n", ""])
+        inputs = iter([str(idx), "n", "", ""])
         monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
         responses = iter([True, False])
         monkeypatch.setattr(

--- a/src/tests/test_secret_mode.py
+++ b/src/tests/test_secret_mode.py
@@ -41,7 +41,7 @@ def test_password_retrieve_secret_mode(monkeypatch, capsys):
         pm, entry_mgr = setup_pm(tmp)
         entry_mgr.add_entry("example", 8)
 
-        inputs = iter(["0", "n"])
+        inputs = iter(["0", "n", ""])
         monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
         called = []
         monkeypatch.setattr(
@@ -90,7 +90,7 @@ def test_password_retrieve_no_secret_mode(monkeypatch, capsys):
         pm.secret_mode_enabled = False
         entry_mgr.add_entry("example", 8)
 
-        inputs = iter(["0", "n"])
+        inputs = iter(["0", "n", ""])
         monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
         called = []
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- extend input sequences in retrieval-related tests so the new action menu is dismissed correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d3143c664832bab820ada78f3507f