### PR TITLE
Add fingerprint display improvements

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -2973,6 +2973,12 @@ class PasswordManager:
             print(
                 color_text(f"  Derivation Index: {entry.get('index', index)}", "index")
             )
+            pub_label = entry.get("public_key_label", "")
+            if pub_label:
+                print(color_text(f"  Public Key Label: {pub_label}", "index"))
+            ssh_fingerprint = entry.get("fingerprint", "")
+            if ssh_fingerprint:
+                print(color_text(f"  Fingerprint: {ssh_fingerprint}", "index"))
             notes = entry.get("notes", "")
             if notes:
                 print(color_text(f"  Notes: {notes}", "index"))
@@ -2991,6 +2997,14 @@ class PasswordManager:
             print(
                 color_text(f"  Derivation Index: {entry.get('index', index)}", "index")
             )
+            try:
+                _priv, pgp_fp = self.entry_manager.get_pgp_key(index, self.parent_seed)
+                if pgp_fp:
+                    print(color_text(f"  Fingerprint: {pgp_fp}", "index"))
+            except Exception as pgp_err:  # pragma: no cover - best effort logging
+                logging.error(
+                    f"Failed to derive PGP fingerprint: {pgp_err}", exc_info=True
+                )
             notes = entry.get("notes", "")
             if notes:
                 print(color_text(f"  Notes: {notes}", "index"))

--- a/src/tests/test_manager_list_entries.py
+++ b/src/tests/test_manager_list_entries.py
@@ -194,6 +194,10 @@ def test_show_ssh_entry_details(monkeypatch, capsys):
         tmp_path = Path(tmpdir)
         pm, entry_mgr = _setup_manager(tmp_path)
         idx = entry_mgr.add_ssh_key("ssh", TEST_SEED)
+        data = entry_mgr._load_index(force_reload=True)
+        data["entries"][str(idx)]["public_key_label"] = "server"
+        data["entries"][str(idx)]["fingerprint"] = "abc123"
+        entry_mgr._save_index(data)
 
         called = _detail_common(monkeypatch, pm)
 
@@ -202,6 +206,8 @@ def test_show_ssh_entry_details(monkeypatch, capsys):
         assert "Type: SSH Key" in out
         assert "Label: ssh" in out
         assert f"Derivation Index: {idx}" in out
+        assert "server" in out
+        assert "abc123" in out
         assert called == [True]
 
 
@@ -210,6 +216,7 @@ def test_show_pgp_entry_details(monkeypatch, capsys):
         tmp_path = Path(tmpdir)
         pm, entry_mgr = _setup_manager(tmp_path)
         idx = entry_mgr.add_pgp_key("pgp", TEST_SEED, user_id="test")
+        _k, fp = entry_mgr.get_pgp_key(idx, TEST_SEED)
 
         called = _detail_common(monkeypatch, pm)
 
@@ -220,6 +227,7 @@ def test_show_pgp_entry_details(monkeypatch, capsys):
         assert "Key Type: ed25519" in out
         assert "User ID: test" in out
         assert f"Derivation Index: {idx}" in out
+        assert fp in out
         assert called == [True]
 
 


### PR DESCRIPTION
## Summary
- show SSH public key labels and fingerprints if present
- derive and display fingerprint for PGP entries
- expand tests for SSH and PGP entry detail output

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68766e313990832b9d312ffa384f1392