### PR TITLE
Refactor sync trigger to background thread

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -741,6 +741,7 @@ def handle_settings(password_manager: PasswordManager) -> None:
             password_manager.lock_vault()
             print(colored("Vault locked. Please re-enter your password.", "yellow"))
             password_manager.unlock_vault()
+            password_manager.start_background_sync()
             pause()
         elif choice == "13":
             handle_display_stats(password_manager)
@@ -777,6 +778,7 @@ def display_menu(
     if callable(display_fn):
         display_fn()
         pause()
+    password_manager.start_background_sync()
     while True:
         fp, parent_fp, child_fp = getattr(
             password_manager,
@@ -793,6 +795,7 @@ def display_menu(
             print(colored("Session timed out. Vault locked.", "yellow"))
             password_manager.lock_vault()
             password_manager.unlock_vault()
+            password_manager.start_background_sync()
             continue
         # Periodically push updates to Nostr
         if (
@@ -815,6 +818,7 @@ def display_menu(
             print(colored("Session timed out. Vault locked.", "yellow"))
             password_manager.lock_vault()
             password_manager.unlock_vault()
+            password_manager.start_background_sync()
             continue
         password_manager.update_activity()
         if not choice:

--- a/src/tests/test_auto_sync.py
+++ b/src/tests/test_auto_sync.py
@@ -22,6 +22,7 @@ def test_auto_sync_triggers_post(monkeypatch):
         update_activity=lambda: None,
         lock_vault=lambda: None,
         unlock_vault=lambda: None,
+        start_background_sync=lambda: None,
     )
 
     called = False

--- a/src/tests/test_cli_invalid_input.py
+++ b/src/tests/test_cli_invalid_input.py
@@ -46,6 +46,7 @@ def _make_pm(called, locked=None):
         update_activity=update,
         lock_vault=lock,
         unlock_vault=unlock,
+        start_background_sync=lambda: None,
     )
     return pm, locked
 

--- a/src/tests/test_inactivity_lock.py
+++ b/src/tests/test_inactivity_lock.py
@@ -34,6 +34,7 @@ def test_inactivity_triggers_lock(monkeypatch):
         update_activity=update_activity,
         lock_vault=lock_vault,
         unlock_vault=unlock_vault,
+        start_background_sync=lambda: None,
     )
 
     monkeypatch.setattr(main, "timed_input", lambda *_: "")
@@ -70,6 +71,7 @@ def test_input_timeout_triggers_lock(monkeypatch):
         update_activity=update_activity,
         lock_vault=lock_vault,
         unlock_vault=unlock_vault,
+        start_background_sync=lambda: None,
     )
 
     responses = iter([TimeoutError(), ""])

--- a/src/tests/test_menu_navigation.py
+++ b/src/tests/test_menu_navigation.py
@@ -30,6 +30,7 @@ def _make_pm(calls):
         update_activity=lambda: None,
         lock_vault=lambda: None,
         unlock_vault=lambda: None,
+        start_background_sync=lambda: None,
     )
 
 

--- a/src/tests/test_menu_options.py
+++ b/src/tests/test_menu_options.py
@@ -24,6 +24,7 @@ def _make_pm(calls):
         update_activity=lambda: None,
         lock_vault=lambda: None,
         unlock_vault=lambda: None,
+        start_background_sync=lambda: None,
     )
 
 

--- a/src/tests/test_menu_search.py
+++ b/src/tests/test_menu_search.py
@@ -23,6 +23,7 @@ def _make_pm(called):
         update_activity=lambda: None,
         lock_vault=lambda: None,
         unlock_vault=lambda: None,
+        start_background_sync=lambda: None,
     )
     return pm
 

--- a/src/tests/test_unlock_sync.py
+++ b/src/tests/test_unlock_sync.py
@@ -22,5 +22,7 @@ def test_unlock_triggers_sync(monkeypatch, tmp_path):
     monkeypatch.setattr(PasswordManager, "sync_index_from_nostr", fake_sync)
 
     pm.unlock_vault()
+    pm.start_background_sync()
+    time.sleep(0.05)
 
     assert called["sync"]


### PR DESCRIPTION
## Summary
- avoid blocking Nostr sync during unlock
- add `start_background_sync` helper
- call background sync from menu loop
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871c97a1524832b973d98b8d19c6197