### PR TITLE
Update tests for AES-GCM

### DIFF
--- a/src/tests/test_encryption_checksum.py
+++ b/src/tests/test_encryption_checksum.py
@@ -3,7 +3,8 @@ import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from cryptography.fernet import Fernet
+import os
+import base64
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -14,7 +15,7 @@ from utils.checksum import verify_and_update_checksum
 def test_encryption_checksum_workflow():
     with TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
-        key = Fernet.generate_key()
+        key = base64.urlsafe_b64encode(os.urandom(32))
         manager = EncryptionManager(key, tmp_path)
 
         data = {"value": 1}

--- a/src/tests/test_encryption_files.py
+++ b/src/tests/test_encryption_files.py
@@ -3,7 +3,8 @@ import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from cryptography.fernet import Fernet
+import os
+import base64
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -12,7 +13,7 @@ from password_manager.encryption import EncryptionManager
 
 def test_json_save_and_load_round_trip():
     with TemporaryDirectory() as tmpdir:
-        key = Fernet.generate_key()
+        key = base64.urlsafe_b64encode(os.urandom(32))
         manager = EncryptionManager(key, Path(tmpdir))
 
         data = {"hello": "world", "nums": [1, 2, 3]}
@@ -27,7 +28,7 @@ def test_json_save_and_load_round_trip():
 
 def test_encrypt_and_decrypt_file_binary_round_trip():
     with TemporaryDirectory() as tmpdir:
-        key = Fernet.generate_key()
+        key = base64.urlsafe_b64encode(os.urandom(32))
         manager = EncryptionManager(key, Path(tmpdir))
 
         payload = b"binary secret"

--- a/src/tests/test_fingerprint_encryption.py
+++ b/src/tests/test_fingerprint_encryption.py
@@ -3,7 +3,8 @@ import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from cryptography.fernet import Fernet
+import os
+import base64
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -24,7 +25,7 @@ def test_generate_fingerprint_deterministic():
 
 def test_encryption_round_trip():
     with TemporaryDirectory() as tmpdir:
-        key = Fernet.generate_key()
+        key = base64.urlsafe_b64encode(os.urandom(32))
         manager = EncryptionManager(key, Path(tmpdir))
         data = b"secret data"
         rel_path = Path("testfile.enc")

--- a/src/tests/test_nostr_client.py
+++ b/src/tests/test_nostr_client.py
@@ -4,7 +4,8 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 import json
 import asyncio
-from cryptography.fernet import Fernet
+import os
+import base64
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -15,7 +16,7 @@ import nostr.client as nostr_client
 
 def test_nostr_client_uses_custom_relays():
     with TemporaryDirectory() as tmpdir:
-        key = Fernet.generate_key()
+        key = base64.urlsafe_b64encode(os.urandom(32))
         enc_mgr = EncryptionManager(key, Path(tmpdir))
         custom_relays = ["wss://relay1", "wss://relay2"]
 
@@ -73,7 +74,7 @@ class FakeWebSocket:
 
 
 def _setup_client(tmpdir, fake_cls):
-    key = Fernet.generate_key()
+    key = base64.urlsafe_b64encode(os.urandom(32))
     enc_mgr = EncryptionManager(key, Path(tmpdir))
 
     with patch("nostr.client.Client", fake_cls), patch(

--- a/src/tests/test_nostr_contract.py
+++ b/src/tests/test_nostr_contract.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from unittest.mock import patch
 import asyncio
 import gzip
-from cryptography.fernet import Fernet
+import os
+import base64
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -61,7 +62,7 @@ class MockClient:
 
 
 def setup_client(tmp_path, server):
-    key = Fernet.generate_key()
+    key = base64.urlsafe_b64encode(os.urandom(32))
     enc_mgr = EncryptionManager(key, tmp_path)
 
     with patch("nostr.client.Client", lambda signer: MockClient(server)), patch(

--- a/src/tests/test_nostr_index_size.py
+++ b/src/tests/test_nostr_index_size.py
@@ -10,7 +10,8 @@ import uuid
 
 import pytest
 
-from cryptography.fernet import Fernet
+import base64
+import os
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -32,7 +33,7 @@ def test_nostr_index_size_limits(pytestconfig: pytest.Config):
     )
     results = []
     with TemporaryDirectory() as tmpdir:
-        key = Fernet.generate_key()
+        key = base64.urlsafe_b64encode(os.urandom(32))
         enc_mgr = EncryptionManager(key, Path(tmpdir))
         with patch.object(enc_mgr, "decrypt_parent_seed", return_value=seed):
             client = NostrClient(

--- a/src/tests/test_nostr_real.py
+++ b/src/tests/test_nostr_real.py
@@ -9,7 +9,7 @@ import gzip
 import uuid
 
 import pytest
-from cryptography.fernet import Fernet
+import base64
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -25,7 +25,9 @@ def test_nostr_publish_and_retrieve():
         "abandon abandon abandon abandon about"
     )
     with TemporaryDirectory() as tmpdir:
-        enc_mgr = EncryptionManager(Fernet.generate_key(), Path(tmpdir))
+        enc_mgr = EncryptionManager(
+            base64.urlsafe_b64encode(os.urandom(32)), Path(tmpdir)
+        )
         with patch.object(enc_mgr, "decrypt_parent_seed", return_value=seed):
             client = NostrClient(
                 enc_mgr,

--- a/src/tests/test_nostr_snapshot.py
+++ b/src/tests/test_nostr_snapshot.py
@@ -3,8 +3,8 @@ import json
 import gzip
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from cryptography.fernet import Fernet
 import base64
+import os
 import asyncio
 from unittest.mock import patch
 
@@ -82,7 +82,9 @@ def test_fetch_latest_snapshot():
 
     client = DummyClient(events)
     with TemporaryDirectory() as tmpdir:
-        enc_mgr = EncryptionManager(Fernet.generate_key(), Path(tmpdir))
+        enc_mgr = EncryptionManager(
+            base64.urlsafe_b64encode(os.urandom(32)), Path(tmpdir)
+        )
         with patch("nostr.client.Client", lambda signer: client), patch(
             "nostr.client.KeyManager"
         ) as MockKM, patch.object(NostrClient, "initialize_client_pool"), patch.object(

--- a/src/tests/test_publish_json_result.py
+++ b/src/tests/test_publish_json_result.py
@@ -4,7 +4,8 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 import asyncio
 import pytest
-from cryptography.fernet import Fernet
+import os
+import base64
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -13,7 +14,7 @@ from nostr.client import NostrClient, Manifest
 
 
 def setup_client(tmp_path):
-    key = Fernet.generate_key()
+    key = base64.urlsafe_b64encode(os.urandom(32))
     enc_mgr = EncryptionManager(key, tmp_path)
 
     with patch("nostr.client.ClientBuilder"), patch(


### PR DESCRIPTION
## Summary
- switch tests to use AES-GCM compatible key generation
- keep deterministic helper vault setup

## Testing
- `black src/tests/test_encryption_checksum.py src/tests/test_encryption_files.py src/tests/test_fingerprint_encryption.py src/tests/test_nostr_client.py src/tests/test_nostr_contract.py src/tests/test_nostr_index_size.py src/tests/test_nostr_real.py src/tests/test_nostr_snapshot.py src/tests/test_publish_json_result.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6872a42b83a4832b8a7b0c8defed79e8