### PR TITLE
Add unlock timing output

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -133,6 +133,7 @@ class PasswordManager:
         self.secret_mode_enabled: bool = False
         self.clipboard_clear_delay: int = 45
         self.profile_stack: list[tuple[str, Path, str]] = []
+        self.last_unlock_duration: float | None = None
 
         # Initialize the fingerprint manager first
         self.initialize_fingerprint_manager()
@@ -225,6 +226,7 @@ class PasswordManager:
 
     def unlock_vault(self) -> None:
         """Prompt for password and reinitialize managers."""
+        start = time.perf_counter()
         if not self.fingerprint_dir:
             raise ValueError("Fingerprint directory not set")
         self.setup_encryption_manager(self.fingerprint_dir)
@@ -233,6 +235,13 @@ class PasswordManager:
         self.locked = False
         self.update_activity()
         self.sync_index_from_nostr()
+        self.last_unlock_duration = time.perf_counter() - start
+        print(
+            colored(
+                f"Vault unlocked in {self.last_unlock_duration:.2f} seconds",
+                "yellow",
+            )
+        )
 
     def initialize_fingerprint_manager(self):
         """


### PR DESCRIPTION
## Summary
- track unlock duration in `PasswordManager`
- print unlock time after unlocking the vault

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871c0f7e070832bb1cc70307a8446e8