### PR TITLE
Add offline mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 - **Change Master Password:** Rotate your encryption password at any time.
 - **Checksum Verification Utilities:** Verify or regenerate the script checksum.
 - **Relay Management:** List, add, remove or reset configured Nostr relays.
+- **Offline Mode:** Disable all Nostr communication for local-only operation.
 
 ## Prerequisites
 

--- a/docs/docs/content/01-getting-started/01-advanced_cli.md
+++ b/docs/docs/content/01-getting-started/01-advanced_cli.md
@@ -93,6 +93,7 @@ Manage profile‑specific settings.
 | :--- | :--- | :--- |
 | Get a setting value | `config get` | `seedpass config get kdf_iterations` |
 | Set a setting value | `config set` | `seedpass config set backup_interval 3600` |
+| Toggle offline mode | `config toggle-offline` | `seedpass config toggle-offline` |
 
 ### Fingerprint Commands
 
@@ -174,6 +175,7 @@ Code: 123456
 - **`seedpass config get <key>`** – Retrieve a configuration value such as `kdf_iterations`, `backup_interval`, `inactivity_timeout`, `secret_mode_enabled`, `clipboard_clear_delay`, `additional_backup_path`, `relays`, or password policy fields like `min_uppercase`.
 - **`seedpass config set <key> <value>`** – Update a configuration option. Example: `seedpass config set kdf_iterations 200000`. Use keys like `min_uppercase`, `min_lowercase`, `min_digits`, or `min_special` to adjust password complexity.
 - **`seedpass config toggle-secret-mode`** – Interactively enable or disable Secret Mode and set the clipboard delay.
+- **`seedpass config toggle-offline`** – Enable or disable offline mode to skip Nostr operations.
 
 ### `fingerprint` Commands
 

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -60,6 +60,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 - **Change Master Password:** Rotate your encryption password at any time.
 - **Checksum Verification Utilities:** Verify or regenerate the script checksum.
 - **Relay Management:** List, add, remove or reset configured Nostr relays.
+- **Offline Mode:** Disable network sync to work entirely locally.
 
 ## Prerequisites
 

--- a/src/password_manager/config_manager.py
+++ b/src/password_manager/config_manager.py
@@ -41,6 +41,7 @@ class ConfigManager:
             logger.info("Config file not found; returning defaults")
             return {
                 "relays": list(DEFAULT_NOSTR_RELAYS),
+                "offline_mode": False,
                 "pin_hash": "",
                 "password_hash": "",
                 "inactivity_timeout": INACTIVITY_TIMEOUT,
@@ -61,6 +62,7 @@ class ConfigManager:
                 raise ValueError("Config data must be a dictionary")
             # Ensure defaults for missing keys
             data.setdefault("relays", list(DEFAULT_NOSTR_RELAYS))
+            data.setdefault("offline_mode", False)
             data.setdefault("pin_hash", "")
             data.setdefault("password_hash", "")
             data.setdefault("inactivity_timeout", INACTIVITY_TIMEOUT)
@@ -196,10 +198,21 @@ class ConfigManager:
         config["secret_mode_enabled"] = bool(enabled)
         self.save_config(config)
 
+    def set_offline_mode(self, enabled: bool) -> None:
+        """Persist the offline mode toggle."""
+        config = self.load_config(require_pin=False)
+        config["offline_mode"] = bool(enabled)
+        self.save_config(config)
+
     def get_secret_mode_enabled(self) -> bool:
         """Retrieve whether secret mode is enabled."""
         config = self.load_config(require_pin=False)
         return bool(config.get("secret_mode_enabled", False))
+
+    def get_offline_mode(self) -> bool:
+        """Retrieve the offline mode setting."""
+        config = self.load_config(require_pin=False)
+        return bool(config.get("offline_mode", False))
 
     def set_clipboard_clear_delay(self, delay: int) -> None:
         """Persist clipboard clear timeout in seconds."""

--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -535,6 +535,41 @@ def config_toggle_secret_mode(ctx: typer.Context) -> None:
     typer.echo(f"Secret mode {status}.")
 
 
+@config_app.command("toggle-offline")
+def config_toggle_offline(ctx: typer.Context) -> None:
+    """Enable or disable offline mode."""
+    pm = _get_pm(ctx)
+    cfg = pm.config_manager
+    try:
+        enabled = cfg.get_offline_mode()
+    except Exception as exc:  # pragma: no cover - pass through errors
+        typer.echo(f"Error loading settings: {exc}")
+        raise typer.Exit(code=1)
+
+    typer.echo(f"Offline mode is currently {'ON' if enabled else 'OFF'}")
+    choice = (
+        typer.prompt(
+            "Enable offline mode? (y/n, blank to keep)", default="", show_default=False
+        )
+        .strip()
+        .lower()
+    )
+    if choice in ("y", "yes"):
+        enabled = True
+    elif choice in ("n", "no"):
+        enabled = False
+
+    try:
+        cfg.set_offline_mode(enabled)
+        pm.offline_mode = enabled
+    except Exception as exc:  # pragma: no cover - pass through errors
+        typer.echo(f"Error: {exc}")
+        raise typer.Exit(code=1)
+
+    status = "enabled" if enabled else "disabled"
+    typer.echo(f"Offline mode {status}.")
+
+
 @fingerprint_app.command("list")
 def fingerprint_list(ctx: typer.Context) -> None:
     """List available seed profiles."""

--- a/src/tests/test_cli_doc_examples.py
+++ b/src/tests/test_cli_doc_examples.py
@@ -63,8 +63,10 @@ class DummyPM:
             set_clipboard_clear_delay=lambda v: None,
             set_additional_backup_path=lambda v: None,
             set_relays=lambda v, require_pin=False: None,
+            set_offline_mode=lambda v: None,
             get_secret_mode_enabled=lambda: True,
             get_clipboard_clear_delay=lambda: 30,
+            get_offline_mode=lambda: False,
         )
         self.secret_mode_enabled = True
         self.clipboard_clear_delay = 30

