### PR TITLE
Record delta timestamps in dummy relay

### DIFF
--- a/src/tests/helpers.py
+++ b/src/tests/helpers.py
@@ -163,6 +163,7 @@ class DummySendResult:
 class DummyRelayClient:
     def __init__(self):
         self.counter = 0
+        self.ts_counter = 0
         self.manifests: list[DummyEvent] = []
         self.chunks: dict[str, DummyEvent] = {}
         self.deltas: list[DummyEvent] = []
@@ -196,7 +197,8 @@ class DummyRelayClient:
             self.chunks[ident] = event
         elif event.kind == KIND_DELTA:
             if not hasattr(event, "created_at"):
-                event.created_at = int(time.time())
+                self.ts_counter += 1
+                event.created_at = self.ts_counter
             self.deltas.append(event)
         return DummySendResult(eid)
 

--- a/src/tests/test_full_sync_roundtrip.py
+++ b/src/tests/test_full_sync_roundtrip.py
@@ -29,7 +29,7 @@ def _init_pm(dir_path: Path, client) -> PasswordManager:
     return pm
 
 
-def test_full_sync_roundtrip(dummy_nostr_client, monkeypatch):
+def test_full_sync_roundtrip(dummy_nostr_client):
     client, relay = dummy_nostr_client
     with TemporaryDirectory() as tmpdir:
         base = Path(tmpdir)
@@ -54,9 +54,9 @@ def test_full_sync_roundtrip(dummy_nostr_client, monkeypatch):
         # Manager A publishes delta with second entry
         pm_a.entry_manager.add_entry("site2", 12)
         delta_bytes = pm_a.vault.get_encrypted_index() or b""
-        # Use a constant timestamp so dummy relay returns the delta
-        monkeypatch.setattr("nostr.client.time.time", lambda: 1)
         asyncio.run(client.publish_delta(delta_bytes, manifest_id))
+        delta_ts = relay.deltas[-1].created_at
+        assert relay.manifests[-1].delta_since == delta_ts
 
         # Manager B fetches delta and updates
         pm_b.sync_index_from_nostr()

--- a/src/tests/test_full_sync_roundtrip_new.py
+++ b/src/tests/test_full_sync_roundtrip_new.py
@@ -29,7 +29,7 @@ def _init_pm(dir_path: Path, client) -> PasswordManager:
     return pm
 
 
-def test_full_sync_roundtrip(dummy_nostr_client, monkeypatch):
+def test_full_sync_roundtrip(dummy_nostr_client):
     client, relay = dummy_nostr_client
     with TemporaryDirectory() as tmpdir:
         base = Path(tmpdir)
@@ -54,8 +54,9 @@ def test_full_sync_roundtrip(dummy_nostr_client, monkeypatch):
         # Manager A publishes delta with second entry
         pm_a.entry_manager.add_entry("site2", 12)
         delta_bytes = pm_a.vault.get_encrypted_index() or b""
-        monkeypatch.setattr("nostr.client.time.time", lambda: 1)
         asyncio.run(client.publish_delta(delta_bytes, manifest_id))
+        delta_ts = relay.deltas[-1].created_at
+        assert relay.manifests[-1].delta_since == delta_ts
 
         # Manager B fetches delta and updates
         pm_b.sync_index_from_nostr()

--- a/src/tests/test_generate_test_profile_sync.py
+++ b/src/tests/test_generate_test_profile_sync.py
@@ -67,5 +67,6 @@ def test_generate_test_profile_sync(monkeypatch, dummy_nostr_client):
 
         assert result is not None
         _manifest, chunks = result
+        assert _manifest.delta_since is None
         retrieved = gzip.decompress(b"".join(chunks))
         assert retrieved == encrypted

--- a/src/tests/test_nostr_dummy_client.py
+++ b/src/tests/test_nostr_dummy_client.py
@@ -49,6 +49,10 @@ def test_publish_and_fetch_deltas(dummy_nostr_client):
     d1 = b"d1"
     d2 = b"d2"
     asyncio.run(client.publish_delta(d1, manifest_id))
+    first_ts = relay.deltas[-1].created_at
     asyncio.run(client.publish_delta(d2, manifest_id))
+    second_ts = relay.deltas[-1].created_at
+    assert second_ts > first_ts
+    assert relay.manifests[-1].delta_since == second_ts
     deltas = asyncio.run(client.fetch_deltas_since(0))
     assert deltas == [d1, d2]


### PR DESCRIPTION
## Summary
- track timestamps for delta events in `DummyRelayClient`
- check that manifests store delta_since when deltas are published
- validate timestamp handling in full sync and dummy client tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6874f581ad00832b91ed0854e987d0b9