### PR TITLE
Improve stats screen usability

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -264,11 +264,24 @@ def _display_live_stats(
     if not sys.stdin or not sys.stdin.isatty():
         clear_screen()
         display_fn()
+        note = drain_notifications(password_manager)
+        if note:
+            print(note)
+        print(colored("Press Enter to continue.", "cyan"))
+        pause()
         return
 
     while True:
         clear_screen()
         display_fn()
+        print()
+        note = drain_notifications(password_manager)
+        sys.stdout.write("\033[F\033[2K")
+        if note:
+            print(note)
+        else:
+            print()
+        print(colored("Press Enter to continue.", "cyan"))
         sys.stdout.flush()
         try:
             user_input = timed_input("", interval)

--- a/src/tests/test_stats_screen.py
+++ b/src/tests/test_stats_screen.py
@@ -1,0 +1,38 @@
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import main
+
+
+def _make_pm():
+    return SimpleNamespace(display_stats=lambda: print("stats"))
+
+
+def test_live_stats_shows_message(monkeypatch, capsys):
+    pm = _make_pm()
+    monkeypatch.setattr(main, "drain_notifications", lambda *_: None)
+    monkeypatch.setattr(
+        main,
+        "timed_input",
+        lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    main._display_live_stats(pm)
+    out = capsys.readouterr().out
+    assert "Press Enter to continue." in out
+
+
+def test_live_stats_shows_notification(monkeypatch, capsys):
+    pm = _make_pm()
+    monkeypatch.setattr(main, "drain_notifications", lambda *_: "note")
+    monkeypatch.setattr(
+        main,
+        "timed_input",
+        lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    main._display_live_stats(pm)
+    out = capsys.readouterr().out
+    assert "note" in out


### PR DESCRIPTION
## Summary
- show queued notifications on the stats screen
- prompt "Press Enter to continue" when displaying stats
- add unit tests for stats screen output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68754cce6404832b8a1c9a1878d2b330