### PR TITLE
Use masked input for passwords

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,6 @@ if vendor_dir.exists():
 import os
 import logging
 import signal
-import getpass
 import time
 import argparse
 import asyncio

--- a/src/password_manager/config_manager.py
+++ b/src/password_manager/config_manager.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 
-import getpass
+from utils.seed_prompt import masked_input
 
 import bcrypt
 
@@ -93,7 +93,7 @@ class ConfigManager:
                 self.save_config(data)
             if require_pin and data.get("pin_hash"):
                 for _ in range(3):
-                    pin = getpass.getpass("Enter settings PIN: ").strip()
+                    pin = masked_input("Enter settings PIN: ").strip()
                     if bcrypt.checkpw(pin.encode(), data["pin_hash"].encode()):
                         break
                     print("Invalid PIN")

--- a/src/password_manager/manager.py
+++ b/src/password_manager/manager.py
@@ -12,7 +12,6 @@ with the password manager functionalities.
 import sys
 import json
 import logging
-import getpass
 import os
 import hashlib
 from typing import Optional, Literal
@@ -668,8 +667,8 @@ class PasswordManager:
         Prompts the user for the master password to decrypt the seed.
         """
         try:
-            # Prompt for password
-            password = getpass.getpass(prompt="Enter your login password: ").strip()
+            # Prompt for password using masked input
+            password = prompt_existing_password("Enter your login password: ")
 
             # Derive encryption key from password
             iterations = (

--- a/src/tests/test_password_prompt.py
+++ b/src/tests/test_password_prompt.py
@@ -9,16 +9,14 @@ from utils import password_prompt
 
 def test_prompt_new_password(monkeypatch):
     responses = cycle(["goodpass", "goodpass"])
-    monkeypatch.setattr(
-        password_prompt.getpass, "getpass", lambda prompt: next(responses)
-    )
+    monkeypatch.setattr(password_prompt, "masked_input", lambda prompt: next(responses))
     result = password_prompt.prompt_new_password()
     assert result == "goodpass"
 
 
 def test_prompt_new_password_retry(monkeypatch, caplog):
     seq = iter(["pass1", "pass2", "passgood", "passgood"])
-    monkeypatch.setattr(password_prompt.getpass, "getpass", lambda prompt: next(seq))
+    monkeypatch.setattr(password_prompt, "masked_input", lambda prompt: next(seq))
     caplog.set_level(logging.WARNING)
     result = password_prompt.prompt_new_password()
     assert "User entered a password shorter" in caplog.text
@@ -26,7 +24,7 @@ def test_prompt_new_password_retry(monkeypatch, caplog):
 
 
 def test_prompt_existing_password(monkeypatch):
-    monkeypatch.setattr(password_prompt.getpass, "getpass", lambda prompt: "mypassword")
+    monkeypatch.setattr(password_prompt, "masked_input", lambda prompt: "mypassword")
     assert password_prompt.prompt_existing_password() == "mypassword"
 
 

--- a/src/utils/password_prompt.py
+++ b/src/utils/password_prompt.py
@@ -11,11 +11,10 @@ this module enhances code reuse, security, and maintainability across the applic
 Ensure that all dependencies are installed and properly configured in your environment.
 """
 
-import getpass
+from utils.seed_prompt import masked_input
 import logging
 import sys
 import unicodedata
-import traceback
 
 from termcolor import colored
 from colorama import init as colorama_init
@@ -53,8 +52,8 @@ def prompt_new_password() -> str:
 
     while attempts < max_retries:
         try:
-            password = getpass.getpass(prompt="Enter a new password: ").strip()
-            confirm_password = getpass.getpass(prompt="Confirm your password: ").strip()
+            password = masked_input("Enter a new password: ").strip()
+            confirm_password = masked_input("Confirm your password: ").strip()
 
             if not password:
                 print(
@@ -128,7 +127,7 @@ def prompt_existing_password(
     attempts = 0
     while attempts < max_retries:
         try:
-            password = getpass.getpass(prompt=prompt_message).strip()
+            password = masked_input(prompt_message).strip()
 
             if not password:
                 print(


### PR DESCRIPTION
## Summary
- replace all `getpass` calls with `masked_input`
- drop unused getpass imports
- adjust config PIN prompt
- update tests for new input handling

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6878ff4d3acc832b9862f47d6bd67aef