### PR TITLE
Update API docs with GUI adapter note

### DIFF
--- a/docs/docs/content/01-getting-started/02-api_reference.md
+++ b/docs/docs/content/01-getting-started/02-api_reference.md
@@ -2,6 +2,9 @@
 
 This guide covers how to start the SeedPass API, authenticate requests, and interact with the available endpoints.
 
+**Note:** All UI layers, including the CLI, BeeWare GUI, and future adapters, consume this REST API through service classes in `seedpass.core`. See [docs/gui_adapter.md](docs/gui_adapter.md) for more details on the GUI integration.
+
+
 ## Starting the API
 
 Run `seedpass api start` from your terminal. The command prints a one‑time token used for authentication:


### PR DESCRIPTION
## Summary
- mention GUI adapter guide and `seedpass.core` service layer
- note all UI layers use the same API

## Testing
- `black . --line-length 88`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6879ad8eab8c832ba8b669ca8267caff