### PR TITLE
Update GUI setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ See `docs/ARCHITECTURE.md` for details.
 ### Quick Installer
 
 Use the automated installer to download SeedPass and its dependencies in one step.
+The scripts also install the correct BeeWare backend for your platform automatically.
 
 **Linux and macOS:**
 ```bash
@@ -241,10 +242,10 @@ python -m seedpass_gui
 seedpass-gui
 ```
 
-To display the interface, you must also install the Toga backend for your
-platform. Only `toga-core` and the headless `toga-dummy` backend are included
-in the requirements file. Depending on your operating system install one of the
-following packages:
+Only `toga-core` and the headless `toga-dummy` backend are included by default.
+The quick installer automatically installs the correct BeeWare backend so the
+GUI works out of the box. If you set up SeedPass manually, install the backend
+for your platform:
 
 ```bash
 # Linux

--- a/docs/docs/content/01-getting-started/06-gui_adapter.md
+++ b/docs/docs/content/01-getting-started/06-gui_adapter.md
@@ -14,9 +14,10 @@ python -m seedpass_gui
 seedpass-gui
 ```
 
-Only the headless `toga-dummy` backend ships with the project for automated
-tests. To actually display windows you need a platform-specific backend such as
-`toga-gtk`, `toga-winforms`, or `toga-cocoa`.
+Only `toga-core` and the headless `toga-dummy` backend ship with the project.
+The installation scripts automatically install the correct BeeWare backend so
+the GUI works out of the box. If you set up SeedPass manually, install the
+backend for your platform:
 
 ```bash
 # Linux


### PR DESCRIPTION
## Summary
- note that the installers now add the correct BeeWare backend automatically
- keep manual Toga backend install commands as a fallback

## Testing
- `black . --quiet`
- `python -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt >/tmp/pip.log && pip install -e . >>/tmp/pip.log && pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687bd26291f0832b9c4eb6f066e7175c