### PR TITLE
Add vault profile export/import feature

### DIFF
--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -207,10 +207,10 @@ create a backup:
 seedpass
 
 # Export your index
-seedpass export --file "~/seedpass_backup.json"
+seedpass vault export --file "~/seedpass_backup.json"
 
 # Later you can restore it
-seedpass import --file "~/seedpass_backup.json"
+seedpass vault import --file "~/seedpass_backup.json"
 # Import also performs a Nostr sync to pull any changes
 
 # Quickly find or retrieve entries

--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -14,8 +14,6 @@ from seedpass.core.api import (
     ConfigService,
     UtilityService,
     NostrService,
-    VaultExportRequest,
-    VaultImportRequest,
     ChangePasswordRequest,
     UnlockRequest,
     BackupParentSeedRequest,
@@ -402,9 +400,10 @@ def entry_export_totp(
 def vault_export(
     ctx: typer.Context, file: str = typer.Option(..., help="Output file")
 ) -> None:
-    """Export the vault."""
+    """Export the vault profile to an encrypted file."""
     vault_service, _profile, _sync = _get_services(ctx)
-    vault_service.export_vault(VaultExportRequest(path=Path(file)))
+    data = vault_service.export_profile()
+    Path(file).write_bytes(data)
     typer.echo(str(file))
 
 
@@ -412,9 +411,10 @@ def vault_export(
 def vault_import(
     ctx: typer.Context, file: str = typer.Option(..., help="Input file")
 ) -> None:
-    """Import a vault from an encrypted JSON file."""
+    """Import a vault profile from an encrypted file."""
     vault_service, _profile, _sync = _get_services(ctx)
-    vault_service.import_vault(VaultImportRequest(path=Path(file)))
+    data = Path(file).read_bytes()
+    vault_service.import_profile(data)
     typer.echo(str(file))
 
 

--- a/src/tests/test_cli_doc_examples.py
+++ b/src/tests/test_cli_doc_examples.py
@@ -84,7 +84,9 @@ def load_doc_commands() -> list[str]:
     cmds = set(re.findall(r"`seedpass ([^`<>]+)`", text))
     cmds = {c for c in cmds if "<" not in c and ">" not in c}
     cmds.discard("vault export")
+    cmds.discard("vault export --file backup.json")
     cmds.discard("vault import")
+    cmds.discard("vault import --file backup.json")
     return sorted(cmds)
 
 

--- a/src/tests/test_profile_export_import.py
+++ b/src/tests/test_profile_export_import.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from seedpass.core.api import VaultService
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+
+def test_profile_export_import_round_trip(tmp_path):
+    dir1 = tmp_path / "a"
+    vault1, _ = create_vault(dir1, TEST_SEED, TEST_PASSWORD)
+    data = {
+        "schema_version": 4,
+        "entries": {"0": {"label": "example", "type": "password"}},
+    }
+    vault1.save_index(data)
+    pm1 = SimpleNamespace(vault=vault1, sync_vault=lambda: None)
+    service1 = VaultService(pm1)
+    blob = service1.export_profile()
+
+    dir2 = tmp_path / "b"
+    vault2, _ = create_vault(dir2, TEST_SEED, TEST_PASSWORD)
+    vault2.save_index({"schema_version": 4, "entries": {}})
+    called = {}
+
+    def sync():
+        called["synced"] = True
+
+    pm2 = SimpleNamespace(vault=vault2, sync_vault=sync)
+    service2 = VaultService(pm2)
+    service2.import_profile(blob)
+
+    assert called.get("synced") is True
+    assert vault2.load_index() == data


### PR DESCRIPTION
## Summary
- implement `export_profile` and `import_profile` in `VaultService`
- update CLI `vault export/import` to use new methods
- document new commands
- add tests covering profile export/import workflow
- adjust CLI doc tests for vault commands

## Testing
- `black src/seedpass/core/api.py src/seedpass/cli.py src/tests/test_typer_cli.py src/tests/test_profile_export_import.py src/tests/test_cli_doc_examples.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687aa615b9b0832ba3d23b08313dcbdf