### PR TITLE
Add schema v4 migration and update tests

### DIFF
--- a/src/password_manager/migrations.py
+++ b/src/password_manager/migrations.py
@@ -58,7 +58,17 @@ def _v2_to_v3(data: dict) -> dict:
     return data
 
 
-LATEST_VERSION = 3
+@migration(3)
+def _v3_to_v4(data: dict) -> dict:
+    """Add tags defaults to each entry."""
+    entries = data.get("entries", {})
+    for entry in entries.values():
+        entry.setdefault("tags", [])
+    data["schema_version"] = 4
+    return data
+
+
+LATEST_VERSION = 4
 
 
 def apply_migrations(data: dict) -> dict:

--- a/src/tests/test_backup_restore.py
+++ b/src/tests/test_backup_restore.py
@@ -22,7 +22,7 @@ def test_backup_restore_workflow(monkeypatch):
         index_file = fp_dir / "seedpass_entries_db.json.enc"
 
         data1 = {
-            "schema_version": 3,
+            "schema_version": 4,
             "entries": {
                 "0": {
                     "label": "a",
@@ -32,6 +32,7 @@ def test_backup_restore_workflow(monkeypatch):
                     "notes": "",
                     "custom_fields": [],
                     "origin": "",
+                    "tags": [],
                 }
             },
         }
@@ -46,7 +47,7 @@ def test_backup_restore_workflow(monkeypatch):
             assert backup1.stat().st_mode & 0o777 == 0o600
 
         data2 = {
-            "schema_version": 3,
+            "schema_version": 4,
             "entries": {
                 "0": {
                     "label": "b",
@@ -56,6 +57,7 @@ def test_backup_restore_workflow(monkeypatch):
                     "notes": "",
                     "custom_fields": [],
                     "origin": "",
+                    "tags": [],
                 }
             },
         }
@@ -69,11 +71,11 @@ def test_backup_restore_workflow(monkeypatch):
         if os.name != "nt":
             assert backup2.stat().st_mode & 0o777 == 0o600
 
-        vault.save_index({"schema_version": 3, "entries": {"temp": {}}})
+        vault.save_index({"schema_version": 4, "entries": {"temp": {}}})
         backup_mgr.restore_latest_backup()
         assert vault.load_index()["entries"] == data2["entries"]
 
-        vault.save_index({"schema_version": 3, "entries": {}})
+        vault.save_index({"schema_version": 4, "entries": {}})
         backup_mgr.restore_backup_by_timestamp(1111)
         assert vault.load_index()["entries"] == data1["entries"]
 
@@ -91,7 +93,7 @@ def test_additional_backup_location(monkeypatch):
         cfg_mgr.set_additional_backup_path(extra)
         backup_mgr = BackupManager(fp_dir, cfg_mgr)
 
-        vault.save_index({"schema_version": 3, "entries": {"a": {}}})
+        vault.save_index({"schema_version": 4, "entries": {"a": {}}})
 
         monkeypatch.setattr(time, "time", lambda: 3333)
         backup_mgr.create_backup()

--- a/src/tests/test_cli_export_import.py
+++ b/src/tests/test_cli_export_import.py
@@ -31,7 +31,7 @@ def _setup_pm(tmp_path: Path):
 def test_cli_export_creates_file(monkeypatch, tmp_path):
     pm, vault = _setup_pm(tmp_path)
     data = {
-        "schema_version": 3,
+        "schema_version": 4,
         "entries": {
             "0": {
                 "label": "example",
@@ -39,6 +39,7 @@ def test_cli_export_creates_file(monkeypatch, tmp_path):
                 "notes": "",
                 "custom_fields": [],
                 "origin": "",
+                "tags": [],
             }
         },
     }
