### PR TITLE
Add Briefcase workflow

### DIFF
--- a/.github/workflows/briefcase.yml
+++ b/.github/workflows/briefcase.yml
@@ -1,0 +1,27 @@
+name: Build GUI
+
+on:
+  push:
+    tags:
+      - 'seedpass-gui*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r src/requirements.txt
+          pip install briefcase
+      - name: Build with Briefcase
+        run: briefcase build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: seedpass-gui
+          path: dist/**

--- a/README.md
+++ b/README.md
@@ -603,6 +603,10 @@ You can also produce packaged installers for the GUI with BeeWare's Briefcase:
 briefcase build
 ```
 
+Pre-built installers are published for each `seedpass-gui` tag. Visit the
+project's **Actions** or **Releases** page on GitHub to download the latest
+package for your platform.
+
 The standalone executable will appear in the `dist/` directory. This process works on Windows, macOS and Linux but you must build on each platform for a native binary.
 
 ## Security Considerations


### PR DESCRIPTION
## Summary
- add Briefcase GitHub Actions workflow to build the GUI on tags
- document where to download the packaged GUI

## Testing
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687ac2dcf8ec832b9512d024ae527e5a