### PR TITLE
Implement EntryManager index caching

### DIFF
--- a/src/tests/test_entry_add.py
+++ b/src/tests/test_entry_add.py
@@ -103,7 +103,7 @@ def test_legacy_entry_defaults_to_password():
         data["entries"][str(index)].pop("type", None)
         enc_mgr.save_json_data(data, entry_mgr.index_file)
 
-        loaded = entry_mgr._load_index()
+        loaded = entry_mgr._load_index(force_reload=True)
         assert loaded["entries"][str(index)]["type"] == "password"
 
 


### PR DESCRIPTION
## Summary
- cache index data in `EntryManager` to avoid repeated loads
- add `force_reload` and `clear_cache` to manage cache
- refresh cache after saving index
- update entry add tests for new caching behavior

## Testing
- `black src/password_manager/entry_management.py src/tests/test_entry_add.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68729e75760c832b8a968ce1abc454fd