### PR TITLE
feat: add short-lived JWT auth and secure endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,30 @@ You can also launch the GUI directly with `seedpass gui` or `seedpass-gui`.
 - **Offline Mode:** When enabled, SeedPass skips all Nostr operations so your vault stays local until syncing is turned back on.
 - **Quick Unlock:** Stores a hashed copy of your password in the encrypted config so you only need to enter it once per session. Avoid this on shared computers.
 
+### Secure Deployment
+
+Always deploy SeedPass behind HTTPS. Place a TLS‑terminating reverse proxy such as Nginx in front of the FastAPI server or configure Uvicorn with certificate files. Example Nginx snippet:
+
+```
+server {
+    listen 443 ssl;
+    ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+```
+
+For local testing, Uvicorn can run with TLS directly:
+
+```
+uvicorn seedpass.api:app --ssl-certfile=cert.pem --ssl-keyfile=key.pem
+```
+
 ## Contributing
 
 Contributions are welcome! If you have suggestions for improvements, bug fixes, or new features, please follow these steps:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -31,6 +31,7 @@ starlette>=0.47.2
 httpx>=0.28.1
 requests>=2.32
 python-multipart
+PyJWT
 orjson
 argon2-cffi
 toga-core>=0.5.2

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -39,6 +39,7 @@ def client(monkeypatch):
         nostr_client=SimpleNamespace(
             key_manager=SimpleNamespace(get_npub=lambda: "np")
         ),
+        verify_password=lambda pw: True,
     )
     monkeypatch.setattr(api, "PasswordManager", lambda: dummy)
     monkeypatch.setenv("SEEDPASS_CORS_ORIGINS", "http://example.com")

--- a/src/tests/test_api_new_endpoints.py
+++ b/src/tests/test_api_new_endpoints.py
@@ -162,7 +162,10 @@ def test_parent_seed_endpoint(client, tmp_path):
     api._pm.encryption_manager = SimpleNamespace(
         encrypt_and_save_file=lambda data, path: called.setdefault("path", path)
     )
-    headers = {"Authorization": f"Bearer {token}"}
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-SeedPass-Password": "pw",
+    }
 
     res = cl.get("/api/v1/parent-seed", headers=headers)
     assert res.status_code == 200
@@ -173,6 +176,9 @@ def test_parent_seed_endpoint(client, tmp_path):
     assert res.status_code == 200
     assert res.json() == {"status": "saved", "path": str(out)}
     assert called["path"] == out
+
+    res = cl.get("/api/v1/parent-seed", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 401
 
 
 def test_fingerprint_endpoints(client):
@@ -330,10 +336,16 @@ def test_vault_export_endpoint(client, tmp_path):
 
     api._pm.handle_export_database = lambda: out
 
-    headers = {"Authorization": f"Bearer {token}"}
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-SeedPass-Password": "pw",
+    }
     res = cl.post("/api/v1/vault/export", headers=headers)
     assert res.status_code == 200
     assert res.content == b"data"
+
+    res = cl.post("/api/v1/vault/export", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 401
 
 
 def test_backup_parent_seed_endpoint(client, tmp_path):


### PR DESCRIPTION
## Summary
- issue short-lived JWT tokens and verify them on each request
- require master password header for parent-seed and vault export endpoints
- document HTTPS deployment and new authentication flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688ebdac37ac832b80909ab058eac8ea