### PR TITLE
Fix fingerprint option in SeedPass CLI

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -102,8 +102,14 @@ class PasswordManager:
     verification, ensuring the integrity and confidentiality of the stored password database.
     """
 
-    def __init__(self) -> None:
-        """Initialize the PasswordManager."""
+    def __init__(self, fingerprint: Optional[str] = None) -> None:
+        """Initialize the PasswordManager.
+
+        Parameters
+        ----------
+        fingerprint:
+            Optional seed profile fingerprint to select without prompting.
+        """
         initialize_app()
         self.ensure_script_checksum()
         self.encryption_mode: EncryptionMode = EncryptionMode.SEED_ONLY
@@ -131,11 +137,16 @@ class PasswordManager:
         # Initialize the fingerprint manager first
         self.initialize_fingerprint_manager()
 
-        # Ensure a parent seed is set up before accessing the fingerprint directory
-        self.setup_parent_seed()
-
-        # Set the current fingerprint directory
-        self.fingerprint_dir = self.fingerprint_manager.get_current_fingerprint_dir()
+        if fingerprint:
+            # Load the specified profile without prompting
+            self.select_fingerprint(fingerprint)
+        else:
+            # Ensure a parent seed is set up before accessing the fingerprint directory
+            self.setup_parent_seed()
+            # Set the current fingerprint directory after selection
+            self.fingerprint_dir = (
+                self.fingerprint_manager.get_current_fingerprint_dir()
+            )
 
     def ensure_script_checksum(self) -> None:
         """Initialize or verify the checksum of the manager script."""

--- a/src/seedpass/api.py
+++ b/src/seedpass/api.py
@@ -51,9 +51,10 @@ def start_server(fingerprint: str | None = None) -> str:
         Optional seed profile fingerprint to select before starting the server.
     """
     global _pm, _token
-    _pm = PasswordManager()
-    if fingerprint:
-        _pm.select_fingerprint(fingerprint)
+    if fingerprint is None:
+        _pm = PasswordManager()
+    else:
+        _pm = PasswordManager(fingerprint=fingerprint)
     _token = secrets.token_urlsafe(16)
     print(f"API token: {_token}")
     origins = [

--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -44,11 +44,11 @@ app.add_typer(api_app, name="api")
 
 def _get_pm(ctx: typer.Context) -> PasswordManager:
     """Return a PasswordManager optionally selecting a fingerprint."""
-    pm = PasswordManager()
     fp = ctx.obj.get("fingerprint")
-    if fp:
-        # `select_fingerprint` will initialize managers
-        pm.select_fingerprint(fp)
+    if fp is None:
+        pm = PasswordManager()
+    else:
+        pm = PasswordManager(fingerprint=fp)
     return pm
 
 


### PR DESCRIPTION
## Summary
- avoid interactive fingerprint prompt if the --fingerprint option is supplied
- update API server helper accordingly

## Testing
- `black src/seedpass/api.py src/seedpass/cli.py src/password_manager/manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871427bcbb4832b81b4f33d151cdbff