### PR TITLE
Add seedpass_gui module entry point

### DIFF
--- a/src/seedpass_gui/__main__.py
+++ b/src/seedpass_gui/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `src/seedpass_gui/__main__.py` so the GUI can be launched via `python -m seedpass_gui`
- format with `black`

## Testing
- `pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687a5a09c1bc832b955a0987270552e7