### PR TITLE
Fix retrieve entry pause order

### DIFF
--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -2497,8 +2497,8 @@ class PasswordManager:
                 return
 
             self.display_sensitive_entry_info(entry, index)
-            self._entry_actions_menu(index, entry)
             pause()
+            self._entry_actions_menu(index, entry)
             return
         except Exception as e:
             logging.error(f"Error during password retrieval: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- adjust handle_retrieve_entry to pause before showing actions menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687696185d3c832bbb0a72585534b56f