### PR TITLE
Refactor password change and unlock

### DIFF
--- a/src/seedpass/api.py
+++ b/src/seedpass/api.py
@@ -554,11 +554,13 @@ def backup_parent_seed(
 
 
 @app.post("/api/v1/change-password")
-def change_password(authorization: str | None = Header(None)) -> dict[str, str]:
+def change_password(
+    data: dict, authorization: str | None = Header(None)
+) -> dict[str, str]:
     """Change the master password for the active profile."""
     _check_token(authorization)
     assert _pm is not None
-    _pm.change_password()
+    _pm.change_password(data.get("old", ""), data.get("new", ""))
     return {"status": "ok"}
 
 

--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -384,7 +384,27 @@ def vault_import(
 def vault_change_password(ctx: typer.Context) -> None:
     """Change the master password used for encryption."""
     pm = _get_pm(ctx)
-    pm.change_password()
+    old_pw = typer.prompt("Current password", hide_input=True)
+    new_pw = typer.prompt("New password", hide_input=True, confirmation_prompt=True)
+    try:
+        pm.change_password(old_pw, new_pw)
+    except Exception as exc:  # pragma: no cover - pass through errors
+        typer.echo(f"Error: {exc}")
+        raise typer.Exit(code=1)
+    typer.echo("Password updated")
+
+
+@vault_app.command("unlock")
+def vault_unlock(ctx: typer.Context) -> None:
+    """Unlock the vault for the active profile."""
+    pm = _get_pm(ctx)
+    password = typer.prompt("Master password", hide_input=True)
+    try:
+        duration = pm.unlock_vault(password)
+    except Exception as exc:  # pragma: no cover - pass through errors
+        typer.echo(f"Error: {exc}")
+        raise typer.Exit(code=1)
+    typer.echo(f"Unlocked in {duration:.2f}s")
 
 
 @vault_app.command("lock")

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -179,12 +179,16 @@ def test_change_password_route(client):
     cl, token = client
     called = {}
 
-    api._pm.change_password = lambda: called.setdefault("called", True)
+    api._pm.change_password = lambda o, n: called.setdefault("called", (o, n))
     headers = {"Authorization": f"Bearer {token}", "Origin": "http://example.com"}
-    res = cl.post("/api/v1/change-password", headers=headers)
+    res = cl.post(
+        "/api/v1/change-password",
+        headers=headers,
+        json={"old": "old", "new": "new"},
+    )
     assert res.status_code == 200
     assert res.json() == {"status": "ok"}
-    assert called.get("called") is True
+    assert called.get("called") == ("old", "new")
     assert res.headers.get("access-control-allow-origin") == "http://example.com"
 
 

--- a/src/tests/test_api_new_endpoints.py
+++ b/src/tests/test_api_new_endpoints.py
@@ -291,8 +291,8 @@ def test_vault_lock_endpoint(client):
     assert res.json() == {"status": "locked"}
     assert called.get("locked") is True
     assert api._pm.locked is True
-    api._pm.unlock_vault = lambda: setattr(api._pm, "locked", False)
-    api._pm.unlock_vault()
+    api._pm.unlock_vault = lambda pw: setattr(api._pm, "locked", False)
+    api._pm.unlock_vault("pw")
     assert api._pm.locked is False
 
 

--- a/src/tests/test_cli_doc_examples.py
+++ b/src/tests/test_cli_doc_examples.py
@@ -40,7 +40,7 @@ class DummyPM:
         self.handle_display_totp_codes = lambda: None
         self.handle_export_database = lambda path: None
         self.handle_import_database = lambda path: None
-        self.change_password = lambda: None
+        self.change_password = lambda *a, **kw: None
         self.lock_vault = lambda: None
         self.get_profile_stats = lambda: {"n": 1}
         self.handle_backup_reveal_parent_seed = lambda path=None: None

--- a/src/tests/test_password_change.py
+++ b/src/tests/test_password_change.py
@@ -36,14 +36,9 @@ def test_change_password_triggers_nostr_backup(monkeypatch):
         pm.store_hashed_password = lambda pw: None
         pm.verify_password = lambda pw: True
 
-        monkeypatch.setattr(
-            "seedpass.core.manager.prompt_existing_password", lambda *_: "old"
-        )
-        monkeypatch.setattr("seedpass.core.manager.prompt_for_password", lambda: "new")
-
         with patch("seedpass.core.manager.NostrClient") as MockClient:
             mock_instance = MockClient.return_value
             mock_instance.publish_snapshot = AsyncMock(return_value=(None, "abcd"))
             pm.nostr_client = mock_instance
-            pm.change_password()
+            pm.change_password("old", "new")
             mock_instance.publish_snapshot.assert_called_once()

--- a/src/tests/test_password_unlock_after_change.py
+++ b/src/tests/test_password_unlock_after_change.py
@@ -71,7 +71,7 @@ def test_password_change_and_unlock(monkeypatch):
             ),
         )
 
