### PR TITLE
Clarify secret mode clipboard handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
 - **Optional External Backup Location:** Configure a second directory where backups are automatically copied.
 - **Auto-Lock on Inactivity:** Vault locks after a configurable timeout for additional security.
 - **Quick Unlock:** Optionally skip the password prompt after verifying once.
-- **Secret Mode:** Copy retrieved passwords directly to your clipboard and automatically clear it after a delay.
+- **Secret Mode:** When enabled, newly generated and retrieved passwords are copied to your clipboard and automatically cleared after a delay.
 - **Tagging Support:** Organize entries with optional tags and find them quickly via search.
 - **Manual Vault Export/Import:** Create encrypted backups or restore them using the CLI or API.
 - **Parent Seed Backup:** Securely save an encrypted copy of the master seed.
@@ -386,11 +386,11 @@ When choosing **Add Entry**, you can now select from:
 
 ### Using Secret Mode
 
-When **Secret Mode** is enabled, SeedPass copies retrieved passwords directly to your clipboard instead of displaying them on screen. The clipboard clears automatically after the delay you choose.
+When **Secret Mode** is enabled, SeedPass copies newly generated and retrieved passwords directly to your clipboard instead of displaying them on screen. The clipboard clears automatically after the delay you choose.
 
 1. From the main menu open **Settings** and select **Toggle Secret Mode**.
 2. Choose how many seconds to keep passwords on the clipboard.
-3. Retrieve an entry and SeedPass will confirm the password was copied.
+3. Generate or retrieve an entry and SeedPass will confirm the password was copied.
 
 ### Viewing Entry Details
 

--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -527,7 +527,11 @@ def config_set(ctx: typer.Context, key: str, value: str) -> None:
 
 @config_app.command("toggle-secret-mode")
 def config_toggle_secret_mode(ctx: typer.Context) -> None:
-    """Interactively enable or disable secret mode."""
+    """Interactively enable or disable secret mode.
+
+    When enabled, newly generated and retrieved passwords are copied to the
+    clipboard instead of printed to the screen.
+    """
     service = _get_config_service(ctx)
     try:
         enabled = service.get_secret_mode_enabled()

--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -1356,7 +1356,16 @@ class PasswordManager:
                     "green",
                 )
             )
-            print(colored(f"Password for {website_name}: {password}\n", "yellow"))
+            if self.secret_mode_enabled:
+                copy_to_clipboard(password, self.clipboard_clear_delay)
+                print(
+                    colored(
+                        f"[+] Password copied to clipboard. Will clear in {self.clipboard_clear_delay} seconds.",
+                        "green",
+                    )
+                )
+            else:
+                print(colored(f"Password for {website_name}: {password}\n", "yellow"))
 
             # Automatically push the updated encrypted index to Nostr so the
             # latest changes are backed up remotely.


### PR DESCRIPTION
## Summary
- document that secret mode copies newly created passwords to the clipboard
- add this note to CLI help text
- copy generated passwords to the clipboard in secret mode
- test password creation with secret mode

## Testing
- `black src/seedpass/cli.py src/seedpass/core/manager.py src/tests/test_manager_add_password.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687a88079718832b8d7e2c71d3bd377d