### PR TITLE
Refactor manager input arguments

### DIFF
--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -462,8 +462,9 @@ def vault_reveal_parent_seed(
 ) -> None:
     """Display the parent seed and optionally write an encrypted backup file."""
     vault_service, _profile, _sync = _get_services(ctx)
+    password = typer.prompt("Master password", hide_input=True)
     vault_service.backup_parent_seed(
-        BackupParentSeedRequest(path=Path(file) if file else None)
+        BackupParentSeedRequest(path=Path(file) if file else None, password=password)
     )
 
 
@@ -630,7 +631,10 @@ def fingerprint_remove(ctx: typer.Context, fingerprint: str) -> None:
 def fingerprint_switch(ctx: typer.Context, fingerprint: str) -> None:
     """Switch to another seed profile."""
     _vault, profile_service, _sync = _get_services(ctx)
-    profile_service.switch_profile(ProfileSwitchRequest(fingerprint=fingerprint))
+    password = typer.prompt("Master password", hide_input=True)
+    profile_service.switch_profile(
+        ProfileSwitchRequest(fingerprint=fingerprint, password=password)
+    )
 
 
 @util_app.command("generate-password")

--- a/src/seedpass/core/api.py
+++ b/src/seedpass/core/api.py
@@ -57,12 +57,14 @@ class BackupParentSeedRequest(BaseModel):
     """Optional path to write the encrypted seed backup."""
 
     path: Optional[Path] = None
+    password: Optional[str] = None
 
 
 class ProfileSwitchRequest(BaseModel):
     """Select a different seed profile."""
 
     fingerprint: str
+    password: Optional[str] = None
 
 
 class ProfileRemoveRequest(BaseModel):
@@ -123,7 +125,9 @@ class VaultService:
         """Backup and reveal the parent seed."""
 
         with self._lock:
-            self._manager.handle_backup_reveal_parent_seed(req.path)
+            self._manager.handle_backup_reveal_parent_seed(
+                req.path, password=req.password
+            )
 
     def stats(self) -> Dict:
         """Return statistics about the current profile."""
@@ -164,7 +168,7 @@ class ProfileService:
         """Switch to ``req.fingerprint``."""
 
         with self._lock:
-            self._manager.select_fingerprint(req.fingerprint)
+            self._manager.select_fingerprint(req.fingerprint, password=req.password)
 
 
 class SyncService:

--- a/src/tests/test_background_sync_always.py
+++ b/src/tests/test_background_sync_always.py
@@ -23,9 +23,6 @@ def test_switch_fingerprint_triggers_bg_sync(monkeypatch, tmp_path):
 
     monkeypatch.setattr("builtins.input", lambda *_a, **_k: "1")
     monkeypatch.setattr(
-        "seedpass.core.manager.prompt_existing_password", lambda *_a, **_k: "pw"
-    )
-    monkeypatch.setattr(
         PasswordManager, "setup_encryption_manager", lambda *a, **k: True
     )
     monkeypatch.setattr(PasswordManager, "initialize_bip85", lambda *a, **k: None)
@@ -39,7 +36,7 @@ def test_switch_fingerprint_triggers_bg_sync(monkeypatch, tmp_path):
 
     monkeypatch.setattr(PasswordManager, "start_background_sync", fake_bg)
 
-    assert pm.handle_switch_fingerprint()
+    assert pm.handle_switch_fingerprint(password="pw")
     assert calls["count"] == 1
 
 

--- a/src/tests/test_cli_doc_examples.py
+++ b/src/tests/test_cli_doc_examples.py
@@ -43,7 +43,7 @@ class DummyPM:
         self.change_password = lambda *a, **kw: None
         self.lock_vault = lambda: None
         self.get_profile_stats = lambda: {"n": 1}
-        self.handle_backup_reveal_parent_seed = lambda path=None: None
+        self.handle_backup_reveal_parent_seed = lambda path=None, **_: None
         self.handle_verify_checksum = lambda: None
         self.handle_update_script_checksum = lambda: None
         self.add_new_fingerprint = lambda: None
@@ -76,7 +76,7 @@ class DummyPM:
         )
         self.secret_mode_enabled = True
         self.clipboard_clear_delay = 30
-        self.select_fingerprint = lambda fp: None
+        self.select_fingerprint = lambda fp, **_: None
 
 
 def load_doc_commands() -> list[str]:

--- a/src/tests/test_parent_seed_backup.py
+++ b/src/tests/test_parent_seed_backup.py
@@ -24,9 +24,6 @@ def _make_pm(tmp_path: Path) -> PasswordManager:
 def test_handle_backup_reveal_parent_seed_confirm(monkeypatch, tmp_path, capsys):
     pm = _make_pm(tmp_path)
 
