### PR TITLE
Fix password notes display

### DIFF
--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -2767,6 +2767,8 @@ class PasswordManager:
                         "cyan",
                     )
                 )
+                if notes:
+                    print(colored(f"Notes: {notes}", "cyan"))
                 tags = entry.get("tags", [])
                 if tags:
                     print(colored(f"Tags: {', '.join(tags)}", "cyan"))
@@ -3387,9 +3389,15 @@ class PasswordManager:
             username = entry.get("username", "")
             url = entry.get("url", "")
             blacklisted = entry.get("archived", entry.get("blacklisted", False))
+            notes = entry.get("notes", "")
+            tags = entry.get("tags", [])
             print(color_text(f"  Label: {website}", "index"))
             print(color_text(f"  Username: {username or 'N/A'}", "index"))
             print(color_text(f"  URL: {url or 'N/A'}", "index"))
+            if notes:
+                print(color_text(f"  Notes: {notes}", "index"))
+            if tags:
+                print(color_text(f"  Tags: {', '.join(tags)}", "index"))
             print(
                 color_text(
                     f"  Archived: {'Yes' if blacklisted else 'No'}",

--- a/src/tests/test_password_notes_display.py
+++ b/src/tests/test_password_notes_display.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from seedpass.core.entry_management import EntryManager
+from seedpass.core.backup import BackupManager
+from seedpass.core.manager import PasswordManager, EncryptionMode
+from seedpass.core.config_manager import ConfigManager
+
+
+def test_password_notes_shown(monkeypatch, capsys):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+        pm.encryption_manager = enc_mgr
+        pm.vault = vault
+        pm.entry_manager = entry_mgr
+        pm.backup_manager = backup_mgr
+        pm.password_generator = SimpleNamespace(generate_password=lambda l, i: "pw")
+        pm.parent_seed = TEST_SEED
+        pm.nostr_client = SimpleNamespace()
+        pm.fingerprint_dir = tmp_path
+        pm.secret_mode_enabled = False
+
+        entry_mgr.add_entry("example.com", 8, notes="remember")
+
+        monkeypatch.setattr(
+            "seedpass.core.manager.clear_header_with_notification", lambda *a, **k: None
+        )
+        monkeypatch.setattr("seedpass.core.manager.pause", lambda *a, **k: None)
+        monkeypatch.setattr(pm, "_entry_actions_menu", lambda *a, **k: None)
+
+        pm.display_entry_details(0)
+        out = capsys.readouterr().out
+        assert "Notes: remember" in out
+
+        inputs = iter(["0", ""])
+        monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+        pm.handle_retrieve_entry()
+        out = capsys.readouterr().out
+        assert "Notes: remember" in out


### PR DESCRIPTION
## Summary
- show notes for password entries in details screens
- test showing notes with list and retrieve

## Testing
- `pytest src/tests/test_password_notes_display.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688b7a406310832bafef81c934b74864