### PR TITLE
Add test for API notifications persistence

### DIFF
--- a/src/tests/test_api_notifications.py
+++ b/src/tests/test_api_notifications.py
@@ -28,3 +28,18 @@ def test_notifications_endpoint_clears_queue(client):
     assert api._pm.notifications.empty()
     res = cl.get("/api/v1/notifications", headers={"Authorization": f"Bearer {token}"})
     assert res.json() == []
+
+
+def test_notifications_endpoint_does_not_clear_current(client):
+    cl, token = client
+    api._pm.notifications = queue.Queue()
+    msg = SimpleNamespace(message="keep", level="INFO")
+    api._pm.notifications.put(msg)
+    api._pm._current_notification = msg
+    api._pm.get_current_notification = lambda: api._pm._current_notification
+
+    res = cl.get("/api/v1/notifications", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    assert res.json() == [{"level": "INFO", "message": "keep"}]
+    assert api._pm.notifications.empty()
+    assert api._pm.get_current_notification() is msg


### PR DESCRIPTION
## Summary
- verify that the `/api/v1/notifications` endpoint pops queued items
- confirm the current UI notification stays active after API calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687570bd5a30832b808c82c4be0d1028