### PR TITLE
Add GUI command

### DIFF
--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -682,5 +682,13 @@ def api_stop(ctx: typer.Context, host: str = "127.0.0.1", port: int = 8000) -> N
         typer.echo(f"Failed to stop server: {exc}")
 
 
+@app.command()
+def gui() -> None:
+    """Launch the BeeWare GUI."""
+    from seedpass_gui.app import main
+
+    main()
+
+
 if __name__ == "__main__":
     app()

--- a/src/tests/test_typer_cli.py
+++ b/src/tests/test_typer_cli.py
@@ -532,3 +532,19 @@ def test_tui_forward_fingerprint(monkeypatch):
     result = runner.invoke(app, ["--fingerprint", "abc"])
     assert result.exit_code == 0
     assert called.get("fp") == "abc"
+
+
+def test_gui_command(monkeypatch):
+    called = {}
+
+    def fake_main():
+        called["called"] = True
+
+    monkeypatch.setitem(
+        sys.modules,
+        "seedpass_gui.app",
+        SimpleNamespace(main=fake_main),
+    )
+    result = runner.invoke(app, ["gui"])
+    assert result.exit_code == 0
+    assert called.get("called") is True


### PR DESCRIPTION
## Summary
- expose a new `seedpass gui` command
- test launching the GUI via the CLI

## Testing
- `black src/seedpass/cli.py src/tests/test_typer_cli.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687a5f042d90832bbde5d8f75121b87f