### PR TITLE
Add tag support for entries

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -981,6 +981,12 @@ class PasswordManager:
             username = input("Enter the username (optional): ").strip()
             url = input("Enter the URL (optional): ").strip()
             notes = input("Enter notes (optional): ").strip()
+            tags_input = input("Enter tags (comma-separated, optional): ").strip()
+            tags = (
+                [t.strip() for t in tags_input.split(",") if t.strip()]
+                if tags_input
+                else []
+            )
 
             custom_fields: list[dict[str, object]] = []
             while True:
@@ -1021,6 +1027,7 @@ class PasswordManager:
                 archived=False,
                 notes=notes,
                 custom_fields=custom_fields,
+                tags=tags,
             )
 
             # Mark database as dirty for background sync
@@ -1084,6 +1091,14 @@ class PasswordManager:
                         )
                         continue
                     notes = input("Notes (optional): ").strip()
+                    tags_input = input(
+                        "Enter tags (comma-separated, optional): "
+                    ).strip()
+                    tags = (
+                        [t.strip() for t in tags_input.split(",") if t.strip()]
+                        if tags_input
+                        else []
+                    )
                     totp_index = self.entry_manager.get_next_totp_index()
                     entry_id = self.entry_manager.get_next_index()
                     uri = self.entry_manager.add_totp(
@@ -1093,6 +1108,7 @@ class PasswordManager:
                         period=int(period),
                         digits=int(digits),
                         notes=notes,
+                        tags=tags,
                     )
                     secret = TotpManager.derive_secret(self.parent_seed, totp_index)
                     self.is_dirty = True
@@ -1128,6 +1144,14 @@ class PasswordManager:
                             period = int(input("Period (default 30): ").strip() or 30)
                             digits = int(input("Digits (default 6): ").strip() or 6)
                         notes = input("Notes (optional): ").strip()
+                        tags_input = input(
+                            "Enter tags (comma-separated, optional): "
+                        ).strip()
+                        tags = (
+                            [t.strip() for t in tags_input.split(",") if t.strip()]
+                            if tags_input
+                            else []
+                        )
                         entry_id = self.entry_manager.get_next_index()
                         uri = self.entry_manager.add_totp(
                             label,
@@ -1136,6 +1160,7 @@ class PasswordManager:
                             period=period,
                             digits=digits,
                             notes=notes,
+                            tags=tags,
                         )
                         self.is_dirty = True
                         self.last_update = time.time()
@@ -1181,7 +1206,15 @@ class PasswordManager:
                 print(colored("Error: Label cannot be empty.", "red"))
                 return
             notes = input("Notes (optional): ").strip()
-            index = self.entry_manager.add_ssh_key(label, self.parent_seed, notes=notes)
+            tags_input = input("Enter tags (comma-separated, optional): ").strip()
+            tags = (
+                [t.strip() for t in tags_input.split(",") if t.strip()]
+                if tags_input
+                else []
+            )
+            index = self.entry_manager.add_ssh_key(
+                label, self.parent_seed, notes=notes, tags=tags
+            )
             priv_pem, pub_pem = self.entry_manager.get_ssh_key_pair(
                 index, self.parent_seed
             )
@@ -1230,12 +1263,18 @@ class PasswordManager:
                 return
             words_input = input("Word count (12 or 24, default 24): ").strip()
             notes = input("Notes (optional): ").strip()
+            tags_input = input("Enter tags (comma-separated, optional): ").strip()
+            tags = (
+                [t.strip() for t in tags_input.split(",") if t.strip()]
+                if tags_input
+                else []
+            )
             if words_input and words_input not in {"12", "24"}:
                 print(colored("Invalid word count. Choose 12 or 24.", "red"))
                 return
             words = int(words_input) if words_input else 24
             index = self.entry_manager.add_seed(
-                label, self.parent_seed, words_num=words, notes=notes
+                label, self.parent_seed, words_num=words, notes=notes, tags=tags
             )
             phrase = self.entry_manager.get_seed_phrase(index, self.parent_seed)
             self.is_dirty = True
@@ -1296,12 +1335,19 @@ class PasswordManager:
             )
             user_id = input("User ID (optional): ").strip()
             notes = input("Notes (optional): ").strip()
