### PR TITLE
Improve seed input flow

### DIFF
--- a/src/tests/test_manager_seed_setup.py
+++ b/src/tests/test_manager_seed_setup.py
@@ -1,6 +1,7 @@
 import builtins
 from mnemonic import Mnemonic
 from password_manager.manager import PasswordManager
+from utils import seed_prompt
 
 
 def test_validate_bip85_seed_invalid_word():
@@ -24,6 +25,7 @@ def test_setup_existing_seed_words(monkeypatch):
     phrase = m.generate(strength=128)
     words = phrase.split()
     inputs = iter(words + ["y"] * len(words))
+    monkeypatch.setattr(seed_prompt, "masked_input", lambda *_: next(inputs))
     monkeypatch.setattr(builtins, "input", lambda *_: next(inputs))
 
     pm = PasswordManager.__new__(PasswordManager)

--- a/src/tests/test_seed_prompt.py
+++ b/src/tests/test_seed_prompt.py
@@ -38,6 +38,7 @@ def test_prompt_seed_words_valid(monkeypatch):
     words = phrase.split()
 
     inputs = iter(words + ["y"] * len(words))
+    monkeypatch.setattr(seed_prompt, "masked_input", lambda *_: next(inputs))
     monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
 
     result = seed_prompt.prompt_seed_words(len(words))
@@ -52,6 +53,7 @@ def test_prompt_seed_words_invalid_word(monkeypatch):
     words = phrase.split()
     # Insert an invalid word for the first entry then the correct one
     inputs = iter(["invalid"] + [words[0]] + words[1:] + ["y"] * len(words))
+    monkeypatch.setattr(seed_prompt, "masked_input", lambda *_: next(inputs))
     monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
 
     result = seed_prompt.prompt_seed_words(len(words))

--- a/src/utils/seed_prompt.py
+++ b/src/utils/seed_prompt.py
@@ -13,6 +13,8 @@ except ImportError:  # pragma: no cover - POSIX only
     termios = None  # type: ignore
     tty = None  # type: ignore
 
+from utils.terminal_utils import clear_screen
+
 
 def _masked_input_windows(prompt: str) -> str:
     """Windows implementation using ``msvcrt``."""
@@ -105,9 +107,10 @@ def prompt_seed_words(count: int = 12) -> str:
 
     idx = 0
     while idx < count:
+        clear_screen()
         progress = [f"{i+1}: {'*' if w else '_'}" for i, w in enumerate(words)]
         print("\n".join(progress))
-        entered = input(f"Enter word number {idx+1}: ").strip().lower()
+        entered = masked_input(f"Enter word number {idx+1}: ").strip().lower()
         if entered not in m.wordlist:
             print("Invalid word, try again.")
             continue
@@ -116,6 +119,9 @@ def prompt_seed_words(count: int = 12) -> str:
 
     for i in range(count):
         while True:
+            clear_screen()
+            progress = [f"{j+1}: {'*' if j < i else '_'}" for j in range(count)]
+            print("\n".join(progress))
             response = (
                 input(f"Is this the correct word for number {i+1}? {words[i]} (Y/N): ")
                 .strip()
@@ -125,7 +131,12 @@ def prompt_seed_words(count: int = 12) -> str:
                 break
             if response in ("n", "no"):
                 while True:
-                    new_word = input(f"Re-enter word number {i+1}: ").strip().lower()
+                    clear_screen()
+                    progress = [f"{j+1}: {'*' if j < i else '_'}" for j in range(count)]
+                    print("\n".join(progress))
+                    new_word = (
+                        masked_input(f"Re-enter word number {i+1}: ").strip().lower()
+                    )
                     if new_word in m.wordlist:
                         words[i] = new_word
                         break


### PR DESCRIPTION
## Summary
- prompt seed words with masked input
- show progress using clear_screen in loops
- update unit tests for new input prompts

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6877d41c36ac832baa8238c76b106fc8