### PR TITLE
Fix install script missing cairo

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ for your platform:
 # Linux
 pip install toga-gtk
 
+# If you see build errors about "cairo" on Linux, install the cairo
+# development headers using your package manager, e.g.:
+sudo apt-get install libcairo2 libcairo2-dev
+
 # Windows
 pip install toga-winforms
 

--- a/docs/docs/content/01-getting-started/06-gui_adapter.md
+++ b/docs/docs/content/01-getting-started/06-gui_adapter.md
@@ -23,6 +23,9 @@ backend for your platform:
 # Linux
 pip install toga-gtk
 
+# If installation fails with cairo errors, install libcairo2-dev or the
+# cairo development package using your distro's package manager.
+
 # Windows
 pip install toga-winforms
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -86,13 +86,18 @@ main() {
     # 3. Install OS-specific dependencies
     print_info "Checking for build dependencies..."
     if [ "$OS_NAME" = "Linux" ]; then
-        if command -v apt-get &> /dev/null; then sudo apt-get update && sudo apt-get install -y build-essential pkg-config xclip;
-        elif command -v dnf &> /dev/null; then sudo dnf groupinstall -y "Development Tools" && sudo dnf install -y pkg-config xclip;
-        elif command -v pacman &> /dev/null; then sudo pacman -Syu --noconfirm base-devel pkg-config xclip;
-        else print_warning "Could not detect package manager. Ensure build tools and pkg-config are installed."; fi
+        if command -v apt-get &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y build-essential pkg-config xclip libcairo2 libcairo2-dev
+        elif command -v dnf &> /dev/null; then
+            sudo dnf groupinstall -y "Development Tools" && sudo dnf install -y pkg-config cairo cairo-devel xclip
+        elif command -v pacman &> /dev/null; then
+            sudo pacman -Syu --noconfirm base-devel pkg-config cairo xclip
+        else
+            print_warning "Could not detect package manager. Ensure build tools, cairo, and pkg-config are installed."
+        fi
     elif [ "$OS_NAME" = "Darwin" ]; then
         if ! command -v brew &> /dev/null; then print_error "Homebrew not installed. See https://brew.sh/"; fi
-        brew install pkg-config
+        brew install pkg-config cairo
     fi
 
     # 4. Clone or update the repository

--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -3,6 +3,7 @@ from typing import Optional, List
 import json
 
 import typer
+import sys
 
 from seedpass.core.manager import PasswordManager
 from seedpass.core.entry_types import EntryType
@@ -368,6 +369,7 @@ def entry_modify(
         )
     except ValueError as e:
         typer.echo(str(e))
+        sys.stdout.flush()
         raise typer.Exit(code=1)
 
 


### PR DESCRIPTION
## Summary
- ensure OS-specific dependencies include cairo
- document cairo requirement in README and GUI docs

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687bd56f1aa8832b9f264bb3228c1b1d