### PR TITLE
Add CLI config set subcommand

### DIFF
--- a/src/tests/test_typer_cli.py
+++ b/src/tests/test_typer_cli.py
@@ -118,6 +118,33 @@ def test_config_get(monkeypatch):
     assert "1" in result.stdout
 
 
+def test_config_set(monkeypatch):
+    called = {}
+
+    def set_timeout(val):
+        called["timeout"] = float(val)
+
+    pm = SimpleNamespace(
+        config_manager=SimpleNamespace(set_inactivity_timeout=set_timeout),
+        select_fingerprint=lambda fp: None,
+    )
+    monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
+    result = runner.invoke(app, ["config", "set", "inactivity_timeout", "5"])
+    assert result.exit_code == 0
+    assert called["timeout"] == 5.0
+    assert "Updated" in result.stdout
+
+
+def test_config_set_unknown_key(monkeypatch):
+    pm = SimpleNamespace(
+        config_manager=SimpleNamespace(), select_fingerprint=lambda fp: None
+    )
+    monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
+    result = runner.invoke(app, ["config", "set", "bogus", "val"])
+    assert result.exit_code != 0
+    assert "Unknown key" in result.stdout
+
+
 def test_nostr_sync(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- manage configuration values via `config set`
- include set in help text
- test new config commands

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686ea15eeef4832bbe3eaca0b61f14dc