### PR TITLE
Add kdf_iterations to CLI config set mapping

### DIFF
--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -461,6 +461,7 @@ def config_set(ctx: typer.Context, key: str, value: str) -> None:
         "relays": lambda v: cfg.set_relays(
             [r.strip() for r in v.split(",") if r.strip()], require_pin=False
         ),
+        "kdf_iterations": lambda v: cfg.set_kdf_iterations(int(v)),
         "backup_interval": lambda v: cfg.set_backup_interval(float(v)),
     }
 

--- a/src/tests/test_cli_config_set_extra.py
+++ b/src/tests/test_cli_config_set_extra.py
@@ -15,6 +15,7 @@ runner = CliRunner()
         ("clipboard_clear_delay", "10", "set_clipboard_clear_delay", 10),
         ("additional_backup_path", "", "set_additional_backup_path", None),
         ("backup_interval", "5", "set_backup_interval", 5.0),
+        ("kdf_iterations", "123", "set_kdf_iterations", 123),
         (
             "relays",
             "wss://a.com, wss://b.com",


### PR DESCRIPTION
## Summary
- support `kdf_iterations` key in `config set`
- extend CLI config tests for the new option

## Testing
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6873d1acfc14832baed73410683aed71