### PR TITLE
Fix iterations call in setup_existing_seed

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -723,7 +723,11 @@ class PasswordManager:
                     # Initialize EncryptionManager with key and fingerprint_dir
                     password = prompt_for_password()
                     index_key = derive_index_key(parent_seed)
-                    iterations = self.config_manager.get_kdf_iterations()
+                    iterations = (
+                        self.config_manager.get_kdf_iterations()
+                        if getattr(self, "config_manager", None)
+                        else 100_000
+                    )
                     seed_key = derive_key_from_password(password, iterations=iterations)
 
                     self.encryption_manager = EncryptionManager(


### PR DESCRIPTION
## Summary
- avoid AttributeError if `config_manager` is unset when setting up an existing seed
- derive seed key with default iterations when no config manager is present

## Testing
- `black src/password_manager/manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873160c168c832badfe97982500383e