### PR TITLE
Add vendoring script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ src/seedpass.egg-info/SOURCES.txt
 src/seedpass.egg-info/dependency_links.txt
 src/seedpass.egg-info/entry_points.txt
 src/seedpass.egg-info/top_level.txt
+
+# Allow vendored dependencies to be committed
+!src/vendor/

--- a/scripts/vendor_dependencies.sh
+++ b/scripts/vendor_dependencies.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VENDOR_DIR="src/vendor"
+
+# Clean vendor directory
+rm -rf "$VENDOR_DIR"
+mkdir -p "$VENDOR_DIR"
+
+pip download --no-binary :all: -r src/runtime_requirements.txt -d "$VENDOR_DIR"
+
+echo "Vendored dependencies installed in $VENDOR_DIR"


### PR DESCRIPTION
## Summary
- add `vendor_dependencies.sh` for downloading runtime wheels
- keep `src/vendor/` committed

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6878edb6639c832b97a91a36230976cf