### PR TITLE
Improve password retry experience

### DIFF
--- a/src/utils/password_prompt.py
+++ b/src/utils/password_prompt.py
@@ -106,44 +106,55 @@ def prompt_new_password() -> str:
     raise PasswordPromptError("Maximum password attempts exceeded")
 
 
-def prompt_existing_password(prompt_message: str = "Enter your password: ") -> str:
+def prompt_existing_password(
+    prompt_message: str = "Enter your password: ", max_retries: int = 5
+) -> str:
     """
-    Prompts the user to enter an existing password, typically used for decryption purposes.
+    Prompt the user for an existing password.
 
-    This function ensures that the password is entered securely without echoing it to the terminal.
+    The user will be reprompted on empty input up to ``max_retries`` times.
 
     Parameters:
-        prompt_message (str): The message displayed to prompt the user. Defaults to "Enter your password: ".
+        prompt_message (str): Message displayed when prompting for the password.
+        max_retries (int): Number of attempts allowed before aborting.
 
     Returns:
-        str: The password entered by the user.
+        str: The password provided by the user.
 
     Raises:
-        PasswordPromptError: If the user interrupts the operation.
+        PasswordPromptError: If the user interrupts the operation or exceeds
+            ``max_retries`` attempts.
     """
-    try:
-        password = getpass.getpass(prompt=prompt_message).strip()
+    attempts = 0
+    while attempts < max_retries:
+        try:
+            password = getpass.getpass(prompt=prompt_message).strip()
 
-        if not password:
-            print(colored("Error: Password cannot be empty.", "red"))
-            logging.warning("User attempted to enter an empty password.")
-            raise PasswordPromptError("Password cannot be empty")
+            if not password:
+                print(
+                    colored("Error: Password cannot be empty. Please try again.", "red")
+                )
+                logging.warning("User attempted to enter an empty password.")
+                attempts += 1
+                continue
 
-        # Normalize the password to NFKD form
-        normalized_password = unicodedata.normalize("NFKD", password)
-        logging.debug("User entered an existing password for decryption.")
-        return normalized_password
+            normalized_password = unicodedata.normalize("NFKD", password)
+            logging.debug("User entered an existing password for decryption.")
+            return normalized_password
 
-    except KeyboardInterrupt:
-        print(colored("\nOperation cancelled by user.", "yellow"))
-        logging.info("Existing password prompt interrupted by user.")
-        raise PasswordPromptError("Operation cancelled by user")
-    except Exception as e:
-        logging.error(
-            f"Unexpected error during existing password prompt: {e}", exc_info=True
-        )
-        print(colored(f"Error: {e}", "red"))
-        raise PasswordPromptError(str(e))
+        except KeyboardInterrupt:
+            print(colored("\nOperation cancelled by user.", "yellow"))
+            logging.info("Existing password prompt interrupted by user.")
+            raise PasswordPromptError("Operation cancelled by user")
+        except Exception as e:
+            logging.error(
+                f"Unexpected error during existing password prompt: {e}",
+                exc_info=True,
+            )
+            print(colored(f"Error: {e}", "red"))
+            attempts += 1
+
+    raise PasswordPromptError("Maximum password attempts exceeded")
 
 
 def confirm_action(


### PR DESCRIPTION
## Summary
- allow multiple retries for password entry
- retry master password setup in PasswordManager

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68726369435c832b9eb8540e07936351