### PR TITLE
Add Toga backend note

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,22 @@ python -m seedpass_gui
 seedpass-gui
 ```
 
+To display the interface, you must also install the Toga backend for your
+platform. Only `toga-core` and the headless `toga-dummy` backend are included
+in the requirements file. Depending on your operating system install one of the
+following packages:
+
+```bash
+# Linux
+pip install toga-gtk
+
+# Windows
+pip install toga-winforms
+
+# macOS
+pip install toga-cocoa
+```
+
 The GUI works with the same vault and configuration files as the CLI.
 
 ```mermaid

--- a/docs/docs/content/01-getting-started/06-gui_adapter.md
+++ b/docs/docs/content/01-getting-started/06-gui_adapter.md
@@ -14,6 +14,21 @@ python -m seedpass_gui
 seedpass-gui
 ```
 
+Only the headless `toga-dummy` backend ships with the project for automated
+tests. To actually display windows you need a platform-specific backend such as
+`toga-gtk`, `toga-winforms`, or `toga-cocoa`.
+
+```bash
+# Linux
+pip install toga-gtk
+
+# Windows
+pip install toga-winforms
+
+# macOS
+pip install toga-cocoa
+```
+
 The GUI shares the same encrypted vault and configuration as the command line tool.
 
 To generate a packaged binary, run `briefcase build` (after the initial `briefcase create`).


### PR DESCRIPTION
## Summary
- mention platform-specific Toga backend in README
- document default `toga-dummy` backend for docs and show how to install a backend

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687b0f7cfa98832badfb4d262785eba4