### PR TITLE
ci: add gitleaks scanning

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -9,6 +9,20 @@ on:
     - cron: '0 3 * * *'
 
 jobs:
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+
   build:
     strategy:
       matrix:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+title = "SeedPass gitleaks config"
+
+[allowlist]
+  description = "Paths and patterns to ignore when scanning for secrets"
+  # Add file paths that contain test data or other non-sensitive strings
+  paths = []
+  # Add regular expressions that match false positive secrets
+  regexes = []

--- a/docs/secret-scanning.md
+++ b/docs/secret-scanning.md
@@ -1,0 +1,17 @@
+# Secret Scanning
+
+SeedPass uses [Gitleaks](https://github.com/gitleaks/gitleaks) to scan the repository for accidentally committed secrets. The scan runs automatically for pull requests and on a nightly schedule. Any findings will cause the build to fail.
+
+## Suppressing False Positives
+
+If a file or string triggers the scanner but does not contain a real secret, add it to the allowlist in `.gitleaks.toml`.
+
+```toml
+[allowlist]
+# Ignore specific files
+paths = ["path/to/file.txt"]
+# Ignore strings that match a regular expression
+regexes = ["""dummy_api_key"""]
+```
+
+Commit the updated `.gitleaks.toml` to stop future alerts for the allowed items.


### PR DESCRIPTION
## Summary
- scan repository with gitleaks on pull requests and nightly schedule
- document how to allowlist secrets with gitleaks

## Testing
- `pip install --require-hashes -r requirements.lock`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688f70397fd8832b89bd0f548cc8de2e