### PR TITLE
Add simple dark mode styling

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -6,8 +6,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>SeedPass - Secure Password Manager</title>
         <!-- Stylesheets -->
-        <link rel="stylesheet" href="./style.css"> 
-        <!-- Relative path to style.css -->
+        <link rel="stylesheet" href="./style.css">
+        <link rel="stylesheet" href="./simple-dark.css">
+        <!-- Relative path to style sheets -->
         <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
         <!-- Font Awesome for Icons -->
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>

--- a/landing/simple-dark.css
+++ b/landing/simple-dark.css
@@ -1,0 +1,73 @@
+:root {
+    --bg-light: #ffffff;
+    --bg-dark: #121212;
+    --text-light: #000000;
+    --text-dark: #e0e0e0;
+    --accent: #e94a39;
+}
+
+body {
+    background-color: var(--bg-light);
+    color: var(--text-light);
+    font-family: 'Roboto', sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    transition: background-color 0.3s, color 0.3s;
+}
+
+body.dark-mode {
+    background-color: var(--bg-dark);
+    color: var(--text-dark);
+}
+
+header,
+.navbar,
+footer {
+    background-color: var(--bg-dark);
+    color: var(--text-dark);
+}
+
+body:not(.dark-mode) header,
+body:not(.dark-mode) .navbar,
+body:not(.dark-mode) footer {
+    background-color: var(--bg-light);
+    color: var(--text-light);
+}
+
+.navbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 0.5rem;
+}
+
+.nav-links {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+}
+
+.nav-links a {
+    color: inherit;
+    text-decoration: none;
+}
+
+section {
+    padding: 2rem 0;
+}
+
+.container {
+    width: 90%;
+    max-width: 900px;
+    margin: auto;
+}
+
+.cta-button {
+    background-color: var(--accent);
+    color: #fff;
+    padding: 0.75rem 1.25rem;
+    border-radius: 4px;
+    text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- create a minimal dark style sheet
- load the new sheet in the landing page

## Testing
- `black .`
- `PYTHONPATH=src pytest src/tests/test_checksum_utils.py::test_json_checksum -q`

------
https://chatgpt.com/codex/tasks/task_b_688048c5d870832baed975ea0d3506c5