### PR TITLE
Install Toga backend via OS detection

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -120,6 +120,14 @@ main() {
     pip install --upgrade pip
     pip install -r src/requirements.txt
     pip install -e .
+    print_info "Installing platform-specific Toga backend..."
+    if [ "$OS_NAME" = "Linux" ]; then
+        print_info "Installing toga-gtk for Linux..."
+        pip install toga-gtk
+    elif [ "$OS_NAME" = "Darwin" ]; then
+        print_info "Installing toga-cocoa for macOS..."
+        pip install toga-cocoa
+    fi
     deactivate
 
     # 7. Create launcher script


### PR DESCRIPTION
## Summary
- install OS-specific toga backend in install.sh
- show info messages around that step

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687bce2d0fd0832bb066553232f2284a