### PR TITLE
Fix Windows workflow test hang

### DIFF
--- a/src/tests/test_manager_list_entries.py
+++ b/src/tests/test_manager_list_entries.py
@@ -176,6 +176,8 @@ def _detail_common(monkeypatch, pm):
     monkeypatch.setattr(
         "password_manager.manager.confirm_action", lambda *a, **k: False
     )
+    monkeypatch.setattr("password_manager.manager.timed_input", lambda *a, **k: "b")
+    monkeypatch.setattr("password_manager.manager.time.sleep", lambda *a, **k: None)
     monkeypatch.setattr(pm, "notify", lambda *a, **k: None)
     pm.password_generator = SimpleNamespace(generate_password=lambda l, i: "pw123")
     called = []


### PR DESCRIPTION
## Summary
- patch `_detail_common` to stub `timed_input` and `time.sleep`

This prevents a Windows-specific hang in the TOTP detail test when
`timed_input` waits forever for keyboard input.

## Testing
- `pytest -k 'test_show_entry_details_with_enum_type and totp' -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68790b2924b4832bbdf90c09a0e4cbba