### PR TITLE
Fix SeedPass CLI launcher

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -125,10 +125,10 @@ main() {
     # 7. Create launcher script
     print_info "Creating launcher script at '$LAUNCHER_PATH'..."
     mkdir -p "$LAUNCHER_DIR"
-    cat > "$LAUNCHER_PATH" << EOF2
+cat > "$LAUNCHER_PATH" << EOF2
 #!/bin/bash
 source "$VENV_DIR/bin/activate"
-exec "$VENV_DIR/bin/python" -m seedpass.cli "\$@"
+exec "$VENV_DIR/bin/seedpass" "\$@"
 EOF2
     chmod +x "$LAUNCHER_PATH"
 

--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -573,3 +573,7 @@ def api_stop(ctx: typer.Context, host: str = "127.0.0.1", port: int = 8000) -> N
         )
     except Exception as exc:  # pragma: no cover - best effort
         typer.echo(f"Failed to stop server: {exc}")
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- ensure CLI runs when called directly
- adjust install launcher to use generated entrypoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68712431d42c832bb351df48e49c8c3f