### PR TITLE
Fix manifest ID handling and add restore test

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -406,6 +406,7 @@ def handle_retrieve_from_nostr(password_manager: PasswordManager):
     Handles the action of retrieving the encrypted password index from Nostr.
     """
     try:
+        password_manager.nostr_client.fingerprint = password_manager.current_fingerprint
         result = asyncio.run(password_manager.nostr_client.fetch_latest_snapshot())
         if result:
             manifest, chunks = result
@@ -423,8 +424,12 @@ def handle_retrieve_from_nostr(password_manager: PasswordManager):
             print(colored("Encrypted index retrieved and saved successfully.", "green"))
             logging.info("Encrypted index retrieved and saved successfully from Nostr.")
         else:
-            print(colored("Failed to retrieve data from Nostr.", "red"))
-            logging.error("Failed to retrieve data from Nostr.")
+            msg = (
+                f"No Nostr events found for fingerprint"
+                f" {password_manager.current_fingerprint}."
+            )
+            print(colored(msg, "red"))
+            logging.error(msg)
     except Exception as e:
         logging.error(f"Failed to retrieve from Nostr: {e}", exc_info=True)
         print(colored(f"Error: Failed to retrieve from Nostr: {e}", "red"))

--- a/src/tests/test_nostr_restore_flow.py
+++ b/src/tests/test_nostr_restore_flow.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import main
+from helpers import create_vault, dummy_nostr_client, TEST_SEED, TEST_PASSWORD
+from seedpass.core.entry_management import EntryManager
+from seedpass.core.backup import BackupManager
+from seedpass.core.config_manager import ConfigManager
+from seedpass.core.manager import PasswordManager, EncryptionMode
+
+
+def _init_pm(dir_path: Path, client) -> PasswordManager:
+    vault, enc_mgr = create_vault(dir_path, TEST_SEED, TEST_PASSWORD)
+    cfg_mgr = ConfigManager(vault, dir_path)
+    backup_mgr = BackupManager(dir_path, cfg_mgr)
+    entry_mgr = EntryManager(vault, backup_mgr)
+
+    pm = PasswordManager.__new__(PasswordManager)
+    pm.encryption_mode = EncryptionMode.SEED_ONLY
+    pm.encryption_manager = enc_mgr
+    pm.vault = vault
+    pm.entry_manager = entry_mgr
+    pm.backup_manager = backup_mgr
+    pm.config_manager = cfg_mgr
+    pm.nostr_client = client
+    pm.fingerprint_dir = dir_path
+    pm.current_fingerprint = "fp"
+    pm.is_dirty = False
+    return pm
+
+
+def test_restore_flow_from_snapshot(monkeypatch, tmp_path):
+    client, relay = dummy_nostr_client.__wrapped__(tmp_path / "srv", monkeypatch)
+
+    dir_a = tmp_path / "A"
+    dir_b = tmp_path / "B"
+    dir_a.mkdir()
+    dir_b.mkdir()
+
+    pm_a = _init_pm(dir_a, client)
+    pm_a.entry_manager.add_entry("site1", 12)
+    pm_a.sync_vault()
+    assert relay.manifests
+
+    pm_b = _init_pm(dir_b, client)
+    monkeypatch.setattr(main, "pause", lambda *a, **k: None)
+    main.handle_retrieve_from_nostr(pm_b)
+
+    labels = [e[1] for e in pm_b.entry_manager.list_entries()]
+    assert labels == ["site1"]


### PR DESCRIPTION
## Summary
- store manifest identifier based on fingerprint when switching or setting up profiles
- keep nostr client fingerprint in sync for restore operations
- improve restore message when no events are found
- handle missing notifications queue in tests
- add regression test for restoring snapshot via CLI

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688bb5277d34832b84a3c79910c78b19