### PR TITLE
Update test notification mocks

### DIFF
--- a/src/tests/test_background_relay_check.py
+++ b/src/tests/test_background_relay_check.py
@@ -12,6 +12,8 @@ from constants import MIN_HEALTHY_RELAYS
 
 def test_background_relay_check_runs_async(monkeypatch):
     pm = PasswordManager.__new__(PasswordManager)
+    pm._current_notification = None
+    pm._notification_expiry = 0.0
     called = {"args": None}
     pm.nostr_client = SimpleNamespace(
         check_relay_health=lambda min_relays: called.__setitem__("args", min_relays)
@@ -26,6 +28,8 @@ def test_background_relay_check_runs_async(monkeypatch):
 
 def test_background_relay_check_warns_when_unhealthy(monkeypatch):
     pm = PasswordManager.__new__(PasswordManager)
+    pm._current_notification = None
+    pm._notification_expiry = 0.0
     pm.notifications = queue.Queue()
     pm.nostr_client = SimpleNamespace(check_relay_health=lambda mr: mr - 1)
 

--- a/src/tests/test_menu_notifications.py
+++ b/src/tests/test_menu_notifications.py
@@ -17,6 +17,8 @@ def _make_pm(msg):
     return SimpleNamespace(
         notifications=q,
         get_current_notification=lambda: q.queue[-1] if not q.empty() else None,
+        _current_notification=None,
+        _notification_expiry=0.0,
         is_dirty=False,
         last_update=time.time(),
         last_activity=time.time(),
@@ -45,11 +47,7 @@ def test_display_menu_prints_notifications(monkeypatch, capsys):
         "clear_header_with_notification",
         lambda pm, *a, **k: (
             print("HEADER"),
-            print(
-                pm.get_current_notification().message
-                if pm.get_current_notification()
-                else ""
-            ),
+            print(main.get_notification_text(pm)),
         ),
     )
     monkeypatch.setattr(main, "timed_input", lambda *a, **k: "")


### PR DESCRIPTION
## Summary
- update test helpers to include `_current_notification` and `_notification_expiry`
- patch menu notification tests to use `get_notification_text`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687573e4f6c8832b859a84bc90ca05e2