### PR TITLE
Add sensitive info confirmation to entry detail view

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -1809,6 +1809,10 @@ class PasswordManager:
             )
 
             self.display_entry_details(index)
+
+            if confirm_action("Show sensitive information? (y/N): "):
+                self.display_sensitive_entry_info(entry, index)
+
             pause()
             self._entry_actions_menu(index, entry)
         except Exception as e:

--- a/src/tests/test_manager_list_entries.py
+++ b/src/tests/test_manager_list_entries.py
@@ -129,6 +129,9 @@ def test_show_entry_details_by_index(monkeypatch):
             lambda *a, **k: call_order.append("actions"),
         )
         monkeypatch.setattr("password_manager.manager.pause", lambda *a, **k: None)
+        monkeypatch.setattr(
+            "password_manager.manager.confirm_action", lambda *a, **k: False
+        )
 
         pm.show_entry_details_by_index(index)
 
@@ -161,6 +164,9 @@ def _detail_common(monkeypatch, pm):
         lambda *a, **k: None,
     )
     monkeypatch.setattr("password_manager.manager.pause", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "password_manager.manager.confirm_action", lambda *a, **k: False
+    )
     called = []
     monkeypatch.setattr(pm, "_entry_actions_menu", lambda *a, **k: called.append(True))
     return called


### PR DESCRIPTION
## Summary
- prompt to display sensitive details when viewing an entry
- skip sensitive info in tests by default

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68766c183938832b92a6de945b5e7189