### PR TITLE
Add SAFE_SPECIAL_CHARS constant usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ seedpass entry get "email"
 # Sort or filter the list view
 seedpass list --sort label
 seedpass list --filter totp
-# Generate a password with the safe character set
+# Generate a password with the safe character set defined by `SAFE_SPECIAL_CHARS`
 seedpass util generate-password --length 20 --special-mode safe --exclude-ambiguous
 
 # Use the **Settings** menu to configure an extra backup directory

--- a/docs/docs/content/01-getting-started/03-json_entries.md
+++ b/docs/docs/content/01-getting-started/03-json_entries.md
@@ -109,7 +109,7 @@ Each entry is stored within `seedpass_entries_db.json.enc` under the `entries` d
 - **min_special** (`integer`, default `2`): Minimum required special characters.
 - **include_special_chars** (`boolean`, default `true`): Enable or disable any punctuation in generated passwords.
 - **allowed_special_chars** (`string`, optional): Restrict punctuation to this exact set.
-- **special_mode** (`string`, default `"standard"`): Choose `"safe"` for the `!@#$%^*-_+=?` set, otherwise the full `string.punctuation` is used.
+- **special_mode** (`string`, default `"standard"`): Choose `"safe"` for the `SAFE_SPECIAL_CHARS` set (`!@#$%^*-_+=?`), otherwise the full `string.punctuation` is used.
 - **exclude_ambiguous** (`boolean`, default `false`): Omit confusing characters like `O0Il1`.
   Example:
 

--- a/src/seedpass/core/password_generation.py
+++ b/src/seedpass/core/password_generation.py
@@ -42,7 +42,12 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for removed module
 
 from local_bip85.bip85 import BIP85
 
-from constants import DEFAULT_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH, MAX_PASSWORD_LENGTH
+from constants import (
+    DEFAULT_PASSWORD_LENGTH,
+    MIN_PASSWORD_LENGTH,
+    MAX_PASSWORD_LENGTH,
+    SAFE_SPECIAL_CHARS,
+)
 from .encryption import EncryptionManager
 
 # Instantiate the logger

--- a/src/tests/test_password_special_chars.py
+++ b/src/tests/test_password_special_chars.py
@@ -4,6 +4,8 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from constants import SAFE_SPECIAL_CHARS
+
 from seedpass.core.password_generation import PasswordGenerator, PasswordPolicy
 
 
@@ -47,3 +49,11 @@ def test_exclude_ambiguous_chars():
     pw = pg.generate_password(length=32, index=2)
     for ch in "O0Il1":
         assert ch not in pw
+
+
+def test_safe_special_chars_mode():
+    policy = PasswordPolicy(special_mode="safe")
+    pg = make_generator(policy)
+    pw = pg.generate_password(length=32, index=3)
+    specials = [c for c in pw if c in string.punctuation]
+    assert specials and all(c in SAFE_SPECIAL_CHARS for c in specials)


### PR DESCRIPTION
## Summary
- import SAFE_SPECIAL_CHARS into password_generation module
- document the constant in JSON entries docs and README
- test safe special character mode in password generator

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest -q src/tests/test_password_special_chars.py::test_safe_special_chars_mode`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688ad1ba5df4832b94bee1c5071873a3