### PR TITLE
Add Briefcase doc and GUI script

### DIFF
--- a/docs/docs/content/01-getting-started/05-briefcase.md
+++ b/docs/docs/content/01-getting-started/05-briefcase.md
@@ -1,0 +1,20 @@
+# Packaging the GUI with Briefcase
+
+This project uses [BeeWare's Briefcase](https://beeware.org) to generate
+platform‑native installers. Once your development environment is set up,
+package the GUI by running the following commands from the repository root:
+
+```bash
+# Create the application scaffold for your platform
+briefcase create
+
+# Compile dependencies and produce a distributable bundle
+briefcase build
+
+# Run the packaged application
+briefcase run
+```
+
+`briefcase create` only needs to be executed once per platform. After the
+initial creation step you can repeatedly run `briefcase build` followed by
+`briefcase run` to test your packaged application on Windows, macOS or Linux.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 
 [project.scripts]
 seedpass = "seedpass.cli:app"
+seedpass-gui = "seedpass_gui.app:main"
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/run_gui.py
+++ b/src/run_gui.py
@@ -1,0 +1,4 @@
+from seedpass_gui.app import main
+
+if __name__ == "__main__":
+    main()

--- a/src/seedpass_gui/app.py
+++ b/src/seedpass_gui/app.py
@@ -197,3 +197,8 @@ class SeedPassApp(toga.App):
         )
         self.main_window = None
         self.lock_window.show()
+
+
+def main() -> None:  # pragma: no cover - GUI bootstrap
+    """Run the BeeWare application."""
+    SeedPassApp().main_loop()


### PR DESCRIPTION
## Summary
- expose a `main()` runner inside `seedpass_gui.app`
- add `run_gui.py` to start the BeeWare GUI
- register the GUI command in `pyproject.toml`
- document Briefcase packaging commands

## Testing
- `black .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6879a03e239c832b8bfe5981080e8be7