### PR TITLE
Fix duplicate import in encryption.py

### DIFF
--- a/src/password_manager/encryption.py
+++ b/src/password_manager/encryption.py
@@ -26,7 +26,6 @@ import base64
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.exceptions import InvalidTag
 from cryptography.fernet import Fernet, InvalidToken
-from cryptography.fernet import Fernet, InvalidToken
 from termcolor import colored
 from utils.file_lock import (
     exclusive_lock,


### PR DESCRIPTION
## Summary
- remove a redundant `Fernet, InvalidToken` import
- keep formatting consistent with `black`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6873aae89160832bb58f5ab842b0f220