### PR TITLE
Refine relay warning notification

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1092,8 +1092,8 @@ class PasswordManager:
                     healthy = self.nostr_client.check_relay_health(MIN_HEALTHY_RELAYS)
                     if healthy < MIN_HEALTHY_RELAYS:
                         self.notify(
-                            f"Only {healthy} relay(s) responded with your latest event."
-                            " Consider adding more relays via Settings.",
+                            f"Only {healthy} relay(s) responded with your latest event. "
+                            "Consider adding more relays via Settings.",
                             level="WARNING",
                         )
             except Exception as exc:


### PR DESCRIPTION
## Summary
- unify message in `start_background_relay_check`
- keep existing tests passing

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68752f00f744832b8ed7d7646f571385