### PR TITLE
Add fingerprint support when starting API server

### DIFF
--- a/src/seedpass/api.py
+++ b/src/seedpass/api.py
@@ -25,10 +25,18 @@ def _check_token(auth: str | None) -> None:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 
-def start_server() -> str:
-    """Initialize global state and return the API token."""
+def start_server(fingerprint: str | None = None) -> str:
+    """Initialize global state and return the API token.
+
+    Parameters
+    ----------
+    fingerprint:
+        Optional seed profile fingerprint to select before starting the server.
+    """
     global _pm, _token
     _pm = PasswordManager()
+    if fingerprint:
+        _pm.select_fingerprint(fingerprint)
     _token = secrets.token_urlsafe(16)
     print(f"API token: {_token}")
     origins = [

--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -183,15 +183,15 @@ def generate_password(ctx: typer.Context, length: int = 24) -> None:
 
 
 @api_app.command("start")
-def api_start(host: str = "127.0.0.1", port: int = 8000) -> None:
+def api_start(ctx: typer.Context, host: str = "127.0.0.1", port: int = 8000) -> None:
     """Start the SeedPass API server."""
-    token = api_module.start_server()
+    token = api_module.start_server(ctx.obj.get("fingerprint"))
     typer.echo(f"API token: {token}")
     uvicorn.run(api_module.app, host=host, port=port)
 
 
 @api_app.command("stop")
-def api_stop(host: str = "127.0.0.1", port: int = 8000) -> None:
+def api_stop(ctx: typer.Context, host: str = "127.0.0.1", port: int = 8000) -> None:
     """Stop the SeedPass API server."""
     import requests
 

--- a/src/tests/test_typer_cli.py
+++ b/src/tests/test_typer_cli.py
@@ -149,3 +149,19 @@ def test_generate_password(monkeypatch):
     assert result.exit_code == 0
     assert called.get("length") == 12
     assert "secretpw" in result.stdout
+
+
+def test_api_start_passes_fingerprint(monkeypatch):
+    """Ensure the API start command forwards the selected fingerprint."""
+    called = {}
+
+    def fake_start(fp=None):
+        called["fp"] = fp
+        return "tok"
+
+    monkeypatch.setattr(cli.api_module, "start_server", fake_start)
+    monkeypatch.setattr(cli, "uvicorn", SimpleNamespace(run=lambda *a, **k: None))
+
+    result = runner.invoke(app, ["--fingerprint", "abc", "api", "start"])
+    assert result.exit_code == 0
+    assert called.get("fp") == "abc"


### PR DESCRIPTION
## Summary
- allow optional fingerprint parameter when starting the API server
- pass fingerprint from CLI when running `api start`
- adjust `api stop` signature for consistency
- test that `api start` forwards the fingerprint to `start_server`

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e7e11e0e4832bb400ddd1b2c255a4