### PR TITLE
Add notifications API endpoint

### DIFF
--- a/docs/docs/content/01-getting-started/02-api_reference.md
+++ b/docs/docs/content/01-getting-started/02-api_reference.md
@@ -31,6 +31,7 @@ Keep this token secret. Every request must include it in the `Authorization` hea
 - `GET /api/v1/totp/export` – Export all TOTP entries as JSON.
 - `GET /api/v1/totp` – Return current TOTP codes and remaining time.
 - `GET /api/v1/stats` – Return statistics about the active seed profile.
+- `GET /api/v1/notifications` – Retrieve and clear queued notifications.
 - `GET /api/v1/parent-seed` – Reveal the parent seed or save it with `?file=`.
 - `GET /api/v1/nostr/pubkey` – Fetch the Nostr public key for the active seed.
 - `POST /api/v1/checksum/verify` – Verify the checksum of the running script.
@@ -186,7 +187,16 @@ Get profile stats such as entry counts with `GET /api/v1/stats`:
 
 ```bash
 curl -H "Authorization: Bearer <token>" \
-     http://127.0.0.1:8000/api/v1/stats
+    http://127.0.0.1:8000/api/v1/stats
+```
+
+### Checking Notifications
+
+Get queued messages with `GET /api/v1/notifications`:
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+     http://127.0.0.1:8000/api/v1/notifications
 ```
 
 ### Changing the Master Password

--- a/src/tests/test_api_notifications.py
+++ b/src/tests/test_api_notifications.py
@@ -1,0 +1,18 @@
+from test_api import client
+from types import SimpleNamespace
+import queue
+import seedpass.api as api
+
+
+def test_notifications_endpoint(client):
+    cl, token = client
+    api._pm.notifications = queue.Queue()
+    api._pm.notifications.put(SimpleNamespace(message="m1", level="INFO"))
+    api._pm.notifications.put(SimpleNamespace(message="m2", level="WARNING"))
+    res = cl.get("/api/v1/notifications", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    assert res.json() == [
+        {"level": "INFO", "message": "m1"},
+        {"level": "WARNING", "message": "m2"},
+    ]
+    assert api._pm.notifications.empty()


### PR DESCRIPTION
## Summary
- add new `/api/v1/notifications` route
- document the endpoint
- test retrieving queued notifications

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687523427b4c832baaf504394c4739cf