### PR TITLE
Fix entry detail display

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1792,24 +1792,9 @@ class PasswordManager:
             pause()
 
     def show_entry_details_by_index(self, index: int) -> None:
-        """Display entry details using :meth:`handle_retrieve_entry` for the
-        given index without prompting for it again."""
+        """Display entry details for ``index`` without prompting."""
 
-        original_input = builtins.input
-        first_call = True
-
-        def patched_input(prompt: str = "") -> str:
-            nonlocal first_call
-            if first_call:
-                first_call = False
-                return str(index)
-            return original_input(prompt)
-
-        try:
-            builtins.input = patched_input
-            self.handle_retrieve_entry()
-        finally:
-            builtins.input = original_input
+        self.display_entry_details(index)
 
     def _prompt_toggle_archive(self, entry: dict, index: int) -> None:
         """Prompt the user to archive or restore ``entry`` based on its status."""

--- a/src/tests/test_manager_list_entries.py
+++ b/src/tests/test_manager_list_entries.py
@@ -80,12 +80,12 @@ def test_list_entries_show_details(monkeypatch, capsys):
             lambda *a, **k: "b",
         )
 
-        inputs = iter(["1", "0", "n"])
+        inputs = iter(["1", "0"])
         monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
 
         pm.handle_list_entries()
         out = capsys.readouterr().out
-        assert "Retrieved 2FA Code" in out
-        assert "123456" in out
+        assert "Label: Example" in out
+        assert "Period: 30s" in out
         assert "API" in out
         assert "acct" in out

--- a/src/tests/test_manager_search_display.py
+++ b/src/tests/test_manager_search_display.py
@@ -41,11 +41,11 @@ def test_search_entries_prompt_for_details(monkeypatch, capsys):
         monkeypatch.setattr("password_manager.manager.time.sleep", lambda *a, **k: None)
         monkeypatch.setattr("password_manager.manager.timed_input", lambda *a, **k: "b")
 
-        inputs = iter(["Example", "0", "n", ""])
+        inputs = iter(["Example", "0"])
         monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
 
         pm.handle_search_entries()
         out = capsys.readouterr().out
         assert "0. Example" in out
-        assert "Retrieved 2FA Code" in out
-        assert "123456" in out
+        assert "Label: Example" in out
+        assert "Period: 30s" in out


### PR DESCRIPTION
## Summary
- show entry details without running the full retrieval routine
- update tests expecting new details behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6875a77f6970832b9e4e870d0e917907