### PR TITLE
Add test for showing Nostr private key QR

### DIFF
--- a/src/tests/test_nostr_qr.py
+++ b/src/tests/test_nostr_qr.py
@@ -10,6 +10,7 @@ from password_manager.entry_management import EntryManager
 from password_manager.backup import BackupManager
 from password_manager.manager import PasswordManager, EncryptionMode, TotpManager
 from password_manager.config_manager import ConfigManager
+from utils.color_scheme import color_text
 
 
 class FakeNostrClient:
@@ -54,3 +55,41 @@ def test_show_qr_for_nostr_keys(monkeypatch):
 
         pm.handle_retrieve_entry()
         assert called == [f"nostr:{npub}"]
+
+
+def test_show_private_key_qr(monkeypatch, capsys):
+    """Ensure nsec QR code is shown and output is colored."""
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+        pm.encryption_manager = enc_mgr
+        pm.vault = vault
+        pm.entry_manager = entry_mgr
+        pm.backup_manager = backup_mgr
+        pm.parent_seed = TEST_SEED
+        pm.nostr_client = FakeNostrClient()
+        pm.fingerprint_dir = tmp_path
+        pm.is_dirty = False
+        pm.secret_mode_enabled = False
+
+        idx = entry_mgr.add_nostr_key("main")
+        _, nsec = entry_mgr.get_nostr_key_pair(idx, TEST_SEED)
+
+        inputs = iter([str(idx), "q", "k", ""])
+        monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+        called = []
+        monkeypatch.setattr(
+            "password_manager.manager.TotpManager.print_qr_code",
+            lambda data: called.append(data),
+        )
+
+        pm.handle_retrieve_entry()
+        out = capsys.readouterr().out
+        assert called == [nsec]
+        assert color_text(f"nsec: {nsec}", "deterministic") in out


### PR DESCRIPTION
## Summary
- cover QR display for Nostr private keys

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686d775178e4832b803cca0fae2bf269