### PR TITLE
Document automatic vault migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ The encrypted index file `seedpass_entries_db.json.enc` begins with `schema_vers
 }
 ```
 
+> **Note**
+>
+> Opening a vault created by older versions automatically converts the legacy
+> `seedpass_passwords_db.json.enc` (Fernet) to AES-GCM as
+> `seedpass_entries_db.json.enc`. The original file is kept with a `.fernet`
+> extension.
+
 ## Usage
 
 After successfully installing the dependencies, install the package with:

--- a/docs/docs/content/01-getting-started/04-migrations.md
+++ b/docs/docs/content/01-getting-started/04-migrations.md
@@ -23,3 +23,16 @@ raise an error.
 
 This process happens automatically; users only need to open their vault to
 upgrade older indices.
+
+### Legacy Fernet migration
+
+Older versions stored the vault index in a file named
+`seedpass_passwords_db.json.enc` encrypted with Fernet.  When opening such a
+vault, SeedPass now automatically decrypts the legacy file, re‑encrypts it using
+AES‑GCM, and saves it under the new name `seedpass_entries_db.json.enc`.
+The original Fernet file is preserved as
+`seedpass_entries_db.json.enc.fernet` and the legacy checksum file, if present,
+is renamed to `seedpass_entries_db_checksum.txt.fernet`.
+
+No additional command is required – simply open your existing vault and the
+conversion happens transparently.


### PR DESCRIPTION
## Summary
- document automatic migration from legacy Fernet encrypted files
- mention renamed file behaviour in README

## Testing
- `black .`
- `pytest`
- `npm install` and `node build-docs.js`

------
https://chatgpt.com/codex/tasks/task_b_6873193348d4832ba00304a8776d1cce