### PR TITLE
Document KDF and backup interval settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,11 +403,20 @@ Back in the Settings menu you can:
 - Choose `8` to import a database from a backup file.
 - Select `9` to export all 2FA codes.
 - Choose `10` to set an additional backup location. A backup is created immediately after the directory is configured.
-- Select `11` to change the inactivity timeout.
-- Choose `12` to lock the vault and require re-entry of your password.
-- Select `13` to view seed profile stats. The summary lists counts for passwords, TOTP codes, SSH keys, seed phrases, and PGP keys. It also shows whether both the encrypted database and the script itself pass checksum validation.
-- Choose `14` to toggle Secret Mode and set the clipboard clear delay.
-- Select `15` to return to the main menu.
+- Select `11` to set the PBKDF2 iteration count used for encryption.
+- Choose `12` to change the inactivity timeout.
+- Select `13` to lock the vault and require re-entry of your password.
+- Select `14` to view seed profile stats. The summary lists counts for passwords, TOTP codes, SSH keys, seed phrases, and PGP keys. It also shows whether both the encrypted database and the script itself pass checksum validation.
+- Choose `15` to toggle Secret Mode and set the clipboard clear delay.
+Press **Enter** at any time to return to the main menu.
+You can adjust these settings directly from the command line:
+
+```bash
+seedpass config set kdf_iterations 200000
+seedpass config set backup_interval 3600
+```
+
+Lower iteration counts speed up vault decryption but make brute-force attacks easier. A long backup interval means fewer backups and increases the risk of data loss.
 
 ## Running Tests
 
@@ -475,6 +484,7 @@ Mutation testing is disabled in the GitHub workflow due to reliability issues an
 - **Potential Bugs and Limitations:** Be aware that the software may contain bugs and lacks certain features. Snapshot chunks are capped at 50 KB and the client rotates snapshots after enough delta events accumulate. The security of memory management and logs has not been thoroughly evaluated and may pose risks of leaking sensitive information.
 - **Multiple Seeds Management:** While managing multiple seeds adds flexibility, it also increases the responsibility to secure each seed and its associated password.
 - **No PBKDF2 Salt Required:** SeedPass deliberately omits an explicit PBKDF2 salt. Every password is derived from a unique 512-bit BIP-85 child seed, which already provides stronger per-password uniqueness than a conventional 128-bit salt.
+- **KDF Iteration Caution:** Lowering `kdf_iterations` makes password cracking easier, while a high `backup_interval` leaves fewer recent backups.
 
 ## Contributing
 

--- a/docs/docs/content/01-getting-started/01-advanced_cli.md
+++ b/docs/docs/content/01-getting-started/01-advanced_cli.md
@@ -91,8 +91,8 @@ Manage profile‑specific settings.
 
 | Action | Command | Examples |
 | :--- | :--- | :--- |
-| Get a setting value | `config get` | `seedpass config get inactivity_timeout` |
-| Set a setting value | `config set` | `seedpass config set secret_mode_enabled true` |
+| Get a setting value | `config get` | `seedpass config get kdf_iterations` |
+| Set a setting value | `config set` | `seedpass config set backup_interval 3600` |
 
 ### Fingerprint Commands
 
@@ -171,8 +171,8 @@ Code: 123456
 
 ### `config` Commands
 
-- **`seedpass config get <key>`** – Retrieve a configuration value such as `inactivity_timeout`, `secret_mode_enabled`, `clipboard_clear_delay`, `additional_backup_path`, or `relays`.
-- **`seedpass config set <key> <value>`** – Update a configuration option. Example: `seedpass config set secret_mode_enabled true`.
+- **`seedpass config get <key>`** – Retrieve a configuration value such as `kdf_iterations`, `backup_interval`, `inactivity_timeout`, `secret_mode_enabled`, `clipboard_clear_delay`, `additional_backup_path`, or `relays`.
+- **`seedpass config set <key> <value>`** – Update a configuration option. Example: `seedpass config set kdf_iterations 200000`.
 - **`seedpass config toggle-secret-mode`** – Interactively enable or disable Secret Mode and set the clipboard delay.
 
 ### `fingerprint` Commands
@@ -208,5 +208,5 @@ Shut down the server with `seedpass api stop`.
 
 - Use the `--help` flag for details on any command.
 - Set a strong master password and regularly export encrypted backups.
-- Adjust configuration values like `inactivity_timeout` or `secret_mode_enabled` through the `config` commands.
+- Adjust configuration values like `kdf_iterations`, `backup_interval`, `inactivity_timeout`, or `secret_mode_enabled` through the `config` commands.
 - `entry get` is script‑friendly and can be piped into other commands.

--- a/docs/docs/content/01-getting-started/02-api_reference.md
+++ b/docs/docs/content/01-getting-started/02-api_reference.md
@@ -102,6 +102,22 @@ curl -X PUT http://127.0.0.1:8000/api/v1/config/inactivity_timeout \
      -d '{"value": 300}'
 ```
 
+To raise the PBKDF2 work factor or change how often backups are written:
+
+```bash
+curl -X PUT http://127.0.0.1:8000/api/v1/config/kdf_iterations \
+     -H "Authorization: Bearer <token>" \
+     -H "Content-Type: application/json" \
+     -d '{"value": 200000}'
+
+curl -X PUT http://127.0.0.1:8000/api/v1/config/backup_interval \
+     -H "Authorization: Bearer <token>" \
+     -H "Content-Type: application/json" \
+     -d '{"value": 3600}'
+```
+
+Using fewer iterations or a long interval reduces security, so adjust these values carefully.
+
 ### Toggling Secret Mode
 
 Send both `enabled` and `delay` values to `/api/v1/secret-mode`:

--- a/src/tests/test_cli_doc_examples.py
+++ b/src/tests/test_cli_doc_examples.py
@@ -57,6 +57,8 @@ class DummyPM:
         self.config_manager = SimpleNamespace(
             load_config=lambda require_pin=False: {"inactivity_timeout": 30},
             set_inactivity_timeout=lambda v: None,
+            set_kdf_iterations=lambda v: None,
+            set_backup_interval=lambda v: None,
             set_secret_mode_enabled=lambda v: None,
             set_clipboard_clear_delay=lambda v: None,
             set_additional_backup_path=lambda v: None,


### PR DESCRIPTION
## Summary
- document setting `kdf_iterations` and `backup_interval`
- mention security impact of changing these values
- sync CLI docs and update tests

## Testing
- `black .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6873d352af7c832ba39a6e93e21eafea