### PR TITLE
Align docs with Typer CLI and update install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ When upgrading pip, use `python -m pip` inside the virtual environment so that p
 ```bash
 python -m pip install --upgrade pip
 python -m pip install -r src/requirements.txt
+python -m pip install -e .
 ```
 
 #### Linux Clipboard Support
@@ -166,8 +167,14 @@ sudo apt-get install xclip
 
 ## Quick Start
 
-After installing dependencies and activating your virtual environment, launch
-SeedPass and create a backup:
+After installing dependencies and activating your virtual environment, install
+the package in editable mode so the `seedpass` command is available:
+
+```bash
+python -m pip install -e .
+```
+
+You can then launch SeedPass and create a backup:
 
 ```bash
 # Start the application
@@ -219,7 +226,13 @@ The encrypted index file `seedpass_entries_db.json.enc` begins with `schema_vers
 
 ## Usage
 
-After successfully installing the dependencies, you can run SeedPass using the following command:
+After successfully installing the dependencies, install the package with:
+
+```bash
+python -m pip install -e .
+```
+
+Once installed, you can run SeedPass using the following command:
 
 ```bash
 python src/main.py

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -150,6 +150,7 @@ When upgrading pip, use `python -m pip` inside the virtual environment so that p
 ```bash
 python -m pip install --upgrade pip
 python -m pip install -r src/requirements.txt
+python -m pip install -e .
 ```
 
 #### Linux Clipboard Support
@@ -164,8 +165,9 @@ sudo apt-get install xclip
 
 ## Quick Start
 
-After installing dependencies and activating your virtual environment, launch
-SeedPass and create a backup:
+After installing dependencies, activate your virtual environment and install
+the package so the `seedpass` command is available, then launch SeedPass and
+create a backup:
 
 ```bash
 # Start the application
@@ -223,7 +225,8 @@ After successfully installing the dependencies, you can run SeedPass using the f
 python src/main.py
 ```
 
-You can also use the new Typer-based CLI:
+You can also use the Typer-based command line interface once the
+package is installed:
 ```bash
 seedpass --help
 ```

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -255,6 +255,11 @@ if ($LASTEXITCODE -ne 0) {
     Write-Error "Dependency installation failed."
 }
 
+& "$VenvDir\Scripts\python.exe" -m pip install -e .
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to install SeedPass package"
+}
+
 # 5. Create launcher script
 Write-Info "Creating launcher script..."
 if (-not (Test-Path $LauncherDir)) { New-Item -ItemType Directory -Path $LauncherDir | Out-Null }
@@ -263,7 +268,7 @@ $LauncherContent = @"
 @echo off
 setlocal
 call "%~dp0..\venv\Scripts\activate.bat"
-python "%~dp0..\src\main.py" %*
+"%~dp0..\venv\Scripts\python.exe" -m seedpass.cli %*
 endlocal
 "@
 Set-Content -Path $LauncherPath -Value $LauncherContent -Force

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,6 +119,7 @@ main() {
     print_info "Installing/updating Python dependencies from src/requirements.txt..."
     pip install --upgrade pip
     pip install -r src/requirements.txt
+    pip install -e .
     deactivate
 
     # 7. Create launcher script
@@ -127,7 +128,7 @@ main() {
     cat > "$LAUNCHER_PATH" << EOF2
 #!/bin/bash
 source "$VENV_DIR/bin/activate"
-exec python3 "$INSTALL_DIR/src/main.py" "\$@"
+exec "$VENV_DIR/bin/python" -m seedpass.cli "\$@"
 EOF2
     chmod +x "$LAUNCHER_PATH"
 


### PR DESCRIPTION
## Summary
- install SeedPass package so the `seedpass` command is available
- update launcher scripts to run the Typer CLI
- document editable install in README and docs

## Testing
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68706fe5e5fc832b963eab17ff9b3f6a