### PR TITLE
Update dummy relay events with timestamps

### DIFF
--- a/src/tests/helpers.py
+++ b/src/tests/helpers.py
@@ -1,4 +1,6 @@
 import sys
+import time
+import json
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -183,11 +185,18 @@ class DummyRelayClient:
         if isinstance(event, DummyEvent):
             event.id = eid
         if event.kind == KIND_MANIFEST:
+            try:
+                data = json.loads(event.content())
+                event.delta_since = data.get("delta_since")
+            except Exception:
+                event.delta_since = None
             self.manifests.append(event)
         elif event.kind == KIND_SNAPSHOT_CHUNK:
             ident = event.tags[0] if event.tags else str(self.counter)
             self.chunks[ident] = event
         elif event.kind == KIND_DELTA:
+            if not hasattr(event, "created_at"):
+                event.created_at = int(time.time())
             self.deltas.append(event)
         return DummySendResult(eid)
 


### PR DESCRIPTION
## Summary
- add `json` and `time` imports for test helpers
- capture `delta_since` when manifests are sent
- timestamp delta events with `created_at`

## Testing
- `pytest src/tests/test_full_sync_roundtrip.py::test_full_sync_roundtrip -q`
- `pytest src/tests/test_full_sync_roundtrip_new.py::test_full_sync_roundtrip -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68746e2c40d0832ba776243cb57681f7