### PR TITLE
Add custom Seed Profile names

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,8 +378,12 @@ SeedPass allows you to manage multiple seed profiles (previously referred to as 
   3. Enter the number corresponding to the seed profile you wish to switch to.
   4. Enter the master password associated with that seed profile.
 
-- **List All Seed Profiles:**  
+- **List All Seed Profiles:**
   In the **Profiles** menu, choose "List All Seed Profiles" to view all existing profiles.
+- **Set Seed Profile Name:**
+  In the **Profiles** menu, choose "Set Seed Profile Name" to assign an optional
+  label to the currently selected profile. The name is stored locally and shown
+  alongside the fingerprint in menus.
 
 **Note:** The term "seed profile" is used to represent different sets of seeds you can manage within SeedPass. This provides an intuitive way to handle multiple identities or sets of passwords.
 

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -368,6 +368,8 @@ SeedPass allows you to manage multiple seed profiles (previously referred to as 
 
 - **List All Seed Profiles:**
   - In the **Profiles** menu, choose "List All Seed Profiles" to view all existing profiles.
+- **Set Seed Profile Name:**
+  - In the **Profiles** menu, choose "Set Seed Profile Name" to assign a label to the current profile. The name is stored locally and shown next to the fingerprint.
 
 **Note:** The term "seed profile" is used to represent different sets of seeds you can manage within SeedPass. This provides an intuitive way to handle multiple identities or sets of passwords.
 

--- a/src/main.py
+++ b/src/main.py
@@ -151,7 +151,8 @@ def handle_switch_fingerprint(password_manager: PasswordManager):
 
         print(colored("Available Seed Profiles:", "cyan"))
         for idx, fp in enumerate(fingerprints, start=1):
-            print(colored(f"{idx}. {fp}", "cyan"))
+            label = password_manager.fingerprint_manager.display_name(fp)
+            print(colored(f"{idx}. {label}", "cyan"))
 
         choice = input("Select a seed profile by number to switch: ").strip()
         if not choice.isdigit() or not (1 <= int(choice) <= len(fingerprints)):
@@ -195,7 +196,8 @@ def handle_remove_fingerprint(password_manager: PasswordManager):
 
         print(colored("Available Seed Profiles:", "cyan"))
         for idx, fp in enumerate(fingerprints, start=1):
-            print(colored(f"{idx}. {fp}", "cyan"))
+            label = password_manager.fingerprint_manager.display_name(fp)
+            print(colored(f"{idx}. {label}", "cyan"))
 
         choice = input("Select a seed profile by number to remove: ").strip()
         if not choice.isdigit() or not (1 <= int(choice) <= len(fingerprints)):
@@ -239,7 +241,8 @@ def handle_list_fingerprints(password_manager: PasswordManager):
 
         print(colored("Available Seed Profiles:", "cyan"))
         for fp in fingerprints:
-            print(colored(f"- {fp}", "cyan"))
+            label = password_manager.fingerprint_manager.display_name(fp)
+            print(colored(f"- {label}", "cyan"))
         pause()
     except Exception as e:
         logging.error(f"Error listing seed profiles: {e}", exc_info=True)
@@ -641,6 +644,25 @@ def handle_set_additional_backup_location(pm: PasswordManager) -> None:
         print(colored(f"Error: {e}", "red"))
 
 
+def handle_set_profile_name(pm: PasswordManager) -> None:
+    """Set or clear the custom name for the current seed profile."""
+    fp = getattr(pm.fingerprint_manager, "current_fingerprint", None)
+    if not fp:
+        print(colored("No seed profile selected.", "red"))
+        return
+    current = pm.fingerprint_manager.get_name(fp)
+    if current:
+        print(colored(f"Current name: {current}", "cyan"))
+    else:
+        print(colored("No custom name set.", "cyan"))
+    value = input("Enter new name (leave blank to remove): ").strip()
+    if pm.fingerprint_manager.set_name(fp, value or None):
+        if value:
+            print(colored("Name updated.", "green"))
+        else:
+            print(colored("Name removed.", "green"))
+
+
 def handle_toggle_secret_mode(pm: PasswordManager) -> None:
     """Toggle secret mode and adjust clipboard delay."""
     cfg = pm.config_manager
@@ -756,6 +778,7 @@ def handle_profiles_menu(password_manager: PasswordManager) -> None:
         print(color_text("2. Add a New Seed Profile", "menu"))
         print(color_text("3. Remove an Existing Seed Profile", "menu"))
         print(color_text("4. List All Seed Profiles", "menu"))
+        print(color_text("5. Set Seed Profile Name", "menu"))
         choice = input("Select an option or press Enter to go back: ").strip()
         password_manager.update_activity()
         if choice == "1":
@@ -767,6 +790,8 @@ def handle_profiles_menu(password_manager: PasswordManager) -> None:
             handle_remove_fingerprint(password_manager)
         elif choice == "4":
             handle_list_fingerprints(password_manager)
+        elif choice == "5":
+            handle_set_profile_name(password_manager)
         elif not choice:
             break
         else:

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -329,8 +329,13 @@ class PasswordManager:
 
             print(colored("\nAvailable Seed Profiles:", "cyan"))
             for idx, fp in enumerate(fingerprints, start=1):
+                label = (
+                    self.fingerprint_manager.display_name(fp)
+                    if hasattr(self.fingerprint_manager, "display_name")
+                    else fp
+                )
                 marker = " *" if fp == current else ""
-                print(colored(f"{idx}. {fp}{marker}", "cyan"))
+                print(colored(f"{idx}. {label}{marker}", "cyan"))
 
             print(colored(f"{len(fingerprints)+1}. Add a new seed profile", "cyan"))
 
@@ -532,7 +537,12 @@ class PasswordManager:
             print(colored("\nAvailable Seed Profiles:", "cyan"))
             fingerprints = self.fingerprint_manager.list_fingerprints()
             for idx, fp in enumerate(fingerprints, start=1):
-                print(colored(f"{idx}. {fp}", "cyan"))
+                display = (
+                    self.fingerprint_manager.display_name(fp)
+                    if hasattr(self.fingerprint_manager, "display_name")
+                    else fp
+                )
+                print(colored(f"{idx}. {display}", "cyan"))
 
             choice = input("Select a seed profile by number to switch: ").strip()
             if not choice.isdigit() or not (1 <= int(choice) <= len(fingerprints)):
@@ -680,7 +690,12 @@ class PasswordManager:
 
             print(colored("Available Seed Profiles:", "cyan"))
             for idx, fp in enumerate(fingerprints, start=1):
-                print(colored(f"{idx}. {fp}", "cyan"))
+                label = (
+                    self.fingerprint_manager.display_name(fp)
+                    if hasattr(self.fingerprint_manager, "display_name")
+                    else fp
+                )
+                print(colored(f"{idx}. {label}", "cyan"))
 
             choice = input("Select a seed profile by number: ").strip()
             if not choice.isdigit() or not (1 <= int(choice) <= len(fingerprints)):

--- a/src/utils/terminal_utils.py
+++ b/src/utils/terminal_utils.py
@@ -8,6 +8,20 @@ from termcolor import colored
 from utils.color_scheme import color_text
 
 
+def format_profile(fingerprint: str | None, pm=None) -> str | None:
+    """Return display string for a fingerprint with optional custom name."""
+    if not fingerprint:
+        return None
+    if pm and getattr(pm, "fingerprint_manager", None):
+        try:
+            name = pm.fingerprint_manager.get_name(fingerprint)
+            if name:
+                return f"{name} ({fingerprint})"
+        except Exception:
+            pass
+    return fingerprint
+
+
 def clear_screen() -> None:
     """Clear the terminal screen using an ANSI escape code."""
     print("\033c", end="")
@@ -18,16 +32,17 @@ def clear_and_print_fingerprint(
     breadcrumb: str | None = None,
     parent_fingerprint: str | None = None,
     child_fingerprint: str | None = None,
+    pm=None,
 ) -> None:
     """Clear the screen and optionally display the current fingerprint and path."""
     clear_screen()
     header_fp = None
     if parent_fingerprint and child_fingerprint:
-        header_fp = f"{parent_fingerprint} > Managed Account > {child_fingerprint}"
+        header_fp = f"{format_profile(parent_fingerprint, pm)} > Managed Account > {format_profile(child_fingerprint, pm)}"
     elif fingerprint:
-        header_fp = fingerprint
+        header_fp = format_profile(fingerprint, pm)
     elif parent_fingerprint or child_fingerprint:
-        header_fp = parent_fingerprint or child_fingerprint
+        header_fp = format_profile(parent_fingerprint or child_fingerprint, pm)
     if header_fp:
         header = f"Seed Profile: {header_fp}"
         if breadcrumb:
@@ -36,15 +51,15 @@ def clear_and_print_fingerprint(
 
 
 def clear_and_print_profile_chain(
-    fingerprints: list[str] | None, breadcrumb: str | None = None
+    fingerprints: list[str] | None, breadcrumb: str | None = None, pm=None
 ) -> None:
     """Clear the screen and display a chain of fingerprints."""
     clear_screen()
     if not fingerprints:
         return
-    chain = fingerprints[0]
+    chain = format_profile(fingerprints[0], pm)
     for fp in fingerprints[1:]:
-        chain += f" > Managed Account > {fp}"
+        chain += f" > Managed Account > {format_profile(fp, pm)}"
     header = f"Seed Profile: {chain}"
     if breadcrumb:
         header += f" > {breadcrumb}"
@@ -63,11 +78,11 @@ def clear_header_with_notification(
     clear_screen()
     header_fp = None
     if parent_fingerprint and child_fingerprint:
-        header_fp = f"{parent_fingerprint} > Managed Account > {child_fingerprint}"
+        header_fp = f"{format_profile(parent_fingerprint, pm)} > Managed Account > {format_profile(child_fingerprint, pm)}"
     elif fingerprint:
-        header_fp = fingerprint
+        header_fp = format_profile(fingerprint, pm)
     elif parent_fingerprint or child_fingerprint:
-        header_fp = parent_fingerprint or child_fingerprint
+        header_fp = format_profile(parent_fingerprint or child_fingerprint, pm)
     if header_fp:
         header = f"Seed Profile: {header_fp}"
         if breadcrumb:


### PR DESCRIPTION
## Summary
- support optional names for seed profiles stored locally
- display names alongside fingerprints in menus and headers
- allow editing the name from Settings > Profiles
- document the new option in README and docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68770302e91c832bba2dcf9c061eb4e5