### PR TITLE
Add fingerprint-based key derivation tests

### DIFF
--- a/src/tests/test_key_derivation.py
+++ b/src/tests/test_key_derivation.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+from utils.fingerprint import generate_fingerprint
 from utils.key_derivation import (
     derive_key_from_password,
     derive_key_from_password_argon2,
@@ -8,14 +9,19 @@ from utils.key_derivation import (
 )
 
 
-def test_derive_key_deterministic():
+def test_pbkdf2_fingerprint_affects_key():
     password = "correct horse battery staple"
-    fp = "fp"
-    key1 = derive_key_from_password(password, fp, iterations=1)
-    key2 = derive_key_from_password(password, fp, iterations=1)
+    fp1 = generate_fingerprint("seed one")
+    fp2 = generate_fingerprint("seed two")
+
+    key1 = derive_key_from_password(password, fp1, iterations=1)
+    key2 = derive_key_from_password(password, fp1, iterations=1)
+    key3 = derive_key_from_password(password, fp2, iterations=1)
+
     assert key1 == key2
+    assert key1 != key3
     assert len(key1) == 44
-    logging.info("Deterministic key derivation succeeded")
+    logging.info("PBKDF2 fingerprint behaviour verified")
 
 
 def test_derive_key_empty_password_error():
@@ -37,14 +43,21 @@ def test_derive_index_key_seed_only():
     assert derive_index_key(seed) == derive_index_key_seed_only(seed)
 
 
-def test_argon2_key_deterministic():
-    pw = "correct horse battery staple"
-    fp = "fp"
+def test_argon2_fingerprint_affects_key():
+    password = "correct horse battery staple"
+    fp1 = generate_fingerprint("seed one")
+    fp2 = generate_fingerprint("seed two")
+
     k1 = derive_key_from_password_argon2(
-        pw, fp, time_cost=1, memory_cost=8, parallelism=1
+        password, fp1, time_cost=1, memory_cost=8, parallelism=1
     )
     k2 = derive_key_from_password_argon2(
-        pw, fp, time_cost=1, memory_cost=8, parallelism=1
+        password, fp1, time_cost=1, memory_cost=8, parallelism=1
     )
+    k3 = derive_key_from_password_argon2(
+        password, fp2, time_cost=1, memory_cost=8, parallelism=1
+    )
+
     assert k1 == k2
+    assert k1 != k3
     assert len(k1) == 44


### PR DESCRIPTION
## Summary
- ensure PBKDF2 key derivation produces unique keys per fingerprint
- add Argon2 key derivation test with fingerprint variations

## Testing
- `black .`
- `PYTHONPATH=src pytest src/tests/test_key_derivation.py`


------
https://chatgpt.com/codex/tasks/task_b_688f67ef5cf0832b972addbb6a046b1b