### PR TITLE
Remove sensitive debug logging

### DIFF
--- a/src/seedpass/core/entry_management.py
+++ b/src/seedpass/core/entry_management.py
@@ -222,7 +222,9 @@ class EntryManager:
 
             data["entries"][str(index)] = entry
 
-            logger.debug(f"Added entry at index {index}: {data['entries'][str(index)]}")
+            logger.debug(
+                f"Added entry at index {index} with label '{entry.get('label', '')}'."
+            )
 
             self._save_index(data)
             self.update_checksum()
@@ -780,7 +782,9 @@ class EntryManager:
                     EntryType.MANAGED_ACCOUNT.value,
                 ):
                     entry.setdefault("custom_fields", [])
-                logger.debug(f"Retrieved entry at index {index}: {entry}")
+                logger.debug(
+                    f"Retrieved entry at index {index} with label '{entry.get('label', '')}'."
+                )
                 clean = {k: v for k, v in entry.items() if k != "modified_ts"}
                 return clean
             else:
@@ -1010,13 +1014,11 @@ class EntryManager:
 
             if custom_fields is not None:
                 entry["custom_fields"] = custom_fields
-                logger.debug(
-                    f"Updated custom fields for index {index}: {custom_fields}"
-                )
+                logger.debug(f"Updated custom fields for index {index}.")
 
             if tags is not None:
                 entry["tags"] = tags
-                logger.debug(f"Updated tags for index {index}: {tags}")
+                logger.debug(f"Updated tags for index {index}.")
 
             policy_updates: dict[str, Any] = {}
             if include_special_chars is not None:
@@ -1043,7 +1045,9 @@ class EntryManager:
             entry["modified_ts"] = int(time.time())
 
             data["entries"][str(index)] = entry
-            logger.debug(f"Modified entry at index {index}: {entry}")
+            logger.debug(
+                f"Modified entry at index {index} with label '{entry.get('label', '')}'."
+            )
 
             self._save_index(data)
             self.update_checksum()

--- a/src/seedpass/core/password_generation.py
+++ b/src/seedpass/core/password_generation.py
@@ -128,7 +128,7 @@ class PasswordGenerator:
     def _derive_password_entropy(self, index: int) -> bytes:
         """Derive deterministic entropy for password generation."""
         entropy = self.bip85.derive_entropy(index=index, bytes_len=64, app_no=32)
-        logger.debug(f"Derived entropy: {entropy.hex()}")
+        logger.debug("Entropy derived for password generation.")
 
         hkdf = HKDF(
             algorithm=hashes.SHA256(),
@@ -138,16 +138,16 @@ class PasswordGenerator:
             backend=default_backend(),
         )
         hkdf_derived = hkdf.derive(entropy)
-        logger.debug(f"Derived key using HKDF: {hkdf_derived.hex()}")
+        logger.debug("Derived key using HKDF.")
 
         dk = hashlib.pbkdf2_hmac("sha256", entropy, b"", 100000)
-        logger.debug(f"Derived key using PBKDF2: {dk.hex()}")
+        logger.debug("Derived key using PBKDF2.")
         return dk
 
     def _map_entropy_to_chars(self, dk: bytes, alphabet: str) -> str:
         """Map derived bytes to characters from the provided alphabet."""
         password = "".join(alphabet[byte % len(alphabet)] for byte in dk)
-        logger.debug(f"Password after mapping to all allowed characters: {password}")
+        logger.debug("Mapped entropy to allowed characters.")
         return password
 
     def _fisher_yates_hmac(self, items: list[str], key: bytes) -> list[str]:
@@ -248,7 +248,7 @@ class PasswordGenerator:
                     extra = self._map_entropy_to_chars(dk, all_allowed)
                     password += extra
                     password = self._shuffle_deterministically(password, dk)
-                    logger.debug(f"Extended password: {password}")
+                    logger.debug("Extended password to meet length requirement.")
 
             # Trim the password to the desired length and enforce complexity on
             # the final result. Complexity enforcement is repeated here because
@@ -261,7 +261,7 @@ class PasswordGenerator:
             )
             password = self._shuffle_deterministically(password, dk)
             logger.debug(
-                f"Final password (trimmed to {length} chars with complexity enforced): {password}"
+                f"Generated final password of length {length} with complexity enforced."
             )
 
             return password
@@ -333,34 +333,28 @@ class PasswordGenerator:
                     index = get_dk_value() % len(password_chars)
                     char = uppercase[get_dk_value() % len(uppercase)]
                     password_chars[index] = char
