### PR TITLE
Add PyInstaller spec and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
   - [Running the Application](#running-the-application)
   - [Managing Multiple Seeds](#managing-multiple-seeds)
     - [Additional Entry Types](#additional-entry-types)
+- [Building a standalone executable](#building-a-standalone-executable)
 - [Security Considerations](#security-considerations)
 - [Contributing](#contributing)
 - [License](#license)
@@ -502,6 +503,22 @@ python -m mutmut results
 ```
 
 Mutation testing is disabled in the GitHub workflow due to reliability issues and should be run on a desktop environment instead.
+
+## Building a standalone executable
+
+1. Run the vendoring script to bundle runtime dependencies:
+
+```bash
+scripts/vendor_dependencies.sh
+```
+
+2. Build the binary with PyInstaller:
+
+```bash
+pyinstaller SeedPass.spec
+```
+
+The standalone executable will appear in the `dist/` directory. This process works on Windows, macOS and Linux but you must build on each platform for a native binary.
 
 ## Security Considerations
 

--- a/SeedPass.spec
+++ b/SeedPass.spec
@@ -1,0 +1,38 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['src/main.py'],
+    pathex=['src', 'src/vendor'],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='SeedPass',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)


### PR DESCRIPTION
## Summary
- generate default PyInstaller spec and commit it
- configure spec search path for vendor deps
- document vendor/build steps in README

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6878f1270ddc832ba21ad7932b615da5