### PR TITLE
Clarify CLI reinstall steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ python -m pip install -r src/requirements.txt
 python -m pip install -e .
 ```
 
+If you previously installed an older version of SeedPass, the `seedpass`
+command might still point to the legacy `main.py` script. Run
+`pip uninstall seedpass` and then reinstall with the command above to
+register the new Typer-based CLI.
+
+After reinstalling, run `which seedpass` on Linux/macOS or `where seedpass`
+on Windows to confirm the command resolves to your virtual environment's
+`seedpass` executable.
+
 #### Linux Clipboard Support
 
 On Linux, `pyperclip` relies on external utilities like `xclip` or `xsel`.
@@ -241,6 +250,15 @@ python src/main.py
 You can also use the new Typer-based CLI:
 ```bash
 seedpass --help
+```
+If this command displays `usage: main.py` instead of the Typer help
+output, an old `seedpass` executable is still on your `PATH`. Remove it
+with `pip uninstall seedpass` or delete the stale launcher and rerun
+`python -m pip install -e .`.
+You can confirm which executable will run with:
+
+```bash
+which seedpass  # or 'where seedpass' on Windows
 ```
 For a full list of commands see [docs/advanced_cli.md](docs/advanced_cli.md). The REST API is described in [docs/api_reference.md](docs/api_reference.md).
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -273,6 +273,12 @@ endlocal
 "@
 Set-Content -Path $LauncherPath -Value $LauncherContent -Force
 
+$existingSeedpass = Get-Command seedpass -ErrorAction SilentlyContinue
+if ($existingSeedpass -and $existingSeedpass.Source -ne $LauncherPath) {
+    Write-Warning "Another 'seedpass' command was found at $($existingSeedpass.Source)."
+    Write-Warning "Ensure '$LauncherDir' comes first in your PATH or remove the old installation."
+}
+
 # 6. Add launcher directory to User's PATH if needed
 Write-Info "Checking if '$LauncherDir' is in your PATH..."
 $UserPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
@@ -287,3 +293,4 @@ if (($UserPath -split ';') -notcontains $LauncherDir) {
 
 Write-Success "Installation/update complete!"
 Write-Info "To run the application, please open a NEW terminal window and type: seedpass"
+Write-Info "'seedpass' resolves to: $(Get-Command seedpass | Select-Object -ExpandProperty Source)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -132,9 +132,16 @@ exec "$VENV_DIR/bin/python" -m seedpass.cli "\$@"
 EOF2
     chmod +x "$LAUNCHER_PATH"
 
+    existing_cmd=$(command -v seedpass 2>/dev/null || true)
+    if [ -n "$existing_cmd" ] && [ "$existing_cmd" != "$LAUNCHER_PATH" ]; then
+        print_warning "Another 'seedpass' command was found at $existing_cmd."
+        print_warning "Ensure '$LAUNCHER_DIR' comes first in your PATH or remove the old installation."
+    fi
+
     # 8. Final instructions
     print_success "Installation/update complete!"
     print_info "You can now run the application by typing: seedpass"
+    print_info "'seedpass' resolves to: $(command -v seedpass)"
     if [[ ":$PATH:" != *":$LAUNCHER_DIR:"* ]]; then
         print_warning "Directory '$LAUNCHER_DIR' is not in your PATH."
         print_warning "Please add 'export PATH=\"$HOME/.local/bin:$PATH\"' to your shell's config file (e.g., ~/.bashrc, ~/.zshrc) and restart your terminal."


### PR DESCRIPTION
## Summary
- clarify README instructions on checking `seedpass` path after reinstall
- show final resolved path in install scripts

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_687073a5fd10832b93a9a941feeef146