### PR TITLE
Fix modify_entry for SSH and managed accounts

### DIFF
--- a/src/tests/test_modify_ssh_managed_entries.py
+++ b/src/tests/test_modify_ssh_managed_entries.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from seedpass.core.entry_management import EntryManager
+from seedpass.core.backup import BackupManager
+from seedpass.core.config_manager import ConfigManager
+
+
+def setup_mgr(tmp_path: Path) -> EntryManager:
+    vault, _ = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+    cfg = ConfigManager(vault, tmp_path)
+    backup = BackupManager(tmp_path, cfg)
+    return EntryManager(vault, backup)
+
+
+def test_modify_ssh_entry():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        em = setup_mgr(tmp_path)
+
+        idx = em.add_ssh_key("ssh", TEST_SEED)
+        em.modify_entry(idx, label="newssh", notes="n", archived=True, tags=["x"])
+        entry = em.retrieve_entry(idx)
+
+        assert entry["label"] == "newssh"
+        assert entry["notes"] == "n"
+        assert entry["archived"] is True
+        assert entry["tags"] == ["x"]
+
+
+def test_modify_managed_account_entry():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        em = setup_mgr(tmp_path)
+
+        idx = em.add_managed_account("acct", TEST_SEED)
+        em.modify_entry(
+            idx,
+            label="acct2",
+            value="val",
+            notes="note",
+            archived=True,
+            tags=["tag"],
+        )
+        entry = em.retrieve_entry(idx)
+
+        assert entry["label"] == "acct2"
+        assert entry["value"] == "val"
+        assert entry["notes"] == "note"
+        assert entry["archived"] is True
+        assert entry["tags"] == ["tag"]


### PR DESCRIPTION
## Summary
- prompt only supported fields when modifying SSH entries
- ask for `key` only when editing key/value entries
- avoid passing unsupported args during modification
- add regression tests for SSH and managed-account modifications

## Testing
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b99bd1ef0832b9978c960468d2a7f