### PR TITLE
Add value editing for Key/Value entries

### DIFF
--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -2173,7 +2173,10 @@ class PasswordManager:
                 child_fingerprint=child_fp,
             )
             print(colored("\n[+] Edit Menu:", "green"))
-            print(colored("L. Edit Label (key)", "cyan"))
+            print(colored("L. Edit Label", "cyan"))
+            if entry_type == EntryType.KEY_VALUE.value:
+                print(colored("K. Edit Key", "cyan"))
+                print(colored("V. Edit Value", "cyan"))
             if entry_type == EntryType.PASSWORD.value:
                 print(colored("U. Edit Username", "cyan"))
                 print(colored("R. Edit URL", "cyan"))
@@ -2184,9 +2187,21 @@ class PasswordManager:
             if not choice:
                 break
             if choice == "l":
-                new_label = input("New label (key): ").strip()
+                new_label = input("New label: ").strip()
                 if new_label:
                     self.entry_manager.modify_entry(index, label=new_label)
+                    self.is_dirty = True
+                    self.last_update = time.time()
+            elif entry_type == EntryType.KEY_VALUE.value and choice == "k":
+                new_key = input("New key: ").strip()
+                if new_key:
+                    self.entry_manager.modify_entry(index, key=new_key)
+                    self.is_dirty = True
+                    self.last_update = time.time()
+            elif entry_type == EntryType.KEY_VALUE.value and choice == "v":
+                new_value = input("New value: ").strip()
+                if new_value:
+                    self.entry_manager.modify_entry(index, value=new_value)
                     self.is_dirty = True
                     self.last_update = time.time()
             elif entry_type == EntryType.PASSWORD.value and choice == "u":


### PR DESCRIPTION
## Summary
- extend edit menu for key/value entries to include value editing
- keep label and key editing options intact

## Testing
- `python3 -m venv venv`
- `pip install -r src/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688a749cb310832b86f31a8f5fd4a7d7