### PR TITLE
Use fingerprint-based salt for password key derivation

### DIFF
--- a/scripts/generate_test_profile.py
+++ b/scripts/generate_test_profile.py
@@ -79,7 +79,7 @@ def initialize_profile(
     profile_dir = APP_DIR / fingerprint
     profile_dir.mkdir(parents=True, exist_ok=True)
 
-    seed_key = derive_key_from_password(DEFAULT_PASSWORD)
+    seed_key = derive_key_from_password(DEFAULT_PASSWORD, fingerprint)
     seed_mgr = EncryptionManager(seed_key, profile_dir)
     seed_file = profile_dir / "parent_seed.enc"
     clear_path = profile_dir / "seed_phrase.txt"

--- a/src/tests/helpers.py
+++ b/src/tests/helpers.py
@@ -11,6 +11,7 @@ from utils.key_derivation import (
     derive_index_key,
     derive_key_from_password,
 )
+from utils.fingerprint import generate_fingerprint
 
 TEST_SEED = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 TEST_PASSWORD = "pw"
@@ -22,7 +23,8 @@ def create_vault(
     password: str = TEST_PASSWORD,
 ) -> tuple[Vault, EncryptionManager]:
     """Create a Vault initialized for tests."""
-    seed_key = derive_key_from_password(password)
+    fp = generate_fingerprint(seed)
+    seed_key = derive_key_from_password(password, fp)
     seed_mgr = EncryptionManager(seed_key, dir_path)
     seed_mgr.encrypt_parent_seed(seed)
 

--- a/src/tests/test_concurrency_stress.py
+++ b/src/tests/test_concurrency_stress.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from multiprocessing import Process, Queue
 import pytest
 from helpers import TEST_SEED, TEST_PASSWORD
+from utils.fingerprint import generate_fingerprint
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -51,7 +52,8 @@ def _backup(index_key: bytes, dir_path: Path, loops: int, out: Queue) -> None:
 @pytest.mark.parametrize("_", range(3))
 def test_concurrency_stress(tmp_path: Path, loops: int, _):
     index_key = derive_index_key(TEST_SEED)
-    seed_key = derive_key_from_password(TEST_PASSWORD)
+    fp = generate_fingerprint(TEST_SEED)
+    seed_key = derive_key_from_password(TEST_PASSWORD, fp)
     EncryptionManager(seed_key, tmp_path).encrypt_parent_seed(TEST_SEED)
     enc = EncryptionManager(index_key, tmp_path)
     Vault(enc, tmp_path).save_index({"counter": 0})

--- a/src/tests/test_fuzz_key_derivation.py
+++ b/src/tests/test_fuzz_key_derivation.py
@@ -9,6 +9,7 @@ from utils.key_derivation import (
     derive_key_from_password_argon2,
     derive_index_key,
 )
+from utils.fingerprint import generate_fingerprint
 from seedpass.core.encryption import EncryptionManager
 
 
@@ -33,12 +34,13 @@ cfg_values = st.one_of(
 def test_fuzz_key_round_trip(password, seed_bytes, config, mode, tmp_path: Path):
     """Ensure EncryptionManager round-trips arbitrary data."""
     seed_phrase = Mnemonic("english").to_mnemonic(seed_bytes)
+    fp = generate_fingerprint(seed_phrase)
     if mode == "argon2":
         key = derive_key_from_password_argon2(
-            password, time_cost=1, memory_cost=8, parallelism=1
+            password, fp, time_cost=1, memory_cost=8, parallelism=1
         )
     else:
-        key = derive_key_from_password(password, iterations=1)
+        key = derive_key_from_password(password, fp, iterations=1)
 
     enc_mgr = EncryptionManager(key, tmp_path)
 

--- a/src/tests/test_index_import_export.py
+++ b/src/tests/test_index_import_export.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 import pytest
 import sys
 from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+from utils.fingerprint import generate_fingerprint
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -16,7 +17,8 @@ PASSWORD = "passw0rd"
 
 
 def setup_vault(tmp: Path) -> Vault:
-    seed_key = derive_key_from_password(PASSWORD)
+    fp = generate_fingerprint(SEED)
+    seed_key = derive_key_from_password(PASSWORD, fp)
     seed_mgr = EncryptionManager(seed_key, tmp)
     seed_mgr.encrypt_parent_seed(SEED)
 

--- a/src/tests/test_key_derivation.py
+++ b/src/tests/test_key_derivation.py
@@ -10,8 +10,9 @@ from utils.key_derivation import (
 
 def test_derive_key_deterministic():
     password = "correct horse battery staple"
-    key1 = derive_key_from_password(password, iterations=1)
-    key2 = derive_key_from_password(password, iterations=1)
+    fp = "fp"
+    key1 = derive_key_from_password(password, fp, iterations=1)
+    key2 = derive_key_from_password(password, fp, iterations=1)
     assert key1 == key2
     assert len(key1) == 44
     logging.info("Deterministic key derivation succeeded")
@@ -19,7 +20,7 @@ def test_derive_key_deterministic():
 
 def test_derive_key_empty_password_error():
     with pytest.raises(ValueError):
-        derive_key_from_password("")
+        derive_key_from_password("", "fp")
     logging.info("Empty password correctly raised ValueError")
 
 
@@ -38,7 +39,12 @@ def test_derive_index_key_seed_only():
 
 def test_argon2_key_deterministic():
     pw = "correct horse battery staple"
-    k1 = derive_key_from_password_argon2(pw, time_cost=1, memory_cost=8, parallelism=1)
-    k2 = derive_key_from_password_argon2(pw, time_cost=1, memory_cost=8, parallelism=1)
+    fp = "fp"
+    k1 = derive_key_from_password_argon2(
+        pw, fp, time_cost=1, memory_cost=8, parallelism=1
+    )
+    k2 = derive_key_from_password_argon2(
+        pw, fp, time_cost=1, memory_cost=8, parallelism=1
+    )
     assert k1 == k2
     assert len(k1) == 44

--- a/src/tests/test_portable_backup.py
+++ b/src/tests/test_portable_backup.py
@@ -15,6 +15,7 @@ from seedpass.core.backup import BackupManager
 from seedpass.core.config_manager import ConfigManager
 from seedpass.core.portable_backup import export_backup, import_backup
 from utils.key_derivation import derive_index_key, derive_key_from_password
+from utils.fingerprint import generate_fingerprint
 
 
 SEED = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
@@ -22,7 +23,8 @@ PASSWORD = "passw0rd"
 
 
 def setup_vault(tmp: Path):
-    seed_key = derive_key_from_password(PASSWORD)
+    fp = generate_fingerprint(SEED)
+    seed_key = derive_key_from_password(PASSWORD, fp)
     seed_mgr = EncryptionManager(seed_key, tmp)
     seed_mgr.encrypt_parent_seed(SEED)
 
@@ -126,7 +128,8 @@ def test_export_creates_additional_backup_and_import(monkeypatch):
     with TemporaryDirectory() as td, TemporaryDirectory() as extra:
         tmp = Path(td)
 
-        seed_key = derive_key_from_password(PASSWORD)
+        fp = generate_fingerprint(SEED)
+        seed_key = derive_key_from_password(PASSWORD, fp)
         seed_mgr = EncryptionManager(seed_key, tmp)
         seed_mgr.encrypt_parent_seed(SEED)
 

--- a/src/tests/test_seed_import.py
+++ b/src/tests/test_seed_import.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from helpers import TEST_PASSWORD
 from utils.key_derivation import derive_key_from_password
+from utils.fingerprint import generate_fingerprint
 from mnemonic import Mnemonic
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -13,10 +14,10 @@ from seedpass.core.manager import PasswordManager, EncryptionMode
 
 def test_seed_encryption_round_trip():
     with TemporaryDirectory() as tmpdir:
-        key = derive_key_from_password(TEST_PASSWORD)
-        enc_mgr = EncryptionManager(key, Path(tmpdir))
-
         seed = Mnemonic("english").generate(strength=128)
+        fp = generate_fingerprint(seed)
+        key = derive_key_from_password(TEST_PASSWORD, fp)
+        enc_mgr = EncryptionManager(key, Path(tmpdir))
         enc_mgr.encrypt_parent_seed(seed)
         decrypted = enc_mgr.decrypt_parent_seed()
 

--- a/src/tests/test_seed_migration.py
+++ b/src/tests/test_seed_migration.py
@@ -4,6 +4,7 @@ from cryptography.fernet import Fernet
 
 from helpers import TEST_PASSWORD, TEST_SEED
 from utils.key_derivation import derive_key_from_password
+from utils.fingerprint import generate_fingerprint
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -11,7 +12,8 @@ from seedpass.core.encryption import EncryptionManager
 
 
 def test_parent_seed_migrates_from_fernet(tmp_path: Path) -> None:
-    key = derive_key_from_password(TEST_PASSWORD)
+    fp = generate_fingerprint(TEST_SEED)
+    key = derive_key_from_password(TEST_PASSWORD, fp)
     fernet = Fernet(key)
     encrypted = fernet.encrypt(TEST_SEED.encode())
     legacy_file = tmp_path / "parent_seed.enc"


### PR DESCRIPTION
## Summary
- Derive PBKDF2 and Argon2 keys using a salt based on the seed fingerprint
- Thread fingerprint-derived salt through password key operations in the manager and scripts
- Adjust tests and helpers to pass the fingerprint when deriving keys

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688f63c169cc832ba926f7aac70319bf