### PR TITLE
Switch to AES-GCM encryption

### DIFF
--- a/src/password_manager/portable_backup.py
+++ b/src/password_manager/portable_backup.py
@@ -74,7 +74,7 @@ def export_backup(
         "created_at": int(time.time()),
         "fingerprint": vault.fingerprint_dir.name,
         "encryption_mode": PortableMode.SEED_ONLY.value,
-        "cipher": "fernet",
+        "cipher": "aes-gcm",
         "checksum": checksum,
         "payload": base64.b64encode(payload_bytes).decode("utf-8"),
     }

--- a/src/tests/test_portable_backup.py
+++ b/src/tests/test_portable_backup.py
@@ -43,13 +43,15 @@ def test_round_trip(monkeypatch):
 
         path = export_backup(vault, backup, parent_seed=SEED)
         assert path.exists()
+        wrapper = json.loads(path.read_text())
+        assert wrapper.get("cipher") == "aes-gcm"
 
         vault.save_index({"pw": 0})
         import_backup(vault, backup, path, parent_seed=SEED)
         assert vault.load_index()["pw"] == data["pw"]
 
 
-from cryptography.fernet import InvalidToken
+from cryptography.exceptions import InvalidTag
 
 
 def test_corruption_detection(monkeypatch):
@@ -66,7 +68,7 @@ def test_corruption_detection(monkeypatch):
         content["payload"] = base64.b64encode(payload).decode()
         path.write_text(json.dumps(content))
 
-        with pytest.raises(InvalidToken):
+        with pytest.raises(InvalidTag):
             import_backup(vault, backup, path, parent_seed=SEED)
 
 


### PR DESCRIPTION
## Summary
- use AES-GCM instead of Fernet for database encryption
- store nonce with ciphertext when encrypting files
- record `"aes-gcm"` in exported backups
- update portable backup tests for new cipher

## Testing
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6872a24f2280832bbd94602566b0fc7e