### PR TITLE
Add tags from retrieval actions

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1623,6 +1623,7 @@ class PasswordManager:
             print(colored("C. Add Custom Field", "cyan"))
             print(colored("H. Add Hidden Field", "cyan"))
             print(colored("E. Edit", "cyan"))
+            print(colored("T. Add Tags", "cyan"))
 
             choice = (
                 input("Select an action or press Enter to return: ").strip().lower()
@@ -1657,6 +1658,15 @@ class PasswordManager:
                         {"label": label, "value": value, "is_hidden": hidden}
                     )
                     self.entry_manager.modify_entry(index, custom_fields=custom_fields)
+                    self.is_dirty = True
+                    self.last_update = time.time()
+            elif choice == "t":
+                tags_input = input("Enter tags (comma-separated): ").strip()
+                if tags_input:
+                    new_tags = [t.strip() for t in tags_input.split(",") if t.strip()]
+                    existing_tags = entry.get("tags", [])
+                    tags = list({*existing_tags, *new_tags})
+                    self.entry_manager.modify_entry(index, tags=tags)
                     self.is_dirty = True
                     self.last_update = time.time()
             elif choice == "e":

--- a/src/tests/test_add_tags_from_retrieve.py
+++ b/src/tests/test_add_tags_from_retrieve.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.entry_management import EntryManager
+from password_manager.backup import BackupManager
+from password_manager.manager import PasswordManager, EncryptionMode
+from password_manager.config_manager import ConfigManager
+
+
+class FakePasswordGenerator:
+    def generate_password(self, length: int, index: int) -> str:  # noqa: D401
+        return "pw"
+
+
+def test_add_tags_from_retrieve(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+        pm.encryption_manager = enc_mgr
+        pm.vault = vault
+        pm.entry_manager = entry_mgr
+        pm.backup_manager = backup_mgr
+        pm.password_generator = FakePasswordGenerator()
+        pm.parent_seed = TEST_SEED
+        pm.nostr_client = SimpleNamespace()
+        pm.fingerprint_dir = tmp_path
+        pm.secret_mode_enabled = False
+
+        index = entry_mgr.add_entry("example.com", 8)
+
+        inputs = iter([str(index), "t", "work,personal", ""])
+        monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+
+        pm.handle_retrieve_entry()
+
+        entry = entry_mgr.retrieve_entry(index)
+        assert set(entry.get("tags", [])) == {"work", "personal"}


### PR DESCRIPTION
## Summary
- add ability to append tags when viewing entry actions
- test adding tags from retrieve menu

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt >/tmp/pip.log && pytest -q >/tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_b_686d6b3a723c832bb538f2d73b46630e