--- a/src/tests/test_cli_toggle_offline_mode.py
+++ b/src/tests/test_cli_toggle_offline_mode.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+from typer.testing import CliRunner
+
+from seedpass.cli import app
+from seedpass import cli
+
+runner = CliRunner()
+
+
+def _make_pm(called, enabled=False):
+    cfg = SimpleNamespace(
+        get_offline_mode=lambda: enabled,
+        set_offline_mode=lambda v: called.setdefault("enabled", v),
+    )
+    pm = SimpleNamespace(
+        config_manager=cfg,
+        offline_mode=enabled,
+        select_fingerprint=lambda fp: None,
+    )
+    return pm
+
+
+def test_toggle_offline_updates(monkeypatch):
+    called = {}
+    pm = _make_pm(called)
+    monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
+    result = runner.invoke(app, ["config", "toggle-offline"], input="y\n")
+    assert result.exit_code == 0
+    assert called == {"enabled": True}
+    assert "Offline mode enabled." in result.stdout
+
+
+def test_toggle_offline_keep(monkeypatch):
+    called = {}
+    pm = _make_pm(called, enabled=True)
+    monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
+    result = runner.invoke(app, ["config", "toggle-offline"], input="\n")
+    assert result.exit_code == 0
+    assert called == {"enabled": True}
+    assert "Offline mode enabled." in result.stdout

--- a/src/tests/test_offline_mode_behavior.py
+++ b/src/tests/test_offline_mode_behavior.py
@@ -1,0 +1,27 @@
+import time
+from types import SimpleNamespace
+
+from password_manager.manager import PasswordManager
+
+
+def test_sync_vault_skips_network(monkeypatch):
+    pm = PasswordManager.__new__(PasswordManager)
+    pm.offline_mode = True
+    pm.get_encrypted_data = lambda: b"data"
+    called = {"nostr": False}
+    pm.nostr_client = SimpleNamespace(
+        publish_snapshot=lambda *a, **kw: called.__setitem__("nostr", True)
+    )
+    result = PasswordManager.sync_vault(pm)
+    assert result is None
+    assert called["nostr"] is False
+
+
+def test_start_background_sync_offline(monkeypatch):
+    pm = PasswordManager.__new__(PasswordManager)
+    pm.offline_mode = True
+    called = {"sync": False}
+    pm.sync_index_from_nostr = lambda: called.__setitem__("sync", True)
+    PasswordManager.start_background_sync(pm)
+    time.sleep(0.05)
+    assert called["sync"] is False


### PR DESCRIPTION
## Summary
- add `offline_mode` option to config
- include CLI command `config toggle-offline`
- skip Nostr sync operations when offline
- support empty relay list in `NostrClient`
- document offline mode
- test offline mode behavior and CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873e67df788832b89ca3fff61111a50