@@ -58,7 +59,7 @@ def test_cli_export_creates_file(monkeypatch, tmp_path):
 def test_cli_import_round_trip(monkeypatch, tmp_path):
     pm, vault = _setup_pm(tmp_path)
     original = {
-        "schema_version": 3,
+        "schema_version": 4,
         "entries": {
             "0": {
                 "label": "example",
@@ -66,6 +67,7 @@ def test_cli_import_round_trip(monkeypatch, tmp_path):
                 "notes": "",
                 "custom_fields": [],
                 "origin": "",
+                "tags": [],
             }
         },
     }
@@ -79,7 +81,7 @@ def test_cli_import_round_trip(monkeypatch, tmp_path):
         parent_seed=TEST_SEED,
     )
 
-    vault.save_index({"schema_version": 3, "entries": {}})
+    vault.save_index({"schema_version": 4, "entries": {}})
 
     monkeypatch.setattr(main, "PasswordManager", lambda: pm)
     monkeypatch.setattr(main, "configure_logging", lambda: None)

--- a/src/tests/test_index_import_export.py
+++ b/src/tests/test_index_import_export.py
@@ -31,7 +31,7 @@ def test_index_export_import_round_trip():
         vault = setup_vault(tmp)
 
         original = {
-            "schema_version": 3,
+            "schema_version": 4,
             "entries": {
                 "0": {
                     "label": "example",
@@ -39,6 +39,7 @@ def test_index_export_import_round_trip():
                     "notes": "",
                     "custom_fields": [],
                     "origin": "",
+                    "tags": [],
                 }
             },
         }
@@ -49,7 +50,7 @@ def test_index_export_import_round_trip():
 
         vault.save_index(
             {
-                "schema_version": 3,
+                "schema_version": 4,
                 "entries": {
                     "0": {
                         "label": "changed",
@@ -57,6 +58,7 @@ def test_index_export_import_round_trip():
                         "notes": "",
                         "custom_fields": [],
                         "origin": "",
+                        "tags": [],
                     }
                 },
             }

--- a/src/tests/test_migrations.py
+++ b/src/tests/test_migrations.py
@@ -13,7 +13,7 @@ def setup(tmp_path: Path):
     return enc_mgr, vault
 
 
-def test_migrate_v0_to_v3(tmp_path: Path):
+def test_migrate_v0_to_v4(tmp_path: Path):
     enc_mgr, vault = setup(tmp_path)
     legacy = {"passwords": {"0": {"website": "a", "length": 8}}}
     enc_mgr.save_json_data(legacy)
@@ -26,11 +26,12 @@ def test_migrate_v0_to_v3(tmp_path: Path):
         "notes": "",
         "custom_fields": [],
         "origin": "",
+        "tags": [],
     }
     assert data["entries"]["0"] == expected_entry
 
 
-def test_migrate_v1_to_v3(tmp_path: Path):
+def test_migrate_v1_to_v4(tmp_path: Path):
     enc_mgr, vault = setup(tmp_path)
     legacy = {"schema_version": 1, "passwords": {"0": {"website": "b", "length": 10}}}
     enc_mgr.save_json_data(legacy)
@@ -43,11 +44,12 @@ def test_migrate_v1_to_v3(tmp_path: Path):
         "notes": "",
         "custom_fields": [],
         "origin": "",
+        "tags": [],
     }
     assert data["entries"]["0"] == expected_entry
 
 
-def test_migrate_v2_to_v3(tmp_path: Path):
+def test_migrate_v2_to_v4(tmp_path: Path):
     enc_mgr, vault = setup(tmp_path)
     legacy = {
         "schema_version": 2,
@@ -65,6 +67,7 @@ def test_migrate_v2_to_v3(tmp_path: Path):
         "notes": "",
         "custom_fields": [],
         "origin": "",
+        "tags": [],
     }
     assert data["entries"]["0"] == expected_entry
 


### PR DESCRIPTION
## Summary
- add `_v3_to_v4` migration that adds `tags` field to each entry
- bump `LATEST_VERSION` to 4
- adjust migration tests for version 4
- update backup/import/export tests to expect version 4

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d5ea0789c832bb67b15ba6c73da8c