### PR TITLE
Add verbose timing logs

### DIFF
--- a/src/password_manager/config_manager.py
+++ b/src/password_manager/config_manager.py
@@ -58,6 +58,7 @@ class ConfigManager:
                 "min_lowercase": 2,
                 "min_digits": 2,
                 "min_special": 2,
+                "verbose_timing": False,
             }
         try:
             data = self.vault.load_config()
@@ -82,6 +83,7 @@ class ConfigManager:
             data.setdefault("min_lowercase", 2)
             data.setdefault("min_digits", 2)
             data.setdefault("min_special", 2)
+            data.setdefault("verbose_timing", False)
 
             # Migrate legacy hashed_password.enc if present and password_hash is missing
             legacy_file = self.fingerprint_dir / "hashed_password.enc"
@@ -315,3 +317,12 @@ class ConfigManager:
         """Retrieve the delay in seconds between Nostr retries."""
         cfg = self.load_config(require_pin=False)
         return float(cfg.get("nostr_retry_delay", 1.0))
+
+    def set_verbose_timing(self, enabled: bool) -> None:
+        cfg = self.load_config(require_pin=False)
+        cfg["verbose_timing"] = bool(enabled)
+        self.save_config(cfg)
+
+    def get_verbose_timing(self) -> bool:
+        cfg = self.load_config(require_pin=False)
+        return bool(cfg.get("verbose_timing", False))

--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -473,6 +473,9 @@ def config_set(ctx: typer.Context, key: str, value: str) -> None:
         "quick_unlock": lambda v: cfg.set_quick_unlock(
             v.lower() in ("1", "true", "yes", "y", "on")
         ),
+        "verbose_timing": lambda v: cfg.set_verbose_timing(
+            v.lower() in ("1", "true", "yes", "y", "on")
+        ),
     }
 
     action = mapping.get(key)

--- a/src/tests/test_verbose_timing.py
+++ b/src/tests/test_verbose_timing.py
@@ -1,0 +1,32 @@
+import asyncio
+import logging
+
+from password_manager.manager import PasswordManager
+from helpers import dummy_nostr_client
+
+
+def test_unlock_vault_logs_time(monkeypatch, caplog, tmp_path):
+    pm = PasswordManager.__new__(PasswordManager)
+    pm.fingerprint_dir = tmp_path
+    pm.setup_encryption_manager = lambda path: None
+    pm.initialize_bip85 = lambda: None
+    pm.initialize_managers = lambda: None
+    pm.update_activity = lambda: None
+    pm.verbose_timing = True
+    caplog.set_level(logging.INFO, logger="password_manager.manager")
+    times = iter([0.0, 1.0])
+    monkeypatch.setattr(
+        "password_manager.manager.time.perf_counter", lambda: next(times)
+    )
+    pm.unlock_vault()
+    assert "Vault unlocked in 1.00 seconds" in caplog.text
+
+
+def test_publish_snapshot_logs_time(dummy_nostr_client, monkeypatch, caplog):
+    client, _relay = dummy_nostr_client
+    client.verbose_timing = True
+    caplog.set_level(logging.INFO, logger="nostr.client")
+    times = iter([0.0, 1.0])
+    monkeypatch.setattr("nostr.client.time.perf_counter", lambda: next(times))
+    asyncio.run(client.publish_snapshot(b"data"))
+    assert "publish_snapshot completed in 1.00 seconds" in caplog.text


### PR DESCRIPTION
## Summary
- log timing for unlock, sync, and snapshot operations
- add `verbose_timing` config option and CLI mapping
- expose timing preference to `NostrClient`
- test verbose timing logs

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687410ad1210832b81aef4d3b08a9959