### PR TITLE
Update docs for entry detail screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,15 @@ When **Secret Mode** is enabled, SeedPass copies retrieved passwords directly to
 2. Choose how many seconds to keep passwords on the clipboard.
 3. Retrieve an entry and SeedPass will confirm the password was copied.
 
+### Viewing Entry Details
+
+Selecting an item from **List Entries** or **Search Entries** first displays the
+entry's metadata such as the label, username, tags and notes. Passwords, seed
+phrases and other sensitive fields remain hidden until you choose to reveal
+them. When you opt to show the secret, the details view presents the same action
+menu as **Retrieve Entry** so you can edit, archive or display QR codes for the
+entry.
+
 ### Additional Entry Types
 
 SeedPass supports storing more than just passwords and 2FA secrets. You can also create entries for:

--- a/docs/docs/content/01-getting-started/01-advanced_cli.md
+++ b/docs/docs/content/01-getting-started/01-advanced_cli.md
@@ -156,6 +156,14 @@ $ seedpass entry get "email"
 Code: 123456
 ```
 
+### Viewing Entry Details
+
+Picking an entry from `entry list` or `entry search` displays its metadata first
+so you can review the label, username and notes. Sensitive fields are hidden
+until you confirm you want to reveal them. After showing the secret, the details
+view offers the same actions as `entry get`—edit the entry, archive it or show
+QR codes for supported types.
+
 ### `vault` Commands
 
 - **`seedpass vault export`** – Export the entire vault to an encrypted JSON file.


### PR DESCRIPTION
## Summary
- document metadata-only entry preview in README
- explain entry detail workflow in advanced CLI docs

## Testing
- `npm run build` in `docs`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687679b5d00c832b8db923368eb93a22