### PR TITLE
Add more lib deps to install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -91,8 +91,10 @@ main() {
                 build-essential pkg-config xclip \
                 libcairo2 libcairo2-dev \
                 libgirepository-2.0-dev gir1.2-girepository-2.0 \
+                libgirepository1.0-dev \
                 gobject-introspection \
-                gir1.2-gtk-3.0 python3-dev
+                gir1.2-gtk-3.0 python3-dev \
+                libffi-dev libssl-dev
         elif command -v dnf &> /dev/null; then
             sudo dnf groupinstall -y "Development Tools" && sudo dnf install -y \
                 pkg-config cairo cairo-devel xclip \


### PR DESCRIPTION
## Summary
- install libffi-dev, libssl-dev, libgirepository1.0-dev on Debian/Ubuntu

## Testing
- `black .`
- `python3 -m venv venv && source venv/bin/activate && pip install -r src/requirements.txt`
- `pytest -q`
- `scripts/install.sh -b main`

------
https://chatgpt.com/codex/tasks/task_b_688b9654dc24832b8c9276a9b84d9acb