### PR TITLE
Improve entry details workflow

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1793,8 +1793,25 @@ class PasswordManager:
 
     def show_entry_details_by_index(self, index: int) -> None:
         """Display entry details for ``index`` without prompting."""
+        try:
+            entry = self.entry_manager.retrieve_entry(index)
+            if not entry:
+                return
 
-        self.display_entry_details(index)
+            fp, parent_fp, child_fp = self.header_fingerprint_args
+            clear_header_with_notification(
+                self,
+                fp,
+                "Entry Details",
+                parent_fingerprint=parent_fp,
+                child_fingerprint=child_fp,
+            )
+
+            self.display_entry_details(index)
+            self._entry_actions_menu(index, entry)
+        except Exception as e:
+            logging.error(f"Failed to display entry details: {e}", exc_info=True)
+            print(colored(f"Error: Failed to display entry details: {e}", "red"))
         pause()
 
     def _prompt_toggle_archive(self, entry: dict, index: int) -> None:

--- a/src/tests/test_manager_list_entries.py
+++ b/src/tests/test_manager_list_entries.py
@@ -89,3 +89,42 @@ def test_list_entries_show_details(monkeypatch, capsys):
         assert "Period: 30s" in out
         assert "API" in out
         assert "acct" in out
+
+
+def test_show_entry_details_by_index(monkeypatch):
+    """Ensure entry details screen triggers expected calls."""
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+        pm.encryption_manager = enc_mgr
+        pm.vault = vault
+        pm.entry_manager = entry_mgr
+        pm.backup_manager = backup_mgr
+        pm.nostr_client = SimpleNamespace()
+        pm.fingerprint_dir = tmp_path
+
+        index = entry_mgr.add_entry("example.com", 12)
+
+        header_calls = []
+        monkeypatch.setattr(
+            "password_manager.manager.clear_header_with_notification",
+            lambda *a, **k: header_calls.append(True),
+        )
+        action_calls = []
+        monkeypatch.setattr(
+            pm,
+            "_entry_actions_menu",
+            lambda *a, **k: action_calls.append(True),
+        )
+        monkeypatch.setattr("password_manager.manager.pause", lambda *a, **k: None)
+
+        pm.show_entry_details_by_index(index)
+
+        assert len(header_calls) == 1
+        assert len(action_calls) == 1


### PR DESCRIPTION
## Summary
- enhance `show_entry_details_by_index` to show header and allow actions
- unit test new behavior

## Testing
- `pytest -k test_show_entry_details_by_index -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875b863f8c0832b9dac60cb2ff9c956