### PR TITLE
Remove QR prompts during entry retrieval

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1944,10 +1944,7 @@ class PasswordManager:
                         )
                     else:
                         print(color_text(phrase, "deterministic"))
-                    if confirm_action("Show Compact Seed QR? (Y/N): "):
-                        from password_manager.seedqr import encode_seedqr
-
-                        TotpManager.print_qr_code(encode_seedqr(phrase))
+                    # Removed QR code display prompt and output
                     if confirm_action("Show derived entropy as hex? (Y/N): "):
                         from local_bip85.bip85 import BIP85
                         from bip_utils import Bip39SeedGenerator
@@ -2023,12 +2020,7 @@ class PasswordManager:
                         )
                     else:
                         print(color_text(f"nsec: {nsec}", "deterministic"))
-                    if confirm_action("Show QR code for npub? (Y/N): "):
-                        TotpManager.print_qr_code(f"nostr:{npub}")
-                    if confirm_action(
-                        "WARNING: Displaying the nsec QR reveals your private key. Continue? (Y/N): "
-                    ):
-                        TotpManager.print_qr_code(nsec)
+                    # QR code display removed for npub and nsec
                     if notes:
                         print(colored(f"Notes: {notes}", "cyan"))
                 except Exception as e:
@@ -2131,10 +2123,7 @@ class PasswordManager:
                         )
                     else:
                         print(color_text(seed, "deterministic"))
-                    if confirm_action("Show Compact Seed QR? (Y/N): "):
-                        from password_manager.seedqr import encode_seedqr
-
-                        TotpManager.print_qr_code(encode_seedqr(seed))
+                    # QR code display removed for managed account seed
                     self._entry_actions_menu(index, entry)
                     pause()
                     return

--- a/src/tests/test_nostr_qr.py
+++ b/src/tests/test_nostr_qr.py
@@ -21,7 +21,7 @@ class FakeNostrClient:
         return None, "abcd"
 
 
-def test_show_qr_for_nostr_keys(monkeypatch):
+def test_no_qr_for_nostr_keys(monkeypatch):
     with TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
         vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
@@ -46,11 +46,6 @@ def test_show_qr_for_nostr_keys(monkeypatch):
 
         inputs = iter([str(idx), "n", "", ""])
         monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
-        responses = iter([True, False])
-        monkeypatch.setattr(
-            "password_manager.manager.confirm_action",
-            lambda *_a, **_k: next(responses),
-        )
         called = []
         monkeypatch.setattr(
             "password_manager.manager.TotpManager.print_qr_code",
@@ -58,4 +53,4 @@ def test_show_qr_for_nostr_keys(monkeypatch):
         )
 
         pm.handle_retrieve_entry()
-        assert called == [f"nostr:{npub}"]
+        assert called == []


### PR DESCRIPTION
## Summary
- remove QR code prompts from `handle_retrieve_entry`
- stop printing QR codes for Nostr, seed, and managed account entries
- update tests accordingly

## Testing
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d722198c0832b9b310040483d6352