### PR TITLE
Document parent seed migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ The encrypted index file `seedpass_entries_db.json.enc` begins with `schema_vers
 > `seedpass_passwords_db.json.enc` (Fernet) to AES-GCM as
 > `seedpass_entries_db.json.enc`. The original file is kept with a `.fernet`
 > extension.
+> The same migration occurs for a legacy `parent_seed.enc` encrypted with
+> Fernet: it is transparently decrypted, re-encrypted with AES-GCM and the old
+> file saved as `parent_seed.enc.fernet`.
 
 ## Usage
 

--- a/docs/docs/content/01-getting-started/04-migrations.md
+++ b/docs/docs/content/01-getting-started/04-migrations.md
@@ -36,3 +36,12 @@ is renamed to `seedpass_entries_db_checksum.txt.fernet`.
 
 No additional command is required – simply open your existing vault and the
 conversion happens transparently.
+
+### Parent seed backup migration
+
+If your vault contains a `parent_seed.enc` file that was encrypted with Fernet,
+SeedPass performs a similar upgrade. Upon loading the vault, the application
+decrypts the old file, re‑encrypts it with AES‑GCM, and writes the result back to
+`parent_seed.enc`. The legacy Fernet file is preserved as
+`parent_seed.enc.fernet` so you can revert if needed. No manual steps are
+required – simply unlock your vault and the conversion runs automatically.


### PR DESCRIPTION
## Summary
- explain automatic migration of legacy `parent_seed.enc` files
- mention this parent seed migration in the README note
- rebuild docs

## Testing
- `npm run build -C docs`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6873b31c1d08832b80de909d26a61f82