### PR TITLE
Update TOTP docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ seedpass import --file "~/seedpass_backup.json"
 seedpass search "github"
 seedpass search --tags "work,personal"
 seedpass get "github"
-seedpass totp "email"
+# Retrieve a TOTP entry
+seedpass entry get "email"
 # The code is printed and copied to your clipboard
 
 # Sort or filter the list view
@@ -185,6 +186,9 @@ seedpass list --filter totp
 # Use the **Settings** menu to configure an extra backup directory
 # on an external drive.
 ```
+
+For additional command examples, see [docs/advanced_cli.md](docs/advanced_cli.md).
+Details on the REST API can be found in [docs/api_reference.md](docs/api_reference.md).
 
 ### Vault JSON Layout
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,12 +4,12 @@ This directory contains supplementary guides for using SeedPass.
 
 ## Quick Example: Get a TOTP Code
 
-Run `seedpass totp <query>` to retrieve a time-based one-time password (TOTP). The
-`<query>` can be a label, title, or index. A progress bar shows the remaining
+Run `seedpass entry get <query>` to retrieve a time-based one-time password (TOTP).
+The `<query>` can be a label, title, or index. A progress bar shows the remaining
 seconds in the current period.
 
 ```bash
-$ seedpass totp "email"
+$ seedpass entry get "email"
 [##########----------] 15s
 Code: 123456
 ```


### PR DESCRIPTION
## Summary
- use `seedpass entry get` for TOTP retrieval in README
- reference advanced CLI and API docs
- update docs README accordingly

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e8ec88950832b860ac5ea859c2188