### PR TITLE
Run relay health checks async

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -742,6 +742,7 @@ def handle_settings(password_manager: PasswordManager) -> None:
             print(colored("Vault locked. Please re-enter your password.", "yellow"))
             password_manager.unlock_vault()
             password_manager.start_background_sync()
+            getattr(password_manager, "start_background_relay_check", lambda: None)()
             pause()
         elif choice == "13":
             handle_display_stats(password_manager)
@@ -779,6 +780,7 @@ def display_menu(
         display_fn()
         pause()
     password_manager.start_background_sync()
+    getattr(password_manager, "start_background_relay_check", lambda: None)()
     while True:
         fp, parent_fp, child_fp = getattr(
             password_manager,
@@ -796,6 +798,7 @@ def display_menu(
             password_manager.lock_vault()
             password_manager.unlock_vault()
             password_manager.start_background_sync()
+            getattr(password_manager, "start_background_relay_check", lambda: None)()
             continue
         # Periodically push updates to Nostr
         if (
@@ -819,6 +822,7 @@ def display_menu(
             password_manager.lock_vault()
             password_manager.unlock_vault()
             password_manager.start_background_sync()
+            getattr(password_manager, "start_background_relay_check", lambda: None)()
             continue
         password_manager.update_activity()
         if not choice:

--- a/src/tests/test_auto_sync.py
+++ b/src/tests/test_auto_sync.py
@@ -23,6 +23,7 @@ def test_auto_sync_triggers_post(monkeypatch):
         lock_vault=lambda: None,
         unlock_vault=lambda: None,
         start_background_sync=lambda: None,
+        start_background_relay_check=lambda: None,
     )
 
     called = False

--- a/src/tests/test_background_relay_check.py
+++ b/src/tests/test_background_relay_check.py
@@ -1,0 +1,23 @@
+import time
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from password_manager.manager import PasswordManager
+from constants import MIN_HEALTHY_RELAYS
+
+
+def test_background_relay_check_runs_async(monkeypatch):
+    pm = PasswordManager.__new__(PasswordManager)
+    called = {"args": None}
+    pm.nostr_client = SimpleNamespace(
+        check_relay_health=lambda min_relays: called.__setitem__("args", min_relays)
+        or min_relays
+    )
+
+    pm.start_background_relay_check()
+    time.sleep(0.05)
+
+    assert called["args"] == MIN_HEALTHY_RELAYS

--- a/src/tests/test_cli_invalid_input.py
+++ b/src/tests/test_cli_invalid_input.py
@@ -47,6 +47,7 @@ def _make_pm(called, locked=None):
         lock_vault=lock,
         unlock_vault=unlock,
         start_background_sync=lambda: None,
+        start_background_relay_check=lambda: None,
     )
     return pm, locked
 

--- a/src/tests/test_inactivity_lock.py
+++ b/src/tests/test_inactivity_lock.py
@@ -35,6 +35,7 @@ def test_inactivity_triggers_lock(monkeypatch):
         lock_vault=lock_vault,
         unlock_vault=unlock_vault,
         start_background_sync=lambda: None,
+        start_background_relay_check=lambda: None,
     )
 
     monkeypatch.setattr(main, "timed_input", lambda *_: "")
@@ -72,6 +73,7 @@ def test_input_timeout_triggers_lock(monkeypatch):
         lock_vault=lock_vault,
         unlock_vault=unlock_vault,
         start_background_sync=lambda: None,
+        start_background_relay_check=lambda: None,
     )
 
     responses = iter([TimeoutError(), ""])

--- a/src/tests/test_menu_navigation.py
+++ b/src/tests/test_menu_navigation.py
@@ -31,6 +31,7 @@ def _make_pm(calls):
         lock_vault=lambda: None,
         unlock_vault=lambda: None,
         start_background_sync=lambda: None,
+        start_background_relay_check=lambda: None,
     )
 
 

--- a/src/tests/test_menu_options.py
+++ b/src/tests/test_menu_options.py
@@ -25,6 +25,7 @@ def _make_pm(calls):
         lock_vault=lambda: None,
         unlock_vault=lambda: None,
         start_background_sync=lambda: None,
+        start_background_relay_check=lambda: None,
     )
 
 

--- a/src/tests/test_menu_search.py
+++ b/src/tests/test_menu_search.py
@@ -24,6 +24,7 @@ def _make_pm(called):
         lock_vault=lambda: None,
         unlock_vault=lambda: None,
         start_background_sync=lambda: None,
+        start_background_relay_check=lambda: None,
     )
     return pm
 


### PR DESCRIPTION
## Summary
- avoid blocking unlock by removing relay health check from manager initialization
- introduce `start_background_relay_check` helper
- call background relay check when showing the main menu
- update tests and add a test for the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871cd7a3090832ba52180db50eebe0f