### PR TITLE
Fix KDF iteration default in test profile generator

### DIFF
--- a/scripts/generate_test_profile.py
+++ b/scripts/generate_test_profile.py
@@ -98,6 +98,8 @@ def initialize_profile(
     # Store the default password hash so the profile can be opened
     hashed = bcrypt.hashpw(DEFAULT_PASSWORD.encode(), bcrypt.gensalt()).decode()
     cfg_mgr.set_password_hash(hashed)
+    # Ensure stored iterations match the PBKDF2 work factor used above
+    cfg_mgr.set_kdf_iterations(100_000)
     backup_mgr = BackupManager(profile_dir, cfg_mgr)
     entry_mgr = EntryManager(vault, backup_mgr)
     return seed_phrase, entry_mgr, profile_dir, fingerprint, cfg_mgr
@@ -146,7 +148,10 @@ def populate(entry_mgr: EntryManager, seed: str, count: int) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Create or extend a SeedPass test profile"
+        description=(
+            "Create or extend a SeedPass test profile (default PBKDF2 iterations:"
+            " 100,000)"
+        )
     )
     parser.add_argument(
         "--profile",


### PR DESCRIPTION
## Summary
- ensure `scripts/generate_test_profile.py` saves the PBKDF2 iteration count used during setup
- mention the default iteration count in the script help text

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687438a72590832b8ea2bb9ee99c4e42