### PR TITLE
Add vendor path to main

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,13 @@
 # main.py
-import os
 from pathlib import Path
 import sys
+
+# Add bundled vendor directory to sys.path so bundled dependencies can be imported
+vendor_dir = Path(__file__).parent / "vendor"
+if vendor_dir.exists():
+    sys.path.insert(0, str(vendor_dir))
+
+import os
 import logging
 import signal
 import getpass


### PR DESCRIPTION
## Summary
- allow `src/vendor` to be imported by modifying `sys.path`
- add comment explaining the purpose

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6878ef13a24c832b89c5349cc042afe3