### PR TITLE
Clarify Nostr vault restoration requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,13 +561,16 @@ The default configuration uses **50,000** PBKDF2 iterations. Increase this value
 ### Recovery
 
 If you previously backed up your vault to Nostr you can restore it during the
-initial setup:
+initial setup. You must provide both your 12‑word master seed and the master
+password that encrypted the vault; without the correct password the retrieved
+data cannot be decrypted.
 
 1. Start SeedPass and choose option **4** when prompted to set up a seed.
-2. Paste your BIP-85 seed phrase when asked.
-3. SeedPass initializes the profile and attempts to download the encrypted vault
-   from the configured relays.
-4. A success message confirms the vault was restored. If no data is found a
+2. Paste your BIP‑85 seed phrase when asked.
+3. Enter the master password associated with that seed.
+4. SeedPass initializes the profile and attempts to download the encrypted
+   vault from the configured relays.
+5. A success message confirms the vault was restored. If no data is found a
    failure message is shown and a new empty vault is created.
 
 ## Running Tests

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -46,6 +46,7 @@ maintainable while enabling a consistent experience on multiple platforms.
   - [Running the Application](#running-the-application)
   - [Managing Multiple Seeds](#managing-multiple-seeds)
     - [Additional Entry Types](#additional-entry-types)
+  - [Recovery](#recovery)
 - [Security Considerations](#security-considerations)
 - [Contributing](#contributing)
 - [License](#license)
@@ -404,6 +405,22 @@ SeedPass allows you to manage multiple seed profiles (previously referred to as 
   - In the **Profiles** menu, choose "Set Seed Profile Name" to assign a label to the current profile. The name is stored locally and shown next to the fingerprint.
 
 **Note:** The term "seed profile" is used to represent different sets of seeds you can manage within SeedPass. This provides an intuitive way to handle multiple identities or sets of passwords.
+
+
+### Recovery
+
+If you previously backed up your vault to Nostr you can restore it during the
+initial setup. You must provide both your 12 -word master seed and the master
+password that encrypted the vault; without the correct password the retrieved
+data cannot be decrypted.
+
+1. Start SeedPass and choose option **4** when prompted to set up a seed.
+2. Paste your BIP‑85 seed phrase when asked.
+3. Enter the master password associated with that seed.
+4. SeedPass initializes the profile and attempts to download the encrypted
+   vault from the configured relays.
+5. A success message confirms the vault was restored. If no data is found a
+   failure message is shown and a new empty vault is created.
 
 ### Configuration File and Settings
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -202,6 +202,8 @@ flowchart TD
                     <p>SeedPass allows you to manage multiple seed profiles (fingerprints). You can switch between different seeds to compartmentalize your passwords.</p>
                     <h3 class="subsection-title">Nostr Relay Integration</h3>
                     <p>SeedPass publishes your encrypted vault to Nostr in 50&#8201;KB chunks using parameterised replaceable events. A manifest describes each snapshot while deltas record updates. When too many deltas accumulate, a new snapshot is rotated in automatically.</p>
+                    <h3 class="subsection-title">Recovery from Nostr</h3>
+                    <p>Restoring a vault on a new device requires both your 12&#8201;word master seed and the master password that encrypted the vault. Without the correct password the downloaded archive cannot be decrypted.</p>
                     <h3 class="subsection-title">Checksum Verification</h3>
                     <p>Built-in checksum verification ensures your SeedPass installation hasn't been tampered with.</p>
                     <h3 class="subsection-title">Interactive TUI</h3>


### PR DESCRIPTION
## Summary
- document that restoring a vault from Nostr requires both the 12-word master seed and the original master password
- add recovery instructions to docs and highlight the same on the landing page

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688f72ffa540832b89509afd7c752f90