### PR TITLE
Add notification handling tests

### DIFF
--- a/src/tests/test_api_notifications.py
+++ b/src/tests/test_api_notifications.py
@@ -16,3 +16,15 @@ def test_notifications_endpoint(client):
         {"level": "WARNING", "message": "m2"},
     ]
     assert api._pm.notifications.empty()
+
+
+def test_notifications_endpoint_clears_queue(client):
+    cl, token = client
+    api._pm.notifications = queue.Queue()
+    api._pm.notifications.put(SimpleNamespace(message="hi", level="INFO"))
+    res = cl.get("/api/v1/notifications", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    assert res.json() == [{"level": "INFO", "message": "hi"}]
+    assert api._pm.notifications.empty()
+    res = cl.get("/api/v1/notifications", headers={"Authorization": f"Bearer {token}"})
+    assert res.json() == []

--- a/src/tests/test_background_relay_check.py
+++ b/src/tests/test_background_relay_check.py
@@ -1,5 +1,6 @@
 import time
 from types import SimpleNamespace
+import queue
 from pathlib import Path
 import sys
 
@@ -21,3 +22,16 @@ def test_background_relay_check_runs_async(monkeypatch):
     time.sleep(0.05)
 
     assert called["args"] == MIN_HEALTHY_RELAYS
+
+
+def test_background_relay_check_warns_when_unhealthy(monkeypatch):
+    pm = PasswordManager.__new__(PasswordManager)
+    pm.notifications = queue.Queue()
+    pm.nostr_client = SimpleNamespace(check_relay_health=lambda mr: mr - 1)
+
+    pm.start_background_relay_check()
+    time.sleep(0.05)
+
+    note = pm.notifications.get_nowait()
+    assert note.level == "WARNING"
+    assert str(MIN_HEALTHY_RELAYS - 1) in note.message

--- a/src/tests/test_menu_notifications.py
+++ b/src/tests/test_menu_notifications.py
@@ -1,0 +1,46 @@
+import time
+import queue
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import main
+
+
+def _make_pm(msg):
+    q = queue.Queue()
+    q.put(SimpleNamespace(message=msg, level="INFO"))
+    return SimpleNamespace(
+        notifications=q,
+        is_dirty=False,
+        last_update=time.time(),
+        last_activity=time.time(),
+        nostr_client=SimpleNamespace(close_client_pool=lambda: None),
+        handle_add_password=lambda: None,
+        handle_retrieve_entry=lambda: None,
+        handle_search_entries=lambda: None,
+        handle_list_entries=lambda: None,
+        handle_modify_entry=lambda: None,
+        handle_display_totp_codes=lambda: None,
+        update_activity=lambda: None,
+        lock_vault=lambda: None,
+        unlock_vault=lambda: None,
+        start_background_sync=lambda: None,
+        start_background_relay_check=lambda: None,
+        profile_stack=[],
+        current_fingerprint="fp",
+    )
+
+
+def test_display_menu_prints_notifications(monkeypatch, capsys):
+    pm = _make_pm("hello")
+    monkeypatch.setattr(main, "_display_live_stats", lambda *_: None)
+    monkeypatch.setattr(main, "clear_and_print_fingerprint", lambda *a, **k: None)
+    monkeypatch.setattr(main, "timed_input", lambda *a, **k: "")
+    with pytest.raises(SystemExit):
+        main.display_menu(pm, sync_interval=1000, inactivity_timeout=1000)
+    out = capsys.readouterr().out
+    assert "hello" in out


### PR DESCRIPTION
## Summary
- test warnings when relay health is low
- expand API tests for notifications endpoint
- ensure menu prints queued notifications

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687525fba45c832b9b352b8778c26112