### PR TITLE
Lazy initialization for NostrClient

### DIFF
--- a/src/tests/test_nostr_client.py
+++ b/src/tests/test_nostr_client.py
@@ -88,6 +88,7 @@ def _setup_client(tmpdir, fake_cls):
 def test_initialize_client_pool_add_relays_used(tmp_path):
     client = _setup_client(tmp_path, FakeAddRelaysClient)
     fc = client.client
+    client.connect()
     assert fc.added == [client.relays]
     assert fc.connected is True
 
@@ -95,6 +96,7 @@ def test_initialize_client_pool_add_relays_used(tmp_path):
 def test_initialize_client_pool_add_relay_fallback(tmp_path):
     client = _setup_client(tmp_path, FakeAddRelayClient)
     fc = client.client
+    client.connect()
     assert fc.added == client.relays
     assert fc.connected is True
 


### PR DESCRIPTION
## Summary
- avoid connecting to relays during `NostrClient` instantiation
- provide `connect()` and connect lazily on the first publish/fetch
- adjust tests for the new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871cbc8f8c8832b86931e27efd31786