### PR TITLE
Clear entry cache on vault lock

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -215,6 +215,8 @@ class PasswordManager:
 
     def lock_vault(self) -> None:
         """Clear sensitive information from memory."""
+        if self.entry_manager is not None:
+            self.entry_manager.clear_cache()
         self.parent_seed = None
         self.encryption_manager = None
         self.entry_manager = None


### PR DESCRIPTION
## Summary
- clear cached entry data in `PasswordManager.lock_vault`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6872a03a0638832baea3258055dd95ab