### PR TITLE
Update GUI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,15 +232,11 @@ For additional command examples, see [docs/advanced_cli.md](docs/advanced_cli.md
 ### Getting Started with the GUI
 
 SeedPass also ships with a simple BeeWare desktop interface. Launch it from
-your virtual environment using:
+your virtual environment using any of the following commands:
 
 ```bash
+seedpass gui
 python -m seedpass_gui
-```
-
-If installed globally, you can run the `seedpass-gui` entry point instead:
-
-```bash
 seedpass-gui
 ```
 
@@ -599,6 +595,12 @@ scripts/vendor_dependencies.sh
 
 ```bash
 pyinstaller SeedPass.spec
+```
+
+You can also produce packaged installers for the GUI with BeeWare's Briefcase:
+
+```bash
+briefcase build
 ```
 
 The standalone executable will appear in the `dist/` directory. This process works on Windows, macOS and Linux but you must build on each platform for a native binary.

--- a/docs/docs/content/01-getting-started/06-gui_adapter.md
+++ b/docs/docs/content/01-getting-started/06-gui_adapter.md
@@ -4,19 +4,18 @@ SeedPass ships with a proof-of-concept graphical interface built using [BeeWare]
 
 ## Getting Started with the GUI
 
-After installing the project dependencies, launch the desktop interface with:
+After installing the project dependencies, launch the desktop interface with one
+of the following commands:
 
 ```bash
+seedpass gui
 python -m seedpass_gui
-```
-
-If you installed the package globally, you can use the provided entry point:
-
-```bash
 seedpass-gui
 ```
 
 The GUI shares the same encrypted vault and configuration as the command line tool.
+
+To generate a packaged binary, run `briefcase build` (after the initial `briefcase create`).
 
 ```mermaid
 graph TD


### PR DESCRIPTION
## Summary
- clarify how to start the GUI
- document Briefcase build command for packaged installers

## Testing
- `pytest -q`
- `black README.md docs/docs/content/01-getting-started/06-gui_adapter.md` *(fails: cannot parse README.md)*

------
https://chatgpt.com/codex/tasks/task_b_687a6a3ee4c0832b8676630e4e0c9309