### PR TITLE
Improve seed profile selection

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -276,13 +276,16 @@ class PasswordManager:
         try:
             fingerprints = self.fingerprint_manager.list_fingerprints()
             current = self.fingerprint_manager.current_fingerprint
-            if current and current in fingerprints:
-                self.select_fingerprint(current)
+
+            # Auto-select when only one fingerprint exists
+            if len(fingerprints) == 1:
+                self.select_fingerprint(fingerprints[0])
                 return
 
             print(colored("\nAvailable Seed Profiles:", "cyan"))
             for idx, fp in enumerate(fingerprints, start=1):
-                print(colored(f"{idx}. {fp}", "cyan"))
+                marker = " *" if fp == current else ""
+                print(colored(f"{idx}. {fp}{marker}", "cyan"))
 
             print(colored(f"{len(fingerprints)+1}. Add a new seed profile", "cyan"))
 

--- a/src/tests/test_multiple_fingerprint_prompt.py
+++ b/src/tests/test_multiple_fingerprint_prompt.py
@@ -1,0 +1,64 @@
+import importlib
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import constants
+import password_manager.manager as manager_module
+from utils.fingerprint_manager import FingerprintManager
+
+from helpers import TEST_SEED
+
+OTHER_SEED = (
+    "legal winner thank year wave sausage worth useful legal winner thank yellow"
+)
+
+
+def test_prompt_when_multiple_fingerprints(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        importlib.reload(constants)
+        importlib.reload(manager_module)
+
+        fm = FingerprintManager(constants.APP_DIR)
+        fp1 = fm.add_fingerprint(TEST_SEED)
+        fm.add_fingerprint(OTHER_SEED)
+
+        def init_fm(self):
+            self.fingerprint_manager = fm
+
+        monkeypatch.setattr(
+            manager_module.PasswordManager, "initialize_fingerprint_manager", init_fm
+        )
+        monkeypatch.setattr(
+            manager_module.PasswordManager,
+            "setup_encryption_manager",
+            lambda *a, **k: True,
+        )
+        monkeypatch.setattr(
+            manager_module.PasswordManager, "initialize_bip85", lambda self: None
+        )
+        monkeypatch.setattr(
+            manager_module.PasswordManager, "initialize_managers", lambda self: None
+        )
+        monkeypatch.setattr(
+            manager_module.PasswordManager,
+            "sync_index_from_nostr_if_missing",
+            lambda self: None,
+        )
+        monkeypatch.setattr(
+            manager_module.PasswordManager, "verify_password", lambda *a, **k: True
+        )
+
+        calls = {"count": 0}
+
+        def fake_input(*args, **kwargs):
+            calls["count"] += 1
+            return "1"  # select first fingerprint
+
+        monkeypatch.setattr("builtins.input", fake_input)
+
+        pm = manager_module.PasswordManager()
+        assert calls["count"] == 1
+        assert pm.current_fingerprint == fp1


### PR DESCRIPTION
## Summary
- prompt for seed profile choice if multiple exist
- automatically select the profile when only one exists
- highlight the current profile in the menu
- test prompt behavior with multiple profiles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871c44195a4832b8fac91c96f659820