### PR TITLE
Ensure CLI add commands trigger sync

### DIFF
--- a/src/tests/test_cli_entry_add_commands.py
+++ b/src/tests/test_cli_entry_add_commands.py
@@ -12,6 +12,22 @@ runner = CliRunner()
     "command,method,cli_args,expected_args,expected_kwargs,stdout",
     [
         (
+            "add",
+            "add_entry",
+            [
+                "Label",
+                "--length",
+                "16",
+                "--username",
+                "user",
+                "--url",
+                "https://example.com",
+            ],
+            ("Label", 16, "user", "https://example.com"),
+            {},
+            "1",
+        ),
+        (
             "add-totp",
             "add_totp",
             [
@@ -99,11 +115,14 @@ def test_entry_add_commands(
         called["kwargs"] = kwargs
         return stdout
 
+    def sync_vault():
+        called["sync"] = True
+
     pm = SimpleNamespace(
         entry_manager=SimpleNamespace(**{method: func}),
         parent_seed="seed",
         select_fingerprint=lambda fp: None,
-        sync_vault=lambda: None,
+        sync_vault=sync_vault,
     )
     monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
     result = runner.invoke(app, ["entry", command] + cli_args)
@@ -111,3 +130,4 @@ def test_entry_add_commands(
     assert stdout in result.stdout
     assert called["args"] == expected_args
     assert called["kwargs"] == expected_kwargs
+    assert called.get("sync") is True


### PR DESCRIPTION
## Summary
- extend tests covering CLI entry add commands
- verify each command triggers `sync_vault`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871a712bcfc832b8da1450476c97868