### PR TITLE
Run GUI desktop tests on all platforms

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -84,12 +84,24 @@ jobs:
         timeout-minutes: 16
         shell: bash
         run: scripts/run_ci_tests.sh
+      - name: Run desktop tests
+        timeout-minutes: 10
+        shell: bash
+        env:
+          TOGA_BACKEND: toga_dummy
+        run: scripts/run_gui_tests.sh
       - name: Upload pytest log
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: pytest-log-${{ matrix.os }}
           path: pytest.log
+      - name: Upload GUI pytest log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gui-pytest-log-${{ matrix.os }}
+          path: pytest_gui.log
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/run_gui_tests.sh
+++ b/scripts/run_gui_tests.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+pytest_args=(-vv --desktop -m desktop src/tests)
+if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
+    pytest_args+=(-n 1)
+fi
+
+timeout_bin="timeout"
+if ! command -v "$timeout_bin" >/dev/null 2>&1; then
+    if command -v gtimeout >/dev/null 2>&1; then
+        timeout_bin="gtimeout"
+    else
+        timeout_bin=""
+    fi
+fi
+
+if [[ -n "$timeout_bin" ]]; then
+    $timeout_bin 10m pytest "${pytest_args[@]}" 2>&1 | tee pytest_gui.log
+    status=${PIPESTATUS[0]}
+else
+    echo "timeout command not found; running tests without timeout" >&2
+    pytest "${pytest_args[@]}" 2>&1 | tee pytest_gui.log
+    status=${PIPESTATUS[0]}
+fi
+
+if [[ $status -eq 124 ]]; then
+    echo "::error::Desktop tests exceeded 10-minute limit"
+    tail -n 20 pytest_gui.log
+    exit 1
+fi
+exit $status

--- a/src/tests/test_gui_features.py
+++ b/src/tests/test_gui_features.py
@@ -108,7 +108,8 @@ def test_totp_viewer_refresh_on_sync(monkeypatch):
     viewer = seedpass_gui.app.TotpViewerWindow(ctrl, entries)
     bus.subscribe("sync_finished", viewer.refresh_codes)
 
-    assert viewer.table.data[0][1] == "111111"
+    # Table rows are Row objects with attribute access
+    assert viewer.table.data[0].code == "111111"
     entries.code = "222222"
     bus.publish("sync_finished")
-    assert viewer.table.data[0][1] == "222222"
+    assert viewer.table.data[0].code == "222222"


### PR DESCRIPTION
## Summary
- execute desktop GUI tests across OS matrix using `toga-dummy`
- add `scripts/run_gui_tests.sh` helper
- upload GUI pytest log for easier debugging

## Testing
- `pytest`
- `scripts/run_gui_tests.sh` *(fails: TypeError: 'Row' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_b_687c1f577508832b8bd8e531b361af5e