### PR TITLE
Record manifest timestamp and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 - **Deterministic Password Generation:** Utilize BIP-85 for generating deterministic and secure passwords.
 - **Encrypted Storage:** All seeds, login passwords, and sensitive index data are encrypted locally.
 - **Nostr Integration:** Post and retrieve your encrypted password index to/from the Nostr network.
-- **Chunked Snapshots:** Encrypted vaults are compressed and split into 50 KB chunks published as `kind 30071` events with a `kind 30070` manifest and `kind 30072` deltas. The manifest's `delta_since` field records the UNIX timestamp of the most recent delta.
+- **Chunked Snapshots:** Encrypted vaults are compressed and split into 50 KB chunks published as `kind 30071` events with a `kind 30070` manifest and `kind 30072` deltas. The manifest's `delta_since` field stores the UNIX timestamp of the latest delta event.
 - **Automatic Checksum Generation:** The script generates and verifies a SHA-256 checksum to detect tampering.
 - **Multiple Seed Profiles:** Manage separate seed profiles and switch between them seamlessly.
 - **Nested Managed Account Seeds:** SeedPass can derive nested managed account seeds.

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -40,7 +40,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 - **Deterministic Password Generation:** Utilize BIP-85 for generating deterministic and secure passwords.
 - **Encrypted Storage:** All seeds, login passwords, and sensitive index data are encrypted locally.
 - **Nostr Integration:** Post and retrieve your encrypted password index to/from the Nostr network.
-- **Chunked Snapshots:** Encrypted vaults are compressed and split into 50 KB chunks published as `kind 30071` events with a `kind 30070` manifest and `kind 30072` deltas. The manifest's `delta_since` field stores the UNIX timestamp of the most recent delta.
+- **Chunked Snapshots:** Encrypted vaults are compressed and split into 50 KB chunks published as `kind 30071` events with a `kind 30070` manifest and `kind 30072` deltas. The manifest's `delta_since` field stores the UNIX timestamp of the latest delta event.
 - **Automatic Checksum Generation:** The script generates and verifies a SHA-256 checksum to detect tampering.
 - **Multiple Seed Profiles:** Manage separate seed profiles and switch between them seamlessly.
 - **Nested Managed Account Seeds:** SeedPass can derive nested managed account seeds.

--- a/src/nostr/client.py
+++ b/src/nostr/client.py
@@ -391,6 +391,7 @@ class NostrClient:
         manifest_id = result.id.to_hex() if hasattr(result, "id") else str(result)
         self.current_manifest = manifest
         self.current_manifest_id = manifest_id
+        # Record when this snapshot was published for future delta events
         self.current_manifest.delta_since = int(time.time())
         self._delta_events = []
         if getattr(self, "verbose_timing", False):
@@ -442,7 +443,10 @@ class NostrClient:
             chunks.append(chunk_bytes)
 
         self.current_manifest = manifest
-        self.current_manifest_id = getattr(manifest_event, "id", None)
+        man_id = getattr(manifest_event, "id", None)
+        if hasattr(man_id, "to_hex"):
+            man_id = man_id.to_hex()
+        self.current_manifest_id = man_id
         return manifest, chunks
 
     async def publish_delta(self, delta_bytes: bytes, manifest_id: str) -> str:


### PR DESCRIPTION
## Summary
- capture manifest event ID as hex in `fetch_latest_snapshot`
- annotate snapshot publish time when publishing snapshots
- document `delta_since` timestamp in README and docs

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687466b82790832b80cb47dd70237ed2