### PR TITLE
Add vault sync to CLI entry commands

### DIFF
--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -150,6 +150,7 @@ def entry_add(
     pm = _get_pm(ctx)
     index = pm.entry_manager.add_entry(label, length, username, url)
     typer.echo(str(index))
+    pm.sync_vault()
 
 
 @entry_app.command("add-totp")
@@ -172,6 +173,7 @@ def entry_add_totp(
         digits=digits,
     )
     typer.echo(uri)
+    pm.sync_vault()
 
 
 @entry_app.command("add-ssh")
@@ -190,6 +192,7 @@ def entry_add_ssh(
         notes=notes,
     )
     typer.echo(str(idx))
+    pm.sync_vault()
 
 
 @entry_app.command("add-pgp")
@@ -212,6 +215,7 @@ def entry_add_pgp(
         notes=notes,
     )
     typer.echo(str(idx))
+    pm.sync_vault()
 
 
 @entry_app.command("add-nostr")
@@ -229,6 +233,7 @@ def entry_add_nostr(
         notes=notes,
     )
     typer.echo(str(idx))
+    pm.sync_vault()
 
 
 @entry_app.command("add-seed")
@@ -249,6 +254,7 @@ def entry_add_seed(
         notes=notes,
     )
     typer.echo(str(idx))
+    pm.sync_vault()
 
 
 @entry_app.command("add-key-value")
@@ -262,6 +268,7 @@ def entry_add_key_value(
     pm = _get_pm(ctx)
     idx = pm.entry_manager.add_key_value(label, value, notes=notes)
     typer.echo(str(idx))
+    pm.sync_vault()
 
 
 @entry_app.command("add-managed-account")
@@ -280,6 +287,7 @@ def entry_add_managed_account(
         notes=notes,
     )
     typer.echo(str(idx))
+    pm.sync_vault()
 
 
 @entry_app.command("modify")
@@ -308,6 +316,7 @@ def entry_modify(
         digits=digits,
         value=value,
     )
+    pm.sync_vault()
 
 
 @entry_app.command("archive")
@@ -316,6 +325,7 @@ def entry_archive(ctx: typer.Context, entry_id: int) -> None:
     pm = _get_pm(ctx)
     pm.entry_manager.archive_entry(entry_id)
     typer.echo(str(entry_id))
+    pm.sync_vault()
 
 
 @entry_app.command("unarchive")
@@ -324,6 +334,7 @@ def entry_unarchive(ctx: typer.Context, entry_id: int) -> None:
     pm = _get_pm(ctx)
     pm.entry_manager.restore_entry(entry_id)
     typer.echo(str(entry_id))
+    pm.sync_vault()
 
 
 @entry_app.command("totp-codes")

--- a/src/tests/test_cli_entry_add_commands.py
+++ b/src/tests/test_cli_entry_add_commands.py
@@ -103,6 +103,7 @@ def test_entry_add_commands(
         entry_manager=SimpleNamespace(**{method: func}),
         parent_seed="seed",
         select_fingerprint=lambda fp: None,
+        sync_vault=lambda: None,
     )
     monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
     result = runner.invoke(app, ["entry", command] + cli_args)

--- a/src/tests/test_typer_cli.py
+++ b/src/tests/test_typer_cli.py
@@ -332,6 +332,7 @@ def test_entry_add(monkeypatch):
     pm = SimpleNamespace(
         entry_manager=SimpleNamespace(add_entry=add_entry),
         select_fingerprint=lambda fp: None,
+        sync_vault=lambda: None,
     )
     monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
     result = runner.invoke(
@@ -362,6 +363,7 @@ def test_entry_modify(monkeypatch):
     pm = SimpleNamespace(
         entry_manager=SimpleNamespace(modify_entry=modify_entry),
         select_fingerprint=lambda fp: None,
+        sync_vault=lambda: None,
     )
     monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
     result = runner.invoke(app, ["entry", "modify", "1", "--username", "alice"])
@@ -378,6 +380,7 @@ def test_entry_archive(monkeypatch):
     pm = SimpleNamespace(
         entry_manager=SimpleNamespace(archive_entry=archive_entry),
         select_fingerprint=lambda fp: None,
+        sync_vault=lambda: None,
     )
     monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
     result = runner.invoke(app, ["entry", "archive", "3"])
@@ -395,6 +398,7 @@ def test_entry_unarchive(monkeypatch):
     pm = SimpleNamespace(
         entry_manager=SimpleNamespace(restore_entry=restore_entry),
         select_fingerprint=lambda fp: None,
+        sync_vault=lambda: None,
     )
     monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
     result = runner.invoke(app, ["entry", "unarchive", "4"])


### PR DESCRIPTION
## Summary
- trigger `pm.sync_vault()` after any CLI command that alters entries
- adjust CLI tests for new sync behavior

## Testing
- `black src/seedpass/cli.py`
- `black src/tests/test_cli_entry_add_commands.py src/tests/test_typer_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68719fd84a60832bb2f830d65d9fc54a