### PR TITLE
Improve install script dependency handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ See `docs/ARCHITECTURE.md` for details.
 
 Use the automated installer to download SeedPass and its dependencies in one step.
 The scripts also install the correct BeeWare backend for your platform automatically.
+If the GTK `gi` bindings are missing, the installer attempts to install the
+necessary system packages using `apt`, `yum`, `pacman`, or Homebrew.
 
 **Linux and macOS:**
 ```bash

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -90,6 +90,8 @@ maintainable while enabling a consistent experience on multiple platforms.
 ### Quick Installer
 
 Use the automated installer to download SeedPass and its dependencies in one step.
+If GTK packages are missing, the installer will try to install them using your
+system's package manager (`apt`, `yum`, `pacman`, or Homebrew).
 
 **Linux and macOS:**
 ```bash


### PR DESCRIPTION
## Summary
- auto-install GTK dependencies via apt/yum/pacman/brew when `gi` isn't present
- call this detection before creating the virtual environment
- document automatic system package installation in README and docs

## Testing
- `black .`
- `python3 -m venv venv`
- `pip install -r src/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688c1a7ff4ac832b855517225271a7ff