### PR TITLE
Improve entry menu actions visibility

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1730,6 +1730,7 @@ class PasswordManager:
         """Provide actions for a retrieved entry."""
         while True:
             archived = entry.get("archived", entry.get("blacklisted", False))
+            entry_type = entry.get("type", EntryType.PASSWORD.value)
             print(colored("\n[+] Entry Actions:", "green"))
             if archived:
                 print(colored("U. Unarchive", "cyan"))
@@ -1740,7 +1741,12 @@ class PasswordManager:
             print(colored("H. Add Hidden Field", "cyan"))
             print(colored("E. Edit", "cyan"))
             print(colored("T. Edit Tags", "cyan"))
-            print(colored("Q. Show QR codes", "cyan"))
+            if entry_type in {
+                EntryType.SEED.value,
+                EntryType.MANAGED_ACCOUNT.value,
+                EntryType.NOSTR.value,
+            }:
+                print(colored("Q. Show QR codes", "cyan"))
 
             choice = (
                 input("Select an action or press Enter to return: ").strip().lower()


### PR DESCRIPTION
## Summary
- hide `Show QR codes` action when entry doesn't support QR codes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687298a31f40832b9bf5c143f9cc668a