### PR TITLE
Use compact orjson serialization

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -32,6 +32,7 @@ monero==1.1.1
 multidict==6.6.3
 mutmut==2.4.4
 nostr-sdk==0.42.1
+orjson==3.10.18
 packaging==25.0
 parso==0.8.4
 pgpy==0.6.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -30,3 +30,4 @@ uvicorn>=0.35.0
 httpx>=0.28.1
 requests>=2.32
 python-multipart
+orjson


### PR DESCRIPTION
## Summary
- add `orjson` dependency
- use optional `orjson` for JSON encoding/decoding
- compute checksums on compact JSON bytes

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873c5af73bc832bbf6fd8e5ed905517