+            tags_input = input("Enter tags (comma-separated, optional): ").strip()
+            tags = (
+                [t.strip() for t in tags_input.split(",") if t.strip()]
+                if tags_input
+                else []
+            )
             index = self.entry_manager.add_pgp_key(
                 label,
                 self.parent_seed,
                 key_type=key_type,
                 user_id=user_id,
                 notes=notes,
+                tags=tags,
             )
             priv_key, fingerprint = self.entry_manager.get_pgp_key(
                 index, self.parent_seed
@@ -1350,7 +1396,13 @@ class PasswordManager:
                 print(colored("Error: Label cannot be empty.", "red"))
                 return
             notes = input("Notes (optional): ").strip()
-            index = self.entry_manager.add_nostr_key(label, notes=notes)
+            tags_input = input("Enter tags (comma-separated, optional): ").strip()
+            tags = (
+                [t.strip() for t in tags_input.split(",") if t.strip()]
+                if tags_input
+                else []
+            )
+            index = self.entry_manager.add_nostr_key(label, notes=notes, tags=tags)
             npub, nsec = self.entry_manager.get_nostr_key_pair(index, self.parent_seed)
             self.is_dirty = True
             self.last_update = time.time()
@@ -1401,6 +1453,12 @@ class PasswordManager:
                 return
             value = input("Value: ").strip()
             notes = input("Notes (optional): ").strip()
+            tags_input = input("Enter tags (comma-separated, optional): ").strip()
+            tags = (
+                [t.strip() for t in tags_input.split(",") if t.strip()]
+                if tags_input
+                else []
+            )
 
             custom_fields: list[dict[str, object]] = []
             while True:
@@ -1419,7 +1477,11 @@ class PasswordManager:
                 )
 
             index = self.entry_manager.add_key_value(
-                label, value, notes=notes, custom_fields=custom_fields
+                label,
+                value,
+                notes=notes,
+                custom_fields=custom_fields,
+                tags=tags,
             )
             self.is_dirty = True
             self.last_update = time.time()
@@ -1465,8 +1527,14 @@ class PasswordManager:
                 print(colored("Error: Label cannot be empty.", "red"))
                 return
             notes = input("Notes (optional): ").strip()
+            tags_input = input("Enter tags (comma-separated, optional): ").strip()
+            tags = (
+                [t.strip() for t in tags_input.split(",") if t.strip()]
+                if tags_input
+                else []
+            )
             index = self.entry_manager.add_managed_account(
-                label, self.parent_seed, notes=notes
+                label, self.parent_seed, notes=notes, tags=tags
             )
             seed = self.entry_manager.get_managed_account_seed(index, self.parent_seed)
             self.is_dirty = True
@@ -2190,6 +2258,15 @@ class PasswordManager:
                             {"label": label, "value": value, "is_hidden": hidden}
                         )
 
+                tags_input = input(
+                    "Enter tags (comma-separated, leave blank to keep current): "
+                ).strip()
+                tags = (
+                    [t.strip() for t in tags_input.split(",") if t.strip()]
+                    if tags_input
+                    else None
+                )
+
                 self.entry_manager.modify_entry(
                     index,
                     archived=new_blacklisted,
@@ -2198,6 +2275,7 @@ class PasswordManager:
                     period=new_period,
                     digits=new_digits,
                     custom_fields=custom_fields,
+                    tags=tags,
                 )
             elif entry_type in (
                 EntryType.KEY_VALUE.value,
@@ -2273,6 +2351,15 @@ class PasswordManager:
                             {"label": f_label, "value": f_value, "is_hidden": hidden}
                         )
 
+                tags_input = input(
+                    "Enter tags (comma-separated, leave blank to keep current): "
+                ).strip()
+                tags = (
+                    [t.strip() for t in tags_input.split(",") if t.strip()]
+                    if tags_input
+                    else None
+                )
+
                 self.entry_manager.modify_entry(
                     index,
                     archived=new_blacklisted,
@@ -2280,6 +2367,7 @@ class PasswordManager:
                     label=new_label,
                     value=new_value,
                     custom_fields=custom_fields,
+                    tags=tags,
                 )
             else:
                 website_name = entry.get("label", entry.get("website"))
@@ -2366,6 +2454,15 @@ class PasswordManager:
                             {"label": label, "value": value, "is_hidden": hidden}
                         )
 
+                tags_input = input(
+                    "Enter tags (comma-separated, leave blank to keep current): "
+                ).strip()
+                tags = (
+                    [t.strip() for t in tags_input.split(",") if t.strip()]
+                    if tags_input
+                    else None
+                )
+
                 self.entry_manager.modify_entry(
                     index,
                     new_username,
@@ -2374,6 +2471,7 @@ class PasswordManager:
                     notes=new_notes,
                     label=new_label,
                     custom_fields=custom_fields,
+                    tags=tags,
                 )
 
             # Mark database as dirty for background sync

