### PR TITLE
Add GUI getting started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,37 @@ seedpass list --filter totp
 
 For additional command examples, see [docs/advanced_cli.md](docs/advanced_cli.md). Details on the REST API can be found in [docs/api_reference.md](docs/api_reference.md).
 
+### Getting Started with the GUI
+
+SeedPass also ships with a simple BeeWare desktop interface. Launch it from
+your virtual environment using:
+
+```bash
+python -m seedpass_gui
+```
+
+If installed globally, you can run the `seedpass-gui` entry point instead:
+
+```bash
+seedpass-gui
+```
+
+The GUI works with the same vault and configuration files as the CLI.
+
+```mermaid
+graph TD
+    core["seedpass.core"]
+    cli["CLI"]
+    api["FastAPI server"]
+    gui["BeeWare GUI"]
+    ext["Browser Extension"]
+
+    cli --> core
+    gui --> core
+    api --> core
+    ext --> api
+```
+
 ### Vault JSON Layout
 
 The encrypted index file `seedpass_entries_db.json.enc` begins with `schema_version` `2` and stores an `entries` map keyed by entry numbers.

--- a/docs/docs/content/01-getting-started/06-gui_adapter.md
+++ b/docs/docs/content/01-getting-started/06-gui_adapter.md
@@ -2,6 +2,36 @@
 
 SeedPass ships with a proof-of-concept graphical interface built using [BeeWare](https://beeware.org). The GUI interacts with the same core services as the CLI by instantiating wrappers around `PasswordManager`.
 
+## Getting Started with the GUI
+
+After installing the project dependencies, launch the desktop interface with:
+
+```bash
+python -m seedpass_gui
+```
+
+If you installed the package globally, you can use the provided entry point:
+
+```bash
+seedpass-gui
+```
+
+The GUI shares the same encrypted vault and configuration as the command line tool.
+
+```mermaid
+graph TD
+    core["seedpass.core"]
+    cli["CLI"]
+    api["FastAPI server"]
+    gui["BeeWare GUI"]
+    ext["Browser Extension"]
+
+    cli --> core
+    gui --> core
+    api --> core
+    ext --> api
+```
+
 ## VaultService and EntryService
 
 `VaultService` provides thread-safe access to vault operations like exporting, importing, unlocking and locking the vault. `EntryService` exposes methods for listing, searching and modifying entries. Both classes live in `seedpass.core.api` and hold a `PasswordManager` instance protected by a `threading.Lock` to ensure safe concurrent access.


### PR DESCRIPTION
## Summary
- document how to launch the GUI in README
- extend GUI adapter docs with a quickstart

## Testing
- `black README.md docs/docs/content/01-getting-started/06-gui_adapter.md` *(fails: cannot parse)*
- `black --check src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687a4ec59a74832ba3f6be69178d81c5