### PR TITLE
Update docs about background sync and quick unlock

### DIFF
--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -51,7 +51,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 - **Display TOTP Codes:** Show all active 2FA codes with a countdown timer.
 - **Optional External Backup Location:** Configure a second directory where backups are automatically copied.
 - **Auto‑Lock on Inactivity:** Vault locks after a configurable timeout for additional security.
-- **Quick Unlock:** Optionally skip the password prompt after verifying once.
+- **Quick Unlock:** Optionally skip the password prompt after verifying once. Startup delay is unaffected.
 - **Secret Mode:** Copy retrieved passwords directly to your clipboard and automatically clear it after a delay.
 - **Tagging Support:** Organize entries with optional tags and find them quickly via search.
 - **Manual Vault Export/Import:** Create encrypted backups or restore them using the CLI or API.
@@ -413,7 +413,7 @@ Back in the Settings menu you can:
   validation.
 * Choose `14` to toggle Secret Mode and set the clipboard clear delay.
 * Select `15` to toggle Offline Mode and work locally without contacting Nostr.
-* Choose `16` to toggle Quick Unlock so subsequent actions skip the password prompt.
+* Choose `16` to toggle Quick Unlock so subsequent actions skip the password prompt. Startup delay is unchanged.
 * Select `17` to return to the main menu.
 
 ## Running Tests
@@ -454,7 +454,8 @@ The script now determines the fingerprint from the generated seed and stores the
 vault under `~/.seedpass/<fingerprint>`. It also prints the fingerprint after
 creation and publishes the encrypted index to Nostr. Use that same seed phrase
 to load SeedPass. The app checks Nostr on startup and pulls any newer snapshot
-so your vault stays in sync across machines.
+so your vault stays in sync across machines. Synchronization also runs in the
+background after unlocking or when switching profiles.
 
 ### Automatically Updating the Script Checksum
 
@@ -499,7 +500,7 @@ Mutation testing is disabled in the GitHub workflow due to reliability issues an
 - **No PBKDF2 Salt Required:** SeedPass deliberately omits an explicit PBKDF2 salt. Every password is derived from a unique 512-bit BIP-85 child seed, which already provides stronger per-password uniqueness than a conventional 128-bit salt.
 - **Default KDF Iterations:** New profiles start with 50,000 PBKDF2 iterations. Use `seedpass config set kdf_iterations` to change this.
 - **Offline Mode:** Disable Nostr sync to keep all operations local until you re-enable networking.
-- **Quick Unlock:** Store a hashed copy of your password so future actions don't prompt again during the session. Use with caution on shared systems.
+  - **Quick Unlock:** Store a hashed copy of your password so future actions skip the prompt. Startup delay no longer changes. Use with caution on shared systems.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- clarify that vault sync runs in the background after unlocking or switching profiles
- note that Quick Unlock only skips the password prompt and does not change startup delay

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687422c718d0832bbf76e089c17a5fe2