### PR TITLE
Track manifest timestamp for deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 - **Deterministic Password Generation:** Utilize BIP-85 for generating deterministic and secure passwords.
 - **Encrypted Storage:** All seeds, login passwords, and sensitive index data are encrypted locally.
 - **Nostr Integration:** Post and retrieve your encrypted password index to/from the Nostr network.
-- **Chunked Snapshots:** Encrypted vaults are compressed and split into 50 KB chunks published as `kind 30071` events with a `kind 30070` manifest and `kind 30072` deltas.
+- **Chunked Snapshots:** Encrypted vaults are compressed and split into 50 KB chunks published as `kind 30071` events with a `kind 30070` manifest and `kind 30072` deltas. The manifest's `delta_since` field records the UNIX timestamp of the most recent delta.
 - **Automatic Checksum Generation:** The script generates and verifies a SHA-256 checksum to detect tampering.
 - **Multiple Seed Profiles:** Manage separate seed profiles and switch between them seamlessly.
 - **Nested Managed Account Seeds:** SeedPass can derive nested managed account seeds.

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -40,7 +40,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 - **Deterministic Password Generation:** Utilize BIP-85 for generating deterministic and secure passwords.
 - **Encrypted Storage:** All seeds, login passwords, and sensitive index data are encrypted locally.
 - **Nostr Integration:** Post and retrieve your encrypted password index to/from the Nostr network.
-- **Chunked Snapshots:** Encrypted vaults are compressed and split into 50 KB chunks published as `kind 30071` events with a `kind 30070` manifest and `kind 30072` deltas.
+- **Chunked Snapshots:** Encrypted vaults are compressed and split into 50 KB chunks published as `kind 30071` events with a `kind 30070` manifest and `kind 30072` deltas. The manifest's `delta_since` field stores the UNIX timestamp of the most recent delta.
 - **Automatic Checksum Generation:** The script generates and verifies a SHA-256 checksum to detect tampering.
 - **Multiple Seed Profiles:** Manage separate seed profiles and switch between them seamlessly.
 - **Nested Managed Account Seeds:** SeedPass can derive nested managed account seeds.

--- a/src/main.py
+++ b/src/main.py
@@ -318,15 +318,12 @@ def handle_retrieve_from_nostr(password_manager: PasswordManager):
             manifest, chunks = result
             encrypted = gzip.decompress(b"".join(chunks))
             if manifest.delta_since:
-                try:
-                    version = int(manifest.delta_since)
-                    deltas = asyncio.run(
-                        password_manager.nostr_client.fetch_deltas_since(version)
-                    )
-                    if deltas:
-                        encrypted = deltas[-1]
-                except ValueError:
-                    pass
+                version = int(manifest.delta_since)
+                deltas = asyncio.run(
+                    password_manager.nostr_client.fetch_deltas_since(version)
+                )
+                if deltas:
+                    encrypted = deltas[-1]
             password_manager.encryption_manager.decrypt_and_save_index_from_nostr(
                 encrypted
             )

--- a/src/nostr/backup_models.py
+++ b/src/nostr/backup_models.py
@@ -23,4 +23,4 @@ class Manifest:
     ver: int
     algo: str
     chunks: List[ChunkMeta]
-    delta_since: Optional[str] = None
+    delta_since: Optional[int] = None

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1022,13 +1022,10 @@ class PasswordManager:
             manifest, chunks = result
             encrypted = gzip.decompress(b"".join(chunks))
             if manifest.delta_since:
-                try:
-                    version = int(manifest.delta_since)
-                    deltas = asyncio.run(self.nostr_client.fetch_deltas_since(version))
-                    if deltas:
-                        encrypted = deltas[-1]
-                except ValueError:
-                    pass
+                version = int(manifest.delta_since)
+                deltas = asyncio.run(self.nostr_client.fetch_deltas_since(version))
+                if deltas:
+                    encrypted = deltas[-1]
             current = self.vault.get_encrypted_index()
             if current != encrypted:
                 self.vault.decrypt_and_save_index_from_nostr(encrypted)
@@ -1108,15 +1105,10 @@ class PasswordManager:
                 manifest, chunks = result
                 encrypted = gzip.decompress(b"".join(chunks))
                 if manifest.delta_since:
-                    try:
-                        version = int(manifest.delta_since)
-                        deltas = asyncio.run(
-                            self.nostr_client.fetch_deltas_since(version)
-                        )
-                        if deltas:
-                            encrypted = deltas[-1]
-                    except ValueError:
-                        pass
+                    version = int(manifest.delta_since)
+                    deltas = asyncio.run(self.nostr_client.fetch_deltas_since(version))
+                    if deltas:
+                        encrypted = deltas[-1]
                 try:
                     self.vault.decrypt_and_save_index_from_nostr(encrypted)
                     logger.info("Initialized local database from Nostr.")
@@ -3841,4 +3833,6 @@ class PasswordManager:
         print(color_text(f"Snapshot chunks: {stats['chunk_count']}", "stats"))
         print(color_text(f"Pending deltas: {stats['pending_deltas']}", "stats"))
         if stats.get("delta_since"):
-            print(color_text(f"Latest delta id: {stats['delta_since']}", "stats"))
+            print(
+                color_text(f"Latest delta timestamp: {stats['delta_since']}", "stats")
+            )


### PR DESCRIPTION
## Summary
- update Manifest model to store `delta_since` as an int timestamp
- keep track of the latest manifest id and timestamp when publishing snapshots
- republish manifest with an updated `delta_since` whenever a delta is posted
- store manifest id when fetching a snapshot
- parse manifest timestamps directly in sync routines
- document that `delta_since` is a UNIX timestamp

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687458e5eed4832b8a75520e2016e43a