### PR TITLE
Ensure sync after seed creation

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -835,6 +835,7 @@ class PasswordManager:
             # Now, save and encrypt the seed with the fingerprint_dir
             try:
                 self.save_and_encrypt_seed(new_seed, fingerprint_dir)
+                self.start_background_sync()
             except BaseException:
                 # Clean up partial profile on failure or interruption
                 self.fingerprint_manager.remove_fingerprint(fingerprint)


### PR DESCRIPTION
## Summary
- call `start_background_sync()` when generating a new seed profile so new profiles sync immediately

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68744479ed30832b9617c5c225ed3333