-    monkeypatch.setattr(
-        "seedpass.core.manager.prompt_existing_password", lambda *_: "pw"
-    )
     confirms = iter([True, True])
     monkeypatch.setattr(
         "seedpass.core.manager.confirm_action", lambda *_a, **_k: next(confirms)
@@ -39,7 +36,7 @@ def test_handle_backup_reveal_parent_seed_confirm(monkeypatch, tmp_path, capsys)
     pm.encryption_manager = SimpleNamespace(encrypt_and_save_file=fake_save)
     monkeypatch.setattr(builtins, "input", lambda *_: "mybackup.enc")
 
-    pm.handle_backup_reveal_parent_seed()
+    pm.handle_backup_reveal_parent_seed(password="pw")
     out = capsys.readouterr().out
 
     assert "seed phrase" in out
@@ -50,16 +47,13 @@ def test_handle_backup_reveal_parent_seed_confirm(monkeypatch, tmp_path, capsys)
 def test_handle_backup_reveal_parent_seed_cancel(monkeypatch, tmp_path, capsys):
     pm = _make_pm(tmp_path)
 
-    monkeypatch.setattr(
-        "seedpass.core.manager.prompt_existing_password", lambda *_: "pw"
-    )
     monkeypatch.setattr("seedpass.core.manager.confirm_action", lambda *_a, **_k: False)
     saved = []
     pm.encryption_manager = SimpleNamespace(
         encrypt_and_save_file=lambda data, path: saved.append((data, path))
     )
 
-    pm.handle_backup_reveal_parent_seed()
+    pm.handle_backup_reveal_parent_seed(password="pw")
     out = capsys.readouterr().out
 
     assert "seed phrase" not in out

--- a/src/tests/test_profiles.py
+++ b/src/tests/test_profiles.py
@@ -32,10 +32,6 @@ def test_add_and_switch_fingerprint(monkeypatch):
 
         monkeypatch.setattr("builtins.input", lambda *_args, **_kwargs: "1")
         monkeypatch.setattr(
-            "seedpass.core.manager.prompt_existing_password",
-            lambda *_a, **_k: "pass",
-        )
-        monkeypatch.setattr(
             PasswordManager,
             "setup_encryption_manager",
             lambda self, d, password=None, exit_on_fail=True: True,
@@ -50,7 +46,7 @@ def test_add_and_switch_fingerprint(monkeypatch):
             "seedpass.core.manager.NostrClient", lambda *a, **kw: object()
         )
 
-        assert pm.handle_switch_fingerprint()
+        assert pm.handle_switch_fingerprint(password="pass")
         assert pm.current_fingerprint == fingerprint
         assert fm.current_fingerprint == fingerprint
         assert pm.fingerprint_dir == expected_dir

--- a/src/tests/test_typer_cli.py
+++ b/src/tests/test_typer_cli.py
@@ -156,7 +156,7 @@ def test_vault_lock(monkeypatch):
 def test_vault_reveal_parent_seed(monkeypatch, tmp_path):
     called = {}
 
-    def reveal(path=None):
+    def reveal(path=None, **_):
         called["path"] = path
 
     pm = SimpleNamespace(
@@ -165,7 +165,9 @@ def test_vault_reveal_parent_seed(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
     out_path = tmp_path / "seed.enc"
     result = runner.invoke(
-        app, ["vault", "reveal-parent-seed", "--file", str(out_path)]
+        app,
+        ["vault", "reveal-parent-seed", "--file", str(out_path)],
+        input="pw\n",
     )
     assert result.exit_code == 0
     assert called["path"] == out_path
@@ -231,14 +233,14 @@ def test_fingerprint_remove(monkeypatch):
 def test_fingerprint_switch(monkeypatch):
     called = {}
 
-    def switch(fp):
+    def switch(fp, **_):
         called["fp"] = fp
 
     pm = SimpleNamespace(
         select_fingerprint=switch, fingerprint_manager=SimpleNamespace()
     )
     monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
-    result = runner.invoke(app, ["fingerprint", "switch", "def"])
+    result = runner.invoke(app, ["fingerprint", "switch", "def"], input="pw\n")
     assert result.exit_code == 0
     assert called.get("fp") == "def"
 


### PR DESCRIPTION
## Summary
- allow passing passwords and seeds directly to manager methods
- update CLI commands to forward user-provided credentials
- extend API request models for new arguments
- adapt tests for updated interfaces and add a new seed setup test

## Testing
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6879b1a9fe04832b8928142748e9e0ef