--- a/src/tests/test_entry_add.py
+++ b/src/tests/test_entry_add.py
@@ -39,6 +39,7 @@ def test_add_and_retrieve_entry():
             "kind": "password",
             "notes": "",
             "custom_fields": custom,
+            "tags": [],
         }
 
         data = enc_mgr.load_json_data(entry_mgr.index_file)

--- a/src/tests/test_key_value_entry.py
+++ b/src/tests/test_key_value_entry.py
@@ -33,6 +33,7 @@ def test_add_and_modify_key_value():
             "notes": "token",
             "archived": False,
             "custom_fields": [],
+            "tags": [],
         }
 
         em.modify_entry(idx, value="def456")

--- a/src/tests/test_manager_add_totp.py
+++ b/src/tests/test_manager_add_totp.py
@@ -48,6 +48,7 @@ def test_handle_add_totp(monkeypatch, capsys):
                 "",  # period
                 "",  # digits
                 "",  # notes
+                "",  # tags
             ]
         )
         monkeypatch.setattr("builtins.input", lambda *args, **kwargs: next(inputs))
@@ -66,5 +67,6 @@ def test_handle_add_totp(monkeypatch, capsys):
             "digits": 6,
             "archived": False,
             "notes": "",
+            "tags": [],
         }
         assert "ID 0" in out

--- a/src/tests/test_manager_workflow.py
+++ b/src/tests/test_manager_workflow.py
@@ -54,6 +54,7 @@ def test_manager_workflow(monkeypatch):
                 "",  # username
                 "",  # url
                 "",  # notes
+                "",  # tags
                 "n",  # add custom field
                 "",  # length (default)
                 "0",  # retrieve index
@@ -65,6 +66,7 @@ def test_manager_workflow(monkeypatch):
                 "",  # archive status
                 "",  # new notes
                 "n",  # edit custom fields
+                "",  # tags keep
             ]
         )
         monkeypatch.setattr("builtins.input", lambda *args, **kwargs: next(inputs))

--- a/src/tests/test_nostr_entry.py
+++ b/src/tests/test_nostr_entry.py
@@ -31,6 +31,7 @@ def test_nostr_key_determinism():
             "label": "main",
             "notes": "",
             "archived": False,
+            "tags": [],
         }
 
         npub1, nsec1 = entry_mgr.get_nostr_key_pair(idx, TEST_SEED)

--- a/src/tests/test_seed_entry.py
+++ b/src/tests/test_seed_entry.py
@@ -42,6 +42,7 @@ def test_seed_phrase_determinism():
             "word_count": 12,
             "notes": "",
             "archived": False,
+            "tags": [],
         }
 
         assert entry24 == {
@@ -52,6 +53,7 @@ def test_seed_phrase_determinism():
             "word_count": 24,
             "notes": "",
             "archived": False,
+            "tags": [],
         }
 
         assert phrase12_a not in entry12.values()

--- a/src/tests/test_ssh_entry.py
+++ b/src/tests/test_ssh_entry.py
@@ -29,6 +29,7 @@ def test_add_and_retrieve_ssh_key_pair():
             "label": "ssh",
             "notes": "",
             "archived": False,
+            "tags": [],
         }
 
         priv1, pub1 = entry_mgr.get_ssh_key_pair(index, TEST_SEED)

--- a/src/tests/test_totp_entry.py
+++ b/src/tests/test_totp_entry.py
@@ -37,6 +37,7 @@ def test_add_totp_and_get_code():
             "digits": 6,
             "archived": False,
             "notes": "",
+            "tags": [],
         }
 
         code = entry_mgr.get_totp_code(0, TEST_SEED, timestamp=0)
@@ -76,6 +77,7 @@ def test_add_totp_imported(tmp_path):
         "digits": 6,
         "archived": False,
         "notes": "",
+        "tags": [],
     }
     code = em.get_totp_code(0, timestamp=0)
     assert code == pyotp.TOTP(secret).at(0)


### PR DESCRIPTION
## Summary
- support tags in `EntryManager` and CLI handlers
- search entries by tags
- update tests for new tags field

## Testing
- `python3 -m venv venv`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d57de6738832b97640b1a5a659efd