### PR TITLE
Use HMAC-based deterministic shuffle

### DIFF
--- a/src/tests/test_password_shuffle_consistency.py
+++ b/src/tests/test_password_shuffle_consistency.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from seedpass.core.password_generation import PasswordGenerator, PasswordPolicy
+
+
+class DummyEnc:
+    def derive_seed_from_mnemonic(self, mnemonic):
+        return b"\x00" * 32
+
+
+class DummyBIP85:
+    def derive_entropy(self, index: int, bytes_len: int, app_no: int = 32) -> bytes:
+        return bytes((index + i) % 256 for i in range(bytes_len))
+
+
+def make_generator():
+    pg = PasswordGenerator.__new__(PasswordGenerator)
+    pg.encryption_manager = DummyEnc()
+    pg.bip85 = DummyBIP85()
+    pg.policy = PasswordPolicy()
+    return pg
+
+
+def test_password_generation_consistent_output():
+    pg = make_generator()
+    expected = "0j6R3e-%4xN@N{Jb"
+    assert pg.generate_password(length=16, index=1) == expected
+    # Generating again should produce the same password
+    assert pg.generate_password(length=16, index=1) == expected

--- a/src/tests/test_pgp_entry.py
+++ b/src/tests/test_pgp_entry.py
@@ -39,3 +39,21 @@ def test_pgp_key_determinism():
         entry = data["entries"][str(idx)]
         assert entry["key_type"] == "ed25519"
         assert entry["user_id"] == "Test"
+
+
+def test_pgp_rsa_key_determinism():
+    """RSA PGP keys should be derived deterministically."""
+
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        idx = entry_mgr.add_pgp_key("pgp", TEST_SEED, key_type="rsa", user_id="Test")
+        key1, fp1 = entry_mgr.get_pgp_key(idx, TEST_SEED)
+        key2, fp2 = entry_mgr.get_pgp_key(idx, TEST_SEED)
+
+        assert fp1 == fp2
+        assert key1 == key2


### PR DESCRIPTION
## Summary
- Replace `random.Random` shuffles with an HMAC-SHA256 based Fisher–Yates algorithm seeded from the derived key
- Explain why this deterministic shuffle remains cryptographically sound
- Add regression test ensuring password generation remains consistent across Python versions

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r src/requirements.txt`
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688f5f72f6c8832bbc3e35ab86abe9fa