### PR TITLE
Add Nostr sync edge case tests

### DIFF
--- a/src/tests/test_post_sync_messages.py
+++ b/src/tests/test_post_sync_messages.py
@@ -29,3 +29,24 @@ def test_handle_post_failure(capsys):
     main.handle_post_to_nostr(pm)
     out = capsys.readouterr().out
     assert "❌ Sync failed…" in out
+
+
+def test_handle_post_prints_all_ids(capsys):
+    pm = SimpleNamespace(
+        sync_vault=lambda alt_summary=None: {
+            "manifest_id": "m1",
+            "chunk_ids": ["c1", "c2"],
+            "delta_ids": ["d1", "d2"],
+        }
+    )
+    main.handle_post_to_nostr(pm)
+    out_lines = capsys.readouterr().out.splitlines()
+    expected = [
+        "  manifest: m1",
+        "  chunk: c1",
+        "  chunk: c2",
+        "  delta: d1",
+        "  delta: d2",
+    ]
+    for line in expected:
+        assert any(line in ol for ol in out_lines)


### PR DESCRIPTION
## Summary
- cover incomplete snapshot retrieval in `attempt_initial_sync`
- ensure snapshot fetching falls back to event ids
- verify `handle_post_to_nostr` prints all event IDs

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68794f8cea68832bb3f60d1f16c2a7ff