### PR TITLE
Handle rm failures in uninstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Run the matching uninstaller if you need to remove a previous installation or cl
 ```bash
 bash -c "$(curl -sSL https://raw.githubusercontent.com/PR0M3TH3AN/SeedPass/main/scripts/uninstall.sh)"
 ```
+If you see a warning that an old executable couldn't be removed, delete the file manually.
 
 **Windows (PowerShell):**
 ```powershell

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -102,6 +102,7 @@ Run the matching uninstaller if you need to remove a previous installation or cl
 ```bash
 bash -c "$(curl -sSL https://raw.githubusercontent.com/PR0M3TH3AN/SeedPass/main/scripts/uninstall.sh)"
 ```
+If the script warns that it couldn't remove an executable, delete that file manually.
 
 **Windows (PowerShell):**
 ```powershell

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -22,7 +22,14 @@ remove_stale_executables() {
         candidate="$dir/seedpass"
         if [ -f "$candidate" ] && [ "$candidate" != "$LAUNCHER_PATH" ]; then
             print_info "Removing old executable '$candidate'..."
-            rm -f "$candidate" || true
+            if rm -f "$candidate"; then
+                rm_status=0
+            else
+                rm_status=$?
+            fi
+            if [ $rm_status -ne 0 ] && [ -f "$candidate" ]; then
+                print_warning "Failed to remove $candidate – try deleting it manually"
+            fi
         fi
     done
 }


### PR DESCRIPTION
## Summary
- warn if uninstall can't remove a stale executable
- document manual removal step

## Testing
- `black .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687121acba30832b847ad33b69bacc62