### PR TITLE
Introduce attempt_initial_sync

### DIFF
--- a/src/tests/test_full_sync_roundtrip.py
+++ b/src/tests/test_full_sync_roundtrip.py
@@ -47,7 +47,8 @@ def test_full_sync_roundtrip(dummy_nostr_client):
         manifest_id = relay.manifests[-1].id
 
         # Manager B retrieves snapshot
-        pm_b.sync_index_from_nostr_if_missing()
+        result = pm_b.attempt_initial_sync()
+        assert result is True
         entries = pm_b.entry_manager.list_entries()
         assert [e[1] for e in entries] == ["site1"]
 

--- a/src/tests/test_full_sync_roundtrip_new.py
+++ b/src/tests/test_full_sync_roundtrip_new.py
@@ -47,7 +47,8 @@ def test_full_sync_roundtrip(dummy_nostr_client):
         manifest_id = relay.manifests[-1].id
 
         # Manager B retrieves snapshot
-        pm_b.sync_index_from_nostr_if_missing()
+        result = pm_b.attempt_initial_sync()
+        assert result is True
         entries = pm_b.entry_manager.list_entries()
         assert [e[1] for e in entries] == ["site1"]
 

--- a/src/tests/test_profiles.py
+++ b/src/tests/test_profiles.py
@@ -81,6 +81,7 @@ def test_sync_index_missing_bad_data(monkeypatch, dummy_nostr_client):
         )
         monkeypatch.setattr(client, "fetch_deltas_since", lambda *_a, **_k: [])
 
-        pm.sync_index_from_nostr_if_missing()
-        data = pm.vault.load_index()
-        assert data["entries"] == {}
+        result = pm.attempt_initial_sync()
+        assert result is False
+        index_path = dir_path / "seedpass_entries_db.json.enc"
+        assert not index_path.exists()


### PR DESCRIPTION
## Summary
- add `attempt_initial_sync` to handle initial download of vault data
- use the new method inside background sync logic
- keep `sync_index_from_nostr_if_missing` as wrapper around the new method
- update tests for the boolean return and unchanged index on failure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687946562d3c832b8dac8658d4e7b802