### PR TITLE
Fix CLI edit options for key/value entries

### DIFF
--- a/docs/docs/content/01-getting-started/01-advanced_cli.md
+++ b/docs/docs/content/01-getting-started/01-advanced_cli.md
@@ -57,7 +57,7 @@ Manage individual entries within a vault.
 | Add a seed phrase entry | `entry add-seed` | `seedpass entry add-seed Backup --words 24` |
 | Add a key/value entry | `entry add-key-value` | `seedpass entry add-key-value "API Token" --key api --value abc123` |
 | Add a managed account entry | `entry add-managed-account` | `seedpass entry add-managed-account Trading` |
-| Modify an entry | `entry modify` | `seedpass entry modify 1 --username alice` |
+| Modify an entry | `entry modify` | `seedpass entry modify 1 --key new --value updated` |
 | Archive an entry | `entry archive` | `seedpass entry archive 1` |
 | Unarchive an entry | `entry unarchive` | `seedpass entry unarchive 1` |
 | Export all TOTP secrets | `entry export-totp` | `seedpass entry export-totp --file totp.json` |
@@ -146,7 +146,7 @@ Run or stop the local HTTP API.
 - **`seedpass entry add-seed <label>`** – Store a derived seed phrase. Use `--words` to set the word count.
  - **`seedpass entry add-key-value <label>`** – Store arbitrary data with `--key` and `--value`.
 - **`seedpass entry add-managed-account <label>`** – Store a BIP‑85 derived account seed.
-- **`seedpass entry modify <id>`** – Update an entry's label, username, URL or notes.
+- **`seedpass entry modify <id>`** – Update an entry's fields. For key/value entries you can change the label, key and value.
 - **`seedpass entry archive <id>`** – Mark an entry as archived so it is hidden from normal lists.
 - **`seedpass entry unarchive <id>`** – Restore an archived entry.
 - **`seedpass entry export-totp --file <path>`** – Export all stored TOTP secrets to a JSON file.

--- a/src/seedpass/api.py
+++ b/src/seedpass/api.py
@@ -218,6 +218,7 @@ def update_entry(
             label=entry.get("label"),
             period=entry.get("period"),
             digits=entry.get("digits"),
+            key=entry.get("key"),
             value=entry.get("value"),
         )
     except ValueError as e:

--- a/src/seedpass/cli.py
+++ b/src/seedpass/cli.py
@@ -354,6 +354,7 @@ def entry_modify(
         None, "--period", help="TOTP period in seconds"
     ),
     digits: Optional[int] = typer.Option(None, "--digits", help="TOTP digits"),
+    key: Optional[str] = typer.Option(None, "--key", help="New key"),
     value: Optional[str] = typer.Option(None, "--value", help="New value"),
 ) -> None:
     """Modify an existing entry."""
@@ -367,6 +368,7 @@ def entry_modify(
             label=label,
             period=period,
             digits=digits,
+            key=key,
             value=value,
         )
     except ValueError as e:

--- a/src/seedpass/core/api.py
+++ b/src/seedpass/core/api.py
@@ -416,6 +416,7 @@ class EntryService:
         label: str | None = None,
         period: int | None = None,
         digits: int | None = None,
+        key: str | None = None,
         value: str | None = None,
     ) -> None:
         with self._lock:
@@ -427,6 +428,7 @@ class EntryService:
                 label=label,
                 period=period,
                 digits=digits,
+                key=key,
                 value=value,
             )
             self._manager.start_background_vault_sync()

--- a/src/tests/test_typer_cli.py
+++ b/src/tests/test_typer_cli.py
@@ -402,8 +402,10 @@ def test_entry_add(monkeypatch):
 def test_entry_modify(monkeypatch):
     called = {}
 
-    def modify_entry(index, username=None, url=None, notes=None, label=None, **kwargs):
-        called["args"] = (index, username, url, notes, label, kwargs)
+    def modify_entry(
+        index, username=None, url=None, notes=None, label=None, key=None, **kwargs
+    ):
+        called["args"] = (index, username, url, notes, label, key, kwargs)
 
     pm = SimpleNamespace(
         entry_manager=SimpleNamespace(modify_entry=modify_entry),
@@ -413,7 +415,7 @@ def test_entry_modify(monkeypatch):
     monkeypatch.setattr(cli, "PasswordManager", lambda: pm)
     result = runner.invoke(app, ["entry", "modify", "1", "--username", "alice"])
     assert result.exit_code == 0
-    assert called["args"][:5] == (1, "alice", None, None, None)
+    assert called["args"][:6] == (1, "alice", None, None, None, None)
 
 
 def test_entry_modify_invalid(monkeypatch):


### PR DESCRIPTION
## Summary
- expose `--key` option when modifying entries via CLI
- pass new key parameter through API layers
- document how to modify key/value entries
- adjust tests for updated signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a82a01dac832ba31dc3bbf7add33b