### PR TITLE
Add run_ci_tests script and update workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -81,10 +81,15 @@ jobs:
         if: github.ref == 'refs/heads/main' || github.event_name == 'schedule'
         run: echo "NOSTR_E2E=1" >> $GITHUB_ENV
       - name: Run tests with coverage
+        timeout-minutes: 16
         shell: bash
-        run: |
-          pytest ${STRESS_ARGS} --cov=src --cov-report=xml --cov-report=term-missing \
-            --cov-fail-under=20 src/tests
+        run: scripts/run_ci_tests.sh
+      - name: Upload pytest log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-log-${{ matrix.os }}
+          path: pytest.log
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/run_ci_tests.sh
+++ b/scripts/run_ci_tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eo pipefail
+timeout 15m pytest -vv ${STRESS_ARGS} \
+    --cov=src --cov-report=xml --cov-report=term-missing \
+    --cov-fail-under=20 src/tests 2>&1 | tee pytest.log
+status=${PIPESTATUS[0]}
+if [[ $status -eq 124 ]]; then
+    echo "::error::Tests exceeded 15-minute limit"
+    tail -n 20 pytest.log
+    exit 1
+fi
+exit $status

--- a/scripts/run_ci_tests.sh
+++ b/scripts/run_ci_tests.sh
@@ -1,9 +1,28 @@
 #!/usr/bin/env bash
 set -eo pipefail
-timeout 15m pytest -vv ${STRESS_ARGS} \
+
+pytest_cmd=(pytest -vv ${STRESS_ARGS} \
     --cov=src --cov-report=xml --cov-report=term-missing \
-    --cov-fail-under=20 src/tests 2>&1 | tee pytest.log
-status=${PIPESTATUS[0]}
+    --cov-fail-under=20 src/tests)
+
+timeout_bin="timeout"
+if ! command -v "$timeout_bin" >/dev/null 2>&1; then
+    if command -v gtimeout >/dev/null 2>&1; then
+        timeout_bin="gtimeout"
+    else
+        timeout_bin=""
+    fi
+fi
+
+if [[ -n "$timeout_bin" ]]; then
+    $timeout_bin 15m "${pytest_cmd[@]}" 2>&1 | tee pytest.log
+    status=${PIPESTATUS[0]}
+else
+    echo "timeout command not found; running tests without timeout" >&2
+    "${pytest_cmd[@]}" 2>&1 | tee pytest.log
+    status=${PIPESTATUS[0]}
+fi
+
 if [[ $status -eq 124 ]]; then
     echo "::error::Tests exceeded 15-minute limit"
     tail -n 20 pytest.log


### PR DESCRIPTION
## Summary
- add `run_ci_tests.sh` for CI test execution with timeout handling
- call the script in the GitHub Actions workflow and upload the pytest log

## Testing
- `pre-commit run --files scripts/run_ci_tests.sh .github/workflows/python-ci.yml`

------
https://chatgpt.com/codex/tasks/task_b_687801586d7c832b8a0d33ab64fbf11a