### PR TITLE
Improve menu notification output

### DIFF
--- a/src/utils/color_scheme.py
+++ b/src/utils/color_scheme.py
@@ -20,7 +20,7 @@ _COLOR_MAP = {
     "index": "yellow",
     "menu": "cyan",
     "stats": "green",
-    "info": "cyan",
+    "info": "white",
     "warning": "yellow",
     "error": "red",
     "default": "white",
@@ -32,4 +32,5 @@ def color_text(text: str, category: str = "default") -> str:
     color = _COLOR_MAP.get(category, "white")
     if color == "orange":
         return _apply_orange(text)
-    return colored(text, color)
+    attrs = ["bold"] if category in {"info", "warning", "error"} else None
+    return colored(text, color, attrs=attrs)


### PR DESCRIPTION
## Summary
- return the last notification instead of printing all
- show latest notification on a fixed line in `display_menu`
- tweak color scheme to ensure informational messages stand out
- expand tests for notification output behavior

## Testing
- `pytest src/tests/test_menu_notifications.py::test_display_menu_prints_notifications -q`
- `pytest src/tests/test_menu_notifications.py::test_display_menu_reuses_notification_line -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687530b861e0832bbda265336fff22eb