### PR TITLE
Enhance install scripts stale command detection

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -283,6 +283,18 @@ if ($existingSeedpass -and $existingSeedpass.Source -ne $LauncherPath) {
     Write-Warning "Ensure '$LauncherDir' comes first in your PATH or remove the old installation."
 }
 
+# Detect additional seedpass executables on PATH that are not our launcher
+$allSeedpass = Get-Command seedpass -All -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source
+$stale = @()
+foreach ($cmd in $allSeedpass) {
+    if ($cmd -ne $LauncherPath) { $stale += $cmd }
+}
+if ($stale.Count -gt 0) {
+    Write-Warning "Stale 'seedpass' executables detected:" 
+    foreach ($cmd in $stale) { Write-Warning "  - $cmd" }
+    Write-Warning "Remove or rename these to avoid launching outdated code."
+}
+
 # 6. Add launcher directory to User's PATH if needed
 Write-Info "Checking if '$LauncherDir' is in your PATH..."
 $UserPath = [System.Environment]::GetEnvironmentVariable("Path", "User")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -159,6 +159,23 @@ EOF2
         print_warning "Ensure '$LAUNCHER_DIR' comes first in your PATH or remove the old installation."
     fi
 
+    # Detect any additional seedpass executables on PATH that are not our launcher
+    IFS=':' read -ra _sp_paths <<< "$PATH"
+    stale_cmds=()
+    for _dir in "${_sp_paths[@]}"; do
+        _candidate="$_dir/seedpass"
+        if [ -x "$_candidate" ] && [ "$_candidate" != "$LAUNCHER_PATH" ]; then
+            stale_cmds+=("$_candidate")
+        fi
+    done
+    if [ ${#stale_cmds[@]} -gt 0 ]; then
+        print_warning "Stale 'seedpass' executables detected:"
+        for cmd in "${stale_cmds[@]}"; do
+            print_warning "  - $cmd"
+        done
+        print_warning "Remove or rename these to avoid launching outdated code."
+    fi
+
     # 8. Final instructions
     print_success "Installation/update complete!"
     print_info "You can now launch the interactive TUI by typing: seedpass"


### PR DESCRIPTION
## Summary
- warn when old `seedpass` binaries are found during install
- list all stale executables to help users clean up

## Testing
- `black . --quiet`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687becd5e700832bb9fb1f726d9fc909