### PR TITLE
Fix unlock flow without explicit password

### DIFF
--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -276,7 +276,7 @@ class PasswordManager:
         self.config_manager = None
         self.locked = True
 
-    def unlock_vault(self, password: str) -> float:
+    def unlock_vault(self, password: Optional[str] = None) -> float:
         """Unlock the vault using the provided ``password``.
 
         Parameters
@@ -292,6 +292,8 @@ class PasswordManager:
         start = time.perf_counter()
         if not self.fingerprint_dir:
             raise ValueError("Fingerprint directory not set")
+        if password is None:
+            password = prompt_existing_password(self.get_password_prompt())
         self.setup_encryption_manager(self.fingerprint_dir, password)
         self.initialize_bip85()
         self.initialize_managers()


### PR DESCRIPTION
## Summary
- make `PasswordManager.unlock_vault` accept an optional password
- prompt for a password when none is provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687a7664f444832bb8f68a5015653492