### PR TITLE
Add relay manager and session lock handling

### DIFF
--- a/docs/docs/content/01-getting-started/06-gui_adapter.md
+++ b/docs/docs/content/01-getting-started/06-gui_adapter.md
@@ -2,6 +2,7 @@
 
 SeedPass ships with a proof-of-concept graphical interface built using [BeeWare](https://beeware.org). The GUI interacts with the same core services as the CLI by instantiating wrappers around `PasswordManager`.
 
+
 ## Getting Started with the GUI
 
 After installing the project dependencies, launch the desktop interface with one
@@ -104,3 +105,14 @@ def start_background_vault_sync(self, alt_summary: str | None = None) -> None:
 ```
 
 This approach ensures synchronization happens asynchronously whether the GUI is running inside or outside an existing event loop.
+
+## Relay Manager and Status Bar
+
+The *Relays* button opens a dialog for adding or removing Nostr relay URLs. The
+status bar at the bottom of the main window shows when the last synchronization
+completed. It updates automatically when `sync_started` and `sync_finished`
+events are published on the internal pubsub bus.
+
+When a ``vault_locked`` event is emitted, the GUI automatically returns to the
+lock screen so the session can be reopened with the master password.
+

--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -304,6 +304,7 @@ class PasswordManager:
         self.nostr_client = None
         self.config_manager = None
         self.locked = True
+        bus.publish("vault_locked")
 
     def unlock_vault(self, password: Optional[str] = None) -> float:
         """Unlock the vault using the provided ``password``.

--- a/src/tests/test_gui_features.py
+++ b/src/tests/test_gui_features.py
@@ -1,0 +1,78 @@
+import os
+import toga
+import types
+
+import pytest
+
+pytestmark = pytest.mark.desktop
+
+from seedpass.core.pubsub import bus
+from seedpass_gui.app import MainWindow, RelayManagerDialog
+
+
+class DummyNostr:
+    def __init__(self):
+        self.relays = ["wss://a"]
+
+    def list_relays(self):
+        return list(self.relays)
+
+    def add_relay(self, url):
+        self.relays.append(url)
+
+    def remove_relay(self, idx):
+        self.relays.pop(idx - 1)
+
+
+class DummyEntries:
+    def list_entries(self):
+        return []
+
+    def search_entries(self, q):
+        return []
+
+
+class DummyController:
+    def __init__(self):
+        self.lock_window = types.SimpleNamespace(show=lambda: None)
+        self.main_window = None
+        self.vault_service = None
+        self.entry_service = None
+        self.nostr_service = None
+
+
+@pytest.fixture(autouse=True)
+def set_backend():
+    os.environ["TOGA_BACKEND"] = "toga_dummy"
+    import asyncio
+
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+def test_relay_manager_add_remove():
+    toga.App("T", "o")
+    ctrl = DummyController()
+    nostr = DummyNostr()
+    win = MainWindow(ctrl, None, DummyEntries(), nostr)
+    dlg = RelayManagerDialog(win, nostr)
+    dlg.new_input.value = "wss://b"
+    dlg.add_relay(None)
+    assert nostr.relays == ["wss://a", "wss://b"]
+    dlg.remove_relay(None, index=1)
+    assert nostr.relays == ["wss://b"]
+
+
+def test_status_bar_updates_and_lock():
+    toga.App("T2", "o2")
+    ctrl = DummyController()
+    nostr = DummyNostr()
+    ctrl.lock_window = types.SimpleNamespace(show=lambda: setattr(ctrl, "locked", True))
+    win = MainWindow(ctrl, None, DummyEntries(), nostr)
+    ctrl.main_window = win
+    bus.publish("sync_started")
+    assert win.status.text == "Syncing..."
+    bus.publish("sync_finished")
+    assert "Last sync:" in win.status.text
+    bus.publish("vault_locked")
+    assert getattr(ctrl, "locked", False)
+    assert ctrl.main_window is None

--- a/src/tests/test_gui_headless.py
+++ b/src/tests/test_gui_headless.py
@@ -40,18 +40,29 @@ def setup_module(module):
     asyncio.set_event_loop(asyncio.new_event_loop())
 
 
+class FakeNostr:
+    def list_relays(self):
+        return []
+
+    def add_relay(self, url):
+        pass
+
+    def remove_relay(self, idx):
+        pass
+
+
 def test_unlock_creates_main_window():
     app = toga.App("Test", "org.example")
-    controller = SimpleNamespace(main_window=None)
+    controller = SimpleNamespace(main_window=None, nostr_service=FakeNostr())
     vault = FakeVault()
     entries = FakeEntries()
-
     win = LockScreenWindow(controller, vault, entries)
     win.password_input.value = "pw"
     win.handle_unlock(None)
 
     assert vault.called
     assert isinstance(controller.main_window, MainWindow)
+    controller.main_window.cleanup()
 
 
 def test_entrydialog_add_calls_service():

--- a/src/tests/test_vault_lock_event.py
+++ b/src/tests/test_vault_lock_event.py
@@ -1,0 +1,28 @@
+from seedpass.core.manager import PasswordManager
+from seedpass.core.pubsub import bus
+
+
+def test_lock_vault_publishes_event():
+    pm = PasswordManager.__new__(PasswordManager)
+    pm.entry_manager = None
+    pm.encryption_manager = None
+    pm.password_generator = None
+    pm.backup_manager = None
+    pm.vault = None
+    pm.bip85 = None
+    pm.nostr_client = None
+    pm.config_manager = None
+    pm.locked = False
+    pm._parent_seed_secret = None
+
+    called = []
+
+    def handler():
+        called.append(True)
+
+    bus.subscribe("vault_locked", handler)
+    pm.lock_vault()
+    bus.unsubscribe("vault_locked", handler)
+
+    assert pm.locked
+    assert called == [True]


### PR DESCRIPTION
## Summary
- manage relays in GUI and show sync status in status bar
- return to lock screen when vault locks
- document GUI features without binary images
- test relay manager, sync updates, and vault lock event
- publish `vault_locked` on bus when vault locks

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_687ab8d220b4832bb4bbcca45f2ae2d2