### PR TITLE
Update notification system

### DIFF
--- a/src/tests/test_stats_screen.py
+++ b/src/tests/test_stats_screen.py
@@ -14,7 +14,7 @@ def _make_pm():
 
 def test_live_stats_shows_message(monkeypatch, capsys):
     pm = _make_pm()
-    monkeypatch.setattr(main, "drain_notifications", lambda *_: None)
+    monkeypatch.setattr(main, "get_notification_text", lambda *_: "")
     monkeypatch.setattr(
         main,
         "timed_input",
@@ -27,7 +27,7 @@ def test_live_stats_shows_message(monkeypatch, capsys):
 
 def test_live_stats_shows_notification(monkeypatch, capsys):
     pm = _make_pm()
-    monkeypatch.setattr(main, "drain_notifications", lambda *_: "note")
+    monkeypatch.setattr(main, "get_notification_text", lambda *_: "note")
     monkeypatch.setattr(
         main,
         "timed_input",


### PR DESCRIPTION
## Summary
- refactor drain_notifications and add get_notification_text
- show notifications via new helper in live stats and menu
- adjust tests to patch get_notification_text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687559afddec832bba5a4e385c51ad14