### PR TITLE
Document Nostr sync on vault import

### DIFF
--- a/docs/docs/content/01-getting-started/01-advanced_cli.md
+++ b/docs/docs/content/01-getting-started/01-advanced_cli.md
@@ -70,7 +70,7 @@ Manage the entire vault for a profile.
 | Action | Command | Examples |
 | :--- | :--- | :--- |
 | Export the vault | `vault export` | `seedpass vault export --file backup.json` |
-| Import a vault | `vault import` | `seedpass vault import --file backup.json` |
+| Import a vault | `vault import` | `seedpass vault import --file backup.json` *(also syncs with Nostr)* |
 | Change the master password | `vault change-password` | `seedpass vault change-password` |
 | Lock the vault | `vault lock` | `seedpass vault lock` |
 | Show profile statistics | `vault stats` | `seedpass vault stats` |
@@ -158,7 +158,7 @@ Code: 123456
 ### `vault` Commands
 
 - **`seedpass vault export`** – Export the entire vault to an encrypted JSON file.
-- **`seedpass vault import`** – Import a vault from an encrypted JSON file.
+- **`seedpass vault import`** – Import a vault from an encrypted JSON file and automatically sync via Nostr.
 - **`seedpass vault change-password`** – Change the master password used for encryption.
 - **`seedpass vault lock`** – Clear sensitive data from memory and require reauthentication.
 - **`seedpass vault stats`** – Display statistics about the active seed profile.

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -193,6 +193,7 @@ seedpass export --file "~/seedpass_backup.json"
 
 # Later you can restore it
 seedpass import --file "~/seedpass_backup.json"
+# Import also performs a Nostr sync to pull any changes
 
 # Quickly find or retrieve entries
 seedpass search "github"
@@ -398,7 +399,7 @@ Back in the Settings menu you can:
 * Select `5` to generate a new script checksum.
 * Choose `6` to back up the parent seed.
 * Select `7` to export the database to an encrypted file.
-* Choose `8` to import a database from a backup file.
+* Choose `8` to import a database from a backup file. This also performs a Nostr sync automatically.
 * Select `9` to export all 2FA codes.
 * Choose `10` to set an additional backup location. A backup is created
   immediately after the directory is configured.


### PR DESCRIPTION
## Summary
- mention that `seedpass vault import` automatically triggers a Nostr sync in the advanced CLI docs
- note the same behavior in the index backup section

## Testing
- `python3 -m venv venv`
- `pip install -r src/requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871a95168cc832b8a1026266984ac0e