### PR TITLE
Extend API password generation options

### DIFF
--- a/src/seedpass/core/api.py
+++ b/src/seedpass/core/api.py
@@ -84,6 +84,34 @@ class SyncResponse(BaseModel):
     delta_ids: List[str] = []
 
 
+class PasswordPolicyOptions(BaseModel):
+    """Optional password policy overrides."""
+
+    include_special_chars: bool | None = None
+    allowed_special_chars: str | None = None
+    special_mode: str | None = None
+    exclude_ambiguous: bool | None = None
+    min_uppercase: int | None = None
+    min_lowercase: int | None = None
+    min_digits: int | None = None
+    min_special: int | None = None
+
+
+class AddPasswordEntryRequest(PasswordPolicyOptions):
+    label: str
+    length: int
+    username: str | None = None
+    url: str | None = None
+
+
+class GeneratePasswordRequest(PasswordPolicyOptions):
+    length: int
+
+
+class GeneratePasswordResponse(BaseModel):
+    password: str
+
+
 class VaultService:
     """Thread-safe wrapper around vault operations."""
 


### PR DESCRIPTION
## Summary
- include password policy fields in Pydantic API models
- allow creating password entries with custom policy via `/api/v1/entry`
- add `/api/v1/password` endpoint for on-demand password generation
- test password generation endpoint honors policy options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688ac0de4b14832b96cdc75e466e4d21