### PR TITLE
Improve TUI responsiveness

### DIFF
--- a/src/tests/test_manager_add_totp.py
+++ b/src/tests/test_manager_add_totp.py
@@ -52,7 +52,9 @@ def test_handle_add_totp(monkeypatch, capsys):
             ]
         )
         monkeypatch.setattr("builtins.input", lambda *args, **kwargs: next(inputs))
-        monkeypatch.setattr(pm, "sync_vault", lambda: None)
+        monkeypatch.setattr(
+            pm, "start_background_vault_sync", lambda *a, **k: pm.sync_vault(*a, **k)
+        )
 
         pm.handle_add_totp()
         out = capsys.readouterr().out

--- a/src/tests/test_manager_workflow.py
+++ b/src/tests/test_manager_workflow.py
@@ -71,6 +71,12 @@ def test_manager_workflow(monkeypatch):
         )
         monkeypatch.setattr("builtins.input", lambda *args, **kwargs: next(inputs))
 
+        monkeypatch.setattr(
+            pm,
+            "start_background_vault_sync",
+            lambda *a, **k: pm.sync_vault(*a, **k),
+        )
+
         pm.handle_add_password()
         assert pm.is_dirty is False
         backups = list((tmp_path / "backups").glob("entries_db_backup_*.json.enc"))

--- a/src/tests/test_profile_management.py
+++ b/src/tests/test_profile_management.py
@@ -74,6 +74,11 @@ def test_add_and_delete_entry(monkeypatch):
 
         inputs = iter([str(index)])
         monkeypatch.setattr("builtins.input", lambda *_a, **_k: next(inputs))
+        monkeypatch.setattr(
+            pm,
+            "start_background_vault_sync",
+            lambda *a, **k: pm.sync_vault(*a, **k),
+        )
 
         pm.delete_entry()
 


### PR DESCRIPTION
## Summary
- add `start_background_vault_sync` to run Nostr sync in a daemon thread
- call new method from add/edit/delete operations
- adjust tests for background sync behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687538bb3df4832b978cd4b2dd9c0ccd