### PR TITLE
feat: add quick password entry mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,15 @@ When choosing **Add Entry**, you can now select from:
 - **Key/Value**
 - **Managed Account**
 
+### Adding a Password Entry
+
+After selecting **Password**, SeedPass asks you to pick a mode:
+
+1. **Quick** – prompts only for a label, username, URL, desired length, and whether to include special characters. Default values are used for notes, tags, and policy settings.
+2. **Advanced** – walks through the full set of prompts for notes, tags, custom fields, and detailed password policy options.
+
+Both modes generate the password, display it (or copy it to the clipboard in Secret Mode), and save the entry to your encrypted vault.
+
 ### Adding a 2FA Entry
 
 1. From the main menu choose **Add Entry** and select **2FA (TOTP)**.

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -316,6 +316,15 @@ When choosing **Add Entry**, you can now select from:
 - **Key/Value**
 - **Managed Account**
 
+### Adding a Password Entry
+
+After selecting **Password**, SeedPass asks you to choose a mode:
+
+1. **Quick** – enter only a label, username, URL, desired length, and whether to include special characters. All other fields use defaults.
+2. **Advanced** – continue through prompts for notes, tags, custom fields, and detailed password policy settings.
+
+Both modes generate the password, display it (or copy it to the clipboard in Secret Mode), and save the entry to your encrypted vault.
+
 ### Adding a 2FA Entry
 
 1. From the main menu choose **Add Entry** and select **2FA (TOTP)**.

--- a/src/tests/test_manager_add_password.py
+++ b/src/tests/test_manager_add_password.py
@@ -45,6 +45,7 @@ def test_handle_add_password(monkeypatch, dummy_nostr_client, capsys):
 
         inputs = iter(
             [
+                "a",  # advanced mode
                 "Example",  # label
                 "",  # username
                 "",  # url
@@ -114,6 +115,7 @@ def test_handle_add_password_secret_mode(monkeypatch, dummy_nostr_client, capsys
 
         inputs = iter(
             [
+                "a",  # advanced mode
                 "Example",  # label
                 "",  # username
                 "",  # url
@@ -147,3 +149,62 @@ def test_handle_add_password_secret_mode(monkeypatch, dummy_nostr_client, capsys
         assert f"pw-0-{DEFAULT_PASSWORD_LENGTH}" not in out
         assert "copied to clipboard" in out
         assert called == [(f"pw-0-{DEFAULT_PASSWORD_LENGTH}", 5)]
+
+
+def test_handle_add_password_quick_mode(monkeypatch, dummy_nostr_client, capsys):
+    client, _relay = dummy_nostr_client
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.encryption_mode = EncryptionMode.SEED_ONLY
+        pm.encryption_manager = enc_mgr
+        pm.vault = vault
+        pm.entry_manager = entry_mgr
+        pm.backup_manager = backup_mgr
+        pm.password_generator = FakePasswordGenerator()
+        pm.parent_seed = TEST_SEED
+        pm.nostr_client = client
+        pm.fingerprint_dir = tmp_path
+        pm.secret_mode_enabled = False
+        pm.is_dirty = False
+
+        inputs = iter(
+            [
+                "q",  # quick mode
+                "Example",  # label
+                "",  # username
+                "",  # url
+                "",  # length (default)
+                "",  # include special default
+            ]
+        )
+        monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+        monkeypatch.setattr("seedpass.core.manager.pause", lambda *a, **k: None)
+        monkeypatch.setattr(pm, "start_background_vault_sync", lambda *a, **k: None)
+
+        pm.handle_add_password()
+        out = capsys.readouterr().out
+
+        entries = entry_mgr.list_entries(verbose=False)
+        assert entries == [(0, "Example", "", "", False)]
+
+        entry = entry_mgr.retrieve_entry(0)
+        assert entry == {
+            "label": "Example",
+            "length": DEFAULT_PASSWORD_LENGTH,
+            "username": "",
+            "url": "",
+            "archived": False,
+            "type": "password",
+            "kind": "password",
+            "notes": "",
+            "custom_fields": [],
+            "tags": [],
+        }
+
+        assert f"pw-0-{DEFAULT_PASSWORD_LENGTH}" in out

--- a/src/tests/test_manager_workflow.py
+++ b/src/tests/test_manager_workflow.py
@@ -50,6 +50,7 @@ def test_manager_workflow(monkeypatch):
 
         inputs = iter(
             [
+                "a",  # advanced mode
                 "example.com",
                 "",  # username
                 "",  # url


### PR DESCRIPTION
## Summary
- add mode selection and quick workflow for password entries
- test quick mode and update docs for quick vs advanced flows

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688e7647133c832b9a6fbd082062141e