-                    logger.debug(
-                        f"Added uppercase letter '{char}' at position {index}."
-                    )
+                    logger.debug(f"Added uppercase letter at position {index}.")
 
             if current_lower < min_lower:
                 for _ in range(min_lower - current_lower):
                     index = get_dk_value() % len(password_chars)
                     char = lowercase[get_dk_value() % len(lowercase)]
                     password_chars[index] = char
-                    logger.debug(
-                        f"Added lowercase letter '{char}' at position {index}."
-                    )
+                    logger.debug(f"Added lowercase letter at position {index}.")
 
             if current_digits < min_digits:
                 for _ in range(min_digits - current_digits):
                     index = get_dk_value() % len(password_chars)
                     char = digits[get_dk_value() % len(digits)]
                     password_chars[index] = char
-                    logger.debug(f"Added digit '{char}' at position {index}.")
+                    logger.debug(f"Added digit at position {index}.")
 
             if special and current_special < min_special:
                 for _ in range(min_special - current_special):
                     index = get_dk_value() % len(password_chars)
                     char = special[get_dk_value() % len(special)]
                     password_chars[index] = char
-                    logger.debug(
-                        f"Added special character '{char}' at position {index}."
-                    )
+                    logger.debug(f"Added special character at position {index}.")
 
             # Additional deterministic inclusion of symbols to increase score
             if special:
@@ -374,9 +368,7 @@ class PasswordGenerator:
                     index = get_dk_value() % len(password_chars)
                     char = special[get_dk_value() % len(special)]
                     password_chars[index] = char
-                    logger.debug(
-                        f"Added additional symbol '{char}' at position {index}."
-                    )
+                    logger.debug(f"Added additional symbol at position {index}.")
 
             # Ensure balanced distribution by assigning different character types to specific segments
             # Example: Divide password into segments and assign different types
@@ -394,19 +386,15 @@ class PasswordGenerator:
                         if i == 0 and password_chars[j] not in uppercase:
                             char = uppercase[get_dk_value() % len(uppercase)]
                             password_chars[j] = char
-                            logger.debug(
-                                f"Assigned uppercase letter '{char}' to position {j}."
-                            )
+                            logger.debug(f"Assigned uppercase letter to position {j}.")
                         elif i == 1 and password_chars[j] not in lowercase:
                             char = lowercase[get_dk_value() % len(lowercase)]
                             password_chars[j] = char
-                            logger.debug(
-                                f"Assigned lowercase letter '{char}' to position {j}."
-                            )
+                            logger.debug(f"Assigned lowercase letter to position {j}.")
                         elif i == 2 and password_chars[j] not in digits:
                             char = digits[get_dk_value() % len(digits)]
                             password_chars[j] = char
-                            logger.debug(f"Assigned digit '{char}' to position {j}.")
+                            logger.debug(f"Assigned digit to position {j}.")
                         elif (
                             special
                             and i == len(char_types) - 1
@@ -414,9 +402,7 @@ class PasswordGenerator:
                         ):
                             char = special[get_dk_value() % len(special)]
                             password_chars[j] = char
-                            logger.debug(
-                                f"Assigned special character '{char}' to position {j}."
-                            )
+                            logger.debug(f"Assigned special character to position {j}.")
 
             # Shuffle again to distribute the characters more evenly.  The key is
             # tweaked with the current ``dk_index`` so that each call produces a

--- a/src/utils/key_derivation.py
+++ b/src/utils/key_derivation.py
@@ -94,11 +94,11 @@ def derive_key_from_password(
             iterations=iterations,
             dklen=32,  # 256-bit key for Fernet
         )
-        logger.debug(f"Derived key (hex): {key.hex()}")
+        logger.debug("Key derived from password using PBKDF2.")
 
         # Encode the key in URL-safe base64
         key_b64 = base64.urlsafe_b64encode(key)
-        logger.debug(f"Base64-encoded key: {key_b64.decode()}")
+        logger.debug("Derived key encoded in URL-safe base64.")
 
         return key_b64
 
@@ -231,7 +231,7 @@ def derive_totp_secret(seed: str, index: int) -> str:
         # Hash the first 32 bytes of entropy and encode the first 20 bytes
         hashed = hashlib.sha256(entropy[:32]).digest()
         secret = base64.b32encode(hashed[:20]).decode("utf-8")
-        logger.debug(f"Derived TOTP secret for index {index}: {secret}")
+        logger.debug(f"Derived TOTP secret for index {index}.")
         return secret
     except Exception as e:
         logger.error(f"Failed to derive TOTP secret: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- redact or remove sensitive debug logs in key derivation and TOTP secret generation
- strip entropy, key, and password values from password generation logs
- limit entry management logs to metadata instead of full entry contents

## Testing
- `pip install --require-hashes -r requirements.lock`
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688f76db8e98832bbce5ae4646864af3