### PR TITLE
Document how to launch SeedPass TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,12 @@ After installing dependencies and activating your virtual environment, install t
 python -m pip install -e .
 ```
 
+
 You can then launch SeedPass and create a backup:
 
 ```bash
-# Start the application
-python src/main.py
+# Start the application (interactive TUI)
+seedpass
 
 # Export your index
 seedpass export --file "~/seedpass_backup.json"
@@ -216,13 +217,19 @@ After successfully installing the dependencies, install the package with:
 python -m pip install -e .
 ```
 
-Once installed, you can run SeedPass using the following command:
+Once installed, launch the interactive TUI with:
+
+```bash
+seedpass
+```
+
+You can also run directly from the repository with:
 
 ```bash
 python src/main.py
 ```
 
-You can also use the new Typer-based CLI:
+You can explore other CLI commands using:
 
 ```bash
 seedpass --help
@@ -247,8 +254,9 @@ For a full list of commands see [docs/advanced_cli.md](docs/advanced_cli.md). Th
 1. **Start the Application:**
 
    ```bash
-   python src/main.py
+   seedpass
    ```
+   *(or `python src/main.py` when running directly from the repository)*
 
 2. **Follow the Prompts:**
 

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -186,7 +186,7 @@ create a backup:
 
 ```bash
 # Start the application
-python src/main.py
+seedpass
 
 # Export your index
 seedpass export --file "~/seedpass_backup.json"
@@ -234,14 +234,19 @@ The encrypted index file `seedpass_entries_db.json.enc` begins with `schema_vers
 
 ## Usage
 
-After successfully installing the dependencies, you can run SeedPass using the following command:
+After successfully installing the dependencies, launch the interactive TUI with:
+
+```bash
+seedpass
+```
+
+You can also run directly from the repository using:
 
 ```bash
 python src/main.py
 ```
 
-You can also use the Typer-based command line interface once the
-package is installed:
+You can explore other CLI commands using:
 ```bash
 seedpass --help
 ```
@@ -252,8 +257,9 @@ For a full list of commands see [docs/advanced_cli.md](docs/advanced_cli.md). Th
 1. **Start the Application:**
 
     ```bash
-    python src/main.py
+    seedpass
     ```
+    *(or `python src/main.py` if running directly from the repository)*
 
 2. **Follow the Prompts:**
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -292,5 +292,5 @@ if (($UserPath -split ';') -notcontains $LauncherDir) {
 }
 
 Write-Success "Installation/update complete!"
-Write-Info "To run the application, please open a NEW terminal window and type: seedpass"
+Write-Info "To launch the interactive TUI, open a NEW terminal window and run: seedpass"
 Write-Info "'seedpass' resolves to: $(Get-Command seedpass | Select-Object -ExpandProperty Source)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -140,7 +140,7 @@ EOF2
 
     # 8. Final instructions
     print_success "Installation/update complete!"
-    print_info "You can now run the application by typing: seedpass"
+    print_info "You can now launch the interactive TUI by typing: seedpass"
     print_info "'seedpass' resolves to: $(command -v seedpass)"
     if [[ ":$PATH:" != *":$LAUNCHER_DIR:"* ]]; then
         print_warning "Directory '$LAUNCHER_DIR' is not in your PATH."


### PR DESCRIPTION
## Summary
- tell users to launch the interactive TUI with `seedpass`
- note the TUI command in both install scripts

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68713b8a4e8c832b8710bcc072b3c8e2