### PR TITLE
Expose all event IDs when syncing vault

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -365,14 +365,15 @@ def handle_post_to_nostr(
     Handles the action of posting the encrypted password index to Nostr.
     """
     try:
-        event_id = password_manager.sync_vault(alt_summary=alt_summary)
-        if event_id:
-            print(
-                colored(
-                    f"\N{WHITE HEAVY CHECK MARK} Sync complete. Event ID: {event_id}",
-                    "green",
-                )
-            )
+        result = password_manager.sync_vault(alt_summary=alt_summary)
+        if result:
+            print(colored("\N{WHITE HEAVY CHECK MARK} Sync complete.", "green"))
+            print("Event IDs:")
+            print(f"  manifest: {result['manifest_id']}")
+            for cid in result["chunk_ids"]:
+                print(f"  chunk: {cid}")
+            for did in result["delta_ids"]:
+                print(f"  delta: {did}")
             logging.info("Encrypted index posted to Nostr successfully.")
         else:
             print(colored("\N{CROSS MARK} Sync failed…", "red"))

--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -419,9 +419,14 @@ def vault_reveal_parent_seed(
 def nostr_sync(ctx: typer.Context) -> None:
     """Sync with configured Nostr relays."""
     pm = _get_pm(ctx)
-    event_id = pm.sync_vault()
-    if event_id:
-        typer.echo(event_id)
+    result = pm.sync_vault()
+    if result:
+        typer.echo("Event IDs:")
+        typer.echo(f"- manifest: {result['manifest_id']}")
+        for cid in result["chunk_ids"]:
+            typer.echo(f"- chunk: {cid}")
+        for did in result["delta_ids"]:
+            typer.echo(f"- delta: {did}")
     else:
         typer.echo("Error: Failed to sync vault")
 

--- a/src/tests/test_cli_doc_examples.py
+++ b/src/tests/test_cli_doc_examples.py
@@ -53,7 +53,11 @@ class DummyPM:
         self.nostr_client = SimpleNamespace(
             key_manager=SimpleNamespace(get_npub=lambda: "npub")
         )
-        self.sync_vault = lambda: "event"
+        self.sync_vault = lambda: {
+            "manifest_id": "event",
+            "chunk_ids": ["c1"],
+            "delta_ids": [],
+        }
         self.config_manager = SimpleNamespace(
             load_config=lambda require_pin=False: {"inactivity_timeout": 30},
             set_inactivity_timeout=lambda v: None,

--- a/src/tests/test_post_sync_messages.py
+++ b/src/tests/test_post_sync_messages.py
@@ -9,12 +9,17 @@ import main
 
 def test_handle_post_success(capsys):
     pm = SimpleNamespace(
-        sync_vault=lambda alt_summary=None: "abcd",
+        sync_vault=lambda alt_summary=None: {
+            "manifest_id": "abcd",
+            "chunk_ids": ["c1", "c2"],
+            "delta_ids": ["d1"],
+        },
     )
     main.handle_post_to_nostr(pm)
     out = capsys.readouterr().out
     assert "✅ Sync complete." in out
     assert "abcd" in out
+    assert "c1" in out and "c2" in out and "d1" in out
 
 
 def test_handle_post_failure(capsys):

--- a/src/tests/test_typer_cli.py
+++ b/src/tests/test_typer_cli.py
@@ -288,7 +288,11 @@ def test_nostr_sync(monkeypatch):
 
     def sync_vault():
         called["called"] = True
-        return "evt123"
+        return {
+            "manifest_id": "evt123",
+            "chunk_ids": ["c1"],
+            "delta_ids": ["d1"],
+        }
 
     pm = SimpleNamespace(sync_vault=sync_vault, select_fingerprint=lambda fp: None)
     monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
@@ -296,6 +300,8 @@ def test_nostr_sync(monkeypatch):
     assert result.exit_code == 0
     assert called.get("called") is True
     assert "evt123" in result.stdout
+    assert "c1" in result.stdout
+    assert "d1" in result.stdout
 
 
 def test_generate_password(monkeypatch):


### PR DESCRIPTION
## Summary
- return manifest, chunk, and delta event IDs from `sync_vault`
- list all returned IDs in `nostr sync` command and in `handle_post_to_nostr`
- update CLI doc tests and unit tests for new output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68794abba01c832bbbf09cd5b7276fd7