### PR TITLE
Add legacy decryption fallback and tests

### DIFF
--- a/src/tests/test_decrypt_data_legacy_fallback.py
+++ b/src/tests/test_decrypt_data_legacy_fallback.py
@@ -1,0 +1,32 @@
+import base64
+import hashlib
+import unicodedata
+
+from helpers import TEST_PASSWORD
+import seedpass.core.encryption as enc_module
+from seedpass.core.encryption import EncryptionManager
+from utils.key_derivation import derive_key_from_password
+
+
+def _fast_legacy_key(password: str, iterations: int = 100_000) -> bytes:
+    normalized = unicodedata.normalize("NFKD", password).strip().encode("utf-8")
+    key = hashlib.pbkdf2_hmac("sha256", normalized, b"", 1, dklen=32)
+    return base64.urlsafe_b64encode(key)
+
+
+def test_decrypt_data_password_fallback(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        enc_module, "_derive_legacy_key_from_password", _fast_legacy_key
+    )
+    monkeypatch.setattr(
+        enc_module, "prompt_existing_password", lambda *_a, **_k: TEST_PASSWORD
+    )
+
+    legacy_key = _fast_legacy_key(TEST_PASSWORD)
+    legacy_mgr = EncryptionManager(legacy_key, tmp_path)
+    payload = legacy_mgr.encrypt_data(b"secret")
+
+    new_key = derive_key_from_password(TEST_PASSWORD, "fp")
+    new_mgr = EncryptionManager(new_key, tmp_path)
+
+    assert new_mgr.decrypt_data(payload) == b"secret"


### PR DESCRIPTION
## Summary
- fall back to password-only key derivation when AES-GCM or Fernet decryption fails
- log legacy key usage during decryption
- add regression test for legacy decryption fallback

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install --require-hashes -r requirements.lock`
- `black src/seedpass/core/encryption.py src/tests/test_decrypt_data_legacy_fallback.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688fd2734d60832b9226a12d9b5f7bc6