### PR TITLE
Reconnect Nostr client pool on relay update

### DIFF
--- a/src/nostr/client.py
+++ b/src/nostr/client.py
@@ -282,6 +282,7 @@ class NostrClient:
         signer = NostrSigner.keys(self.keys)
         self.client = Client(signer)
         self._connected = False
+        self.initialize_client_pool()
 
     def retrieve_json_from_nostr_sync(
         self, retries: int | None = None, delay: float | None = None

--- a/src/tests/test_nostr_client.py
+++ b/src/tests/test_nostr_client.py
@@ -131,3 +131,23 @@ def test_ping_relay_accepts_eose(tmp_path, monkeypatch):
     result = asyncio.run(client._ping_relay("wss://relay", timeout=0.1))
 
     assert result is True
+
+
+def test_update_relays_reinitializes_pool(tmp_path, monkeypatch):
+    client = _setup_client(tmp_path, FakeAddRelayClient)
+
+    monkeypatch.setattr(nostr_client, "Client", FakeAddRelaysClient)
+
+    called = {"ran": False}
+
+    def fake_init(self):
+        called["ran"] = True
+
+    monkeypatch.setattr(NostrClient, "initialize_client_pool", fake_init)
+
+    new_relays = ["wss://relay1"]
+    client.update_relays(new_relays)
+
+    assert called["ran"] is True
+    assert isinstance(client.client, FakeAddRelaysClient)
+    assert client.relays == new_relays


### PR DESCRIPTION
## Summary
- reinitialize Nostr client pool when changing relays
- test that update_relays connects with the new client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68745e8498e8832b9ac293cdd476649f