### PR TITLE
Add debug prints during manager setup

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -386,8 +386,10 @@ class PasswordManager:
                 if getattr(self, "config_manager", None)
                 else 100_000
             )
+            print("Deriving key...")
             seed_key = derive_key_from_password(password, iterations=iterations)
             seed_mgr = EncryptionManager(seed_key, fingerprint_dir)
+            print("Decrypting seed...")
             try:
                 self.parent_seed = seed_mgr.decrypt_parent_seed()
             except Exception:
@@ -939,6 +941,7 @@ class PasswordManager:
             self.secret_mode_enabled = bool(config.get("secret_mode_enabled", False))
             self.clipboard_clear_delay = int(config.get("clipboard_clear_delay", 45))
 
+            print("Connecting to relays...")
             self.nostr_client = NostrClient(
                 encryption_manager=self.encryption_manager,
                 fingerprint=self.current_fingerprint,


### PR DESCRIPTION
## Summary
- print progress updates when deriving keys and decrypting seeds
- announce relay connection when initializing managers

## Testing
- `pytest src/tests/test_profiles.py::test_add_and_switch_fingerprint -q`

------
https://chatgpt.com/codex/tasks/task_b_687260df85e4832b8b4527f213bd7b14