### PR TITLE
Update docs for tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 - **Optional External Backup Location:** Configure a second directory where backups are automatically copied.
 - **Auto‑Lock on Inactivity:** Vault locks after a configurable timeout for additional security.
 - **Secret Mode:** Copy retrieved passwords directly to your clipboard and automatically clear it after a delay.
+- **Tagging Support:** Organize entries with optional tags and find them quickly via search.
 
 ## Prerequisites
 
@@ -172,6 +173,7 @@ seedpass import --file "~/seedpass_backup.json"
 
 # Quickly find or retrieve entries
 seedpass search "github"
+seedpass search --tags "work,personal"
 seedpass get "github"
 seedpass totp "email"
 # The code is printed and copied to your clipboard
@@ -295,14 +297,14 @@ entry includes a `label`, while only password entries track a `url`.
 
 | Entry Type    | Extra Fields |
 |---------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| Password      | `username`, `url`, `length`, `archived`, optional `notes`, optional `custom_fields` (may include hidden fields) |
-| 2FA (TOTP)    | `index` or `secret`, `period`, `digits`, `archived`, optional `notes` |
-| SSH Key       | `index`, `archived`, optional `notes` |
-| Seed Phrase   | `index`, `word_count` *(mnemonic regenerated; never stored)*, `archived`, optional `notes` |
-| PGP Key       | `index`, `key_type`, `archived`, optional `user_id`, optional `notes` |
-| Nostr Key Pair| `index`, `archived`, optional `notes` |
-| Key/Value     | `value`, `archived`, optional `notes`, optional `custom_fields` |
-| Managed Account | `index`, `word_count`, `fingerprint`, `archived`, optional `notes` |
+| Password      | `username`, `url`, `length`, `archived`, optional `notes`, optional `custom_fields` (may include hidden fields), optional `tags` |
+| 2FA (TOTP)    | `index` or `secret`, `period`, `digits`, `archived`, optional `notes`, optional `tags` |
+| SSH Key       | `index`, `archived`, optional `notes`, optional `tags` |
+| Seed Phrase   | `index`, `word_count` *(mnemonic regenerated; never stored)*, `archived`, optional `notes`, optional `tags` |
+| PGP Key       | `index`, `key_type`, `archived`, optional `user_id`, optional `notes`, optional `tags` |
+| Nostr Key Pair| `index`, `archived`, optional `notes`, optional `tags` |
+| Key/Value     | `value`, `archived`, optional `notes`, optional `custom_fields`, optional `tags` |
+| Managed Account | `index`, `word_count`, `fingerprint`, `archived`, optional `notes`, optional `tags` |
 
 
 ### Managing Multiple Seeds

--- a/docs/advanced_cli.md
+++ b/docs/advanced_cli.md
@@ -107,11 +107,11 @@ Miscellaneous helper commands.
 
 ### `entry` Commands
 
-- **`seedpass entry add`** – Add a new entry. Use `--type` to specify `password`, `totp`, `ssh`, `pgp`, `nostr`, `key-value`, or `managed-account`.
+- **`seedpass entry add`** – Add a new entry. Use `--type` to specify `password`, `totp`, `ssh`, `pgp`, `nostr`, `key-value`, or `managed-account`. Include `--tags tag1,tag2` to categorize the entry.
 - **`seedpass entry get <query>`** – Retrieve the primary secret for one matching entry.
 - **`seedpass entry list`** – List entries in the vault, optionally sorted or filtered.
-- **`seedpass entry search <query>`** – Search across labels, usernames, URLs, and notes.
-- **`seedpass entry modify <query>`** – Update fields on an existing entry. Use `--archive` to hide or `--restore` to un‑archive.
+- **`seedpass entry search <query>`** – Search across labels, usernames, URLs, notes, and tags.
+- **`seedpass entry modify <query>`** – Update fields on an existing entry. Use `--archive` to hide or `--restore` to un‑archive. Specify `--tags tag1,tag2` to replace the entry's tags.
 - **`seedpass entry delete <query>`** – Permanently delete an entry after confirmation.
 
 ### `vault` Commands

--- a/docs/json_entries.md
+++ b/docs/json_entries.md
@@ -77,6 +77,7 @@ Each entry is stored within `seedpass_entries_db.json.enc` under the `entries` d
   "notes": "",
   "custom_fields": [],
   "origin": "",
+  "tags": [],
   "index": 0
 }
 ```
@@ -97,6 +98,7 @@ Each entry is stored within `seedpass_entries_db.json.enc` under the `entries` d
 - **index** (`integer`, optional): BIP-85 derivation index for entries that derive material from a seed.
 - **word_count** (`integer`, managed_account only): Number of words in the child seed. Managed accounts always use `12`.
 - **fingerprint** (`string`, managed_account only): Identifier of the child profile, used for its directory name.
+- **tags** (`array`, optional): Category labels to aid in organization and search.
   Example:
 
   ```json
@@ -126,6 +128,7 @@ Each entry is stored within `seedpass_entries_db.json.enc` under the `entries` d
   "custom_fields": [
     {"name": "department", "value": "finance"}
   ],
+  "tags": ["work"],
   "timestamp": "2024-04-27T12:34:56Z",
   "metadata": {
     "created_at": "2024-04-27T12:34:56Z",
@@ -250,6 +253,7 @@ Each entry is stored within `seedpass_entries_db.json.enc` under the `entries` d
     "key": "api_key",
     "value": "<encrypted_value>"
   },
+  "tags": ["api"],
   "timestamp": "2024-04-27T12:40:56Z"
 }
 ```


### PR DESCRIPTION
## Summary
- document tagging in README features list
- note optional `tags` for each entry type
- add search example with `--tags`
- update JSON docs with tags field and tagged example entries
- describe CLI support for tags in advanced CLI doc

## Testing
- `python3 -m venv venv`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d63274384832bbab69ff14d5011b0