### PR TITLE
Enable background sync when quick unlock

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -530,7 +530,13 @@ class PasswordManager:
             # Initialize BIP85 and other managers
             self.initialize_bip85()
             self.initialize_managers()
-            self.sync_index_from_nostr()
+            if (
+                getattr(self, "config_manager", None)
+                and self.config_manager.get_quick_unlock()
+            ):
+                self.start_background_sync()
+            else:
+                self.sync_index_from_nostr()
             print(colored(f"Switched to seed profile {selected_fingerprint}.", "green"))
 
             # Re-initialize NostrClient with the new fingerprint
@@ -603,7 +609,13 @@ class PasswordManager:
         self.initialize_managers()
         self.locked = False
         self.update_activity()
-        self.sync_index_from_nostr()
+        if (
+            getattr(self, "config_manager", None)
+            and self.config_manager.get_quick_unlock()
+        ):
+            self.start_background_sync()
+        else:
+            self.sync_index_from_nostr()
 
     def handle_existing_seed(self) -> None:
         """
@@ -775,7 +787,13 @@ class PasswordManager:
 
                     self.initialize_bip85()
                     self.initialize_managers()
-                    self.sync_index_from_nostr()
+                    if (
+                        getattr(self, "config_manager", None)
+                        and self.config_manager.get_quick_unlock()
+                    ):
+                        self.start_background_sync()
+                    else:
+                        self.sync_index_from_nostr()
                     return fingerprint  # Return the generated or added fingerprint
                 except BaseException:
                     # Clean up partial profile on failure or interruption
@@ -930,7 +948,13 @@ class PasswordManager:
 
             self.initialize_bip85()
             self.initialize_managers()
-            self.sync_index_from_nostr()
+            if (
+                getattr(self, "config_manager", None)
+                and self.config_manager.get_quick_unlock()
+            ):
+                self.start_background_sync()
+            else:
+                self.sync_index_from_nostr()
         except Exception as e:
             logging.error(f"Failed to encrypt and save parent seed: {e}", exc_info=True)
             print(colored(f"Error: Failed to encrypt and save parent seed: {e}", "red"))


### PR DESCRIPTION
## Summary
- support quick-unlock by launching sync in a background thread
- test background sync when quick unlock is enabled

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687402cfc348832bb5eb1cb9fb0c13fb