-        pm.change_password()
+        pm.change_password(old_pw, new_pw)
         pm.lock_vault()
 
         monkeypatch.setattr(
@@ -81,7 +81,7 @@ def test_password_change_and_unlock(monkeypatch):
         monkeypatch.setattr(PasswordManager, "initialize_managers", lambda self: None)
         monkeypatch.setattr(PasswordManager, "sync_index_from_nostr", lambda self: None)
 
-        pm.unlock_vault()
+        pm.unlock_vault(new_pw)
 
         assert pm.parent_seed == SEED
         assert pm.verify_password(new_pw)

--- a/src/tests/test_typer_cli.py
+++ b/src/tests/test_typer_cli.py
@@ -126,14 +126,14 @@ def test_vault_import_triggers_sync(monkeypatch, tmp_path):
 def test_vault_change_password(monkeypatch):
     called = {}
 
-    def change_pw():
-        called["called"] = True
+    def change_pw(old, new):
+        called["args"] = (old, new)
 
     pm = SimpleNamespace(change_password=change_pw, select_fingerprint=lambda fp: None)
     monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
-    result = runner.invoke(app, ["vault", "change-password"])
+    result = runner.invoke(app, ["vault", "change-password"], input="old\nnew\nnew\n")
     assert result.exit_code == 0
-    assert called.get("called") is True
+    assert called.get("args") == ("old", "new")
 
 
 def test_vault_lock(monkeypatch):

--- a/src/tests/test_unlock_sync.py
+++ b/src/tests/test_unlock_sync.py
@@ -22,7 +22,7 @@ def test_unlock_triggers_sync(monkeypatch, tmp_path):
 
     monkeypatch.setattr(PasswordManager, "sync_index_from_nostr", fake_sync)
 
-    pm.unlock_vault()
+    pm.unlock_vault("pw")
     pm.start_background_sync()
     time.sleep(0.05)
 

--- a/src/tests/test_verbose_timing.py
+++ b/src/tests/test_verbose_timing.py
@@ -8,7 +8,7 @@ from helpers import dummy_nostr_client
 def test_unlock_vault_logs_time(monkeypatch, caplog, tmp_path):
     pm = PasswordManager.__new__(PasswordManager)
     pm.fingerprint_dir = tmp_path
-    pm.setup_encryption_manager = lambda path: None
+    pm.setup_encryption_manager = lambda path, pw=None: None
     pm.initialize_bip85 = lambda: None
     pm.initialize_managers = lambda: None
     pm.update_activity = lambda: None
@@ -16,7 +16,7 @@ def test_unlock_vault_logs_time(monkeypatch, caplog, tmp_path):
     caplog.set_level(logging.INFO, logger="seedpass.core.manager")
     times = iter([0.0, 1.0])
     monkeypatch.setattr("seedpass.core.manager.time.perf_counter", lambda: next(times))
-    pm.unlock_vault()
+    pm.unlock_vault("pw")
     assert "Vault unlocked in 1.00 seconds" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- accept passwords as parameters in `PasswordManager.unlock_vault` and `change_password`
- add `vault unlock` command and update CLI `change-password`
- expose password change parameters via API
- update tests for new method signatures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6879872aaab8832b88298b6847c9d260