### PR TITLE
feat: add legacy migration prompt

### DIFF
--- a/src/seedpass/core/vault.py
+++ b/src/seedpass/core/vault.py
@@ -76,6 +76,9 @@ class Vault:
             )
 
         data = self.encryption_manager.load_json_data(self.index_file)
+        self.migrated_from_legacy = self.migrated_from_legacy or getattr(
+            self.encryption_manager, "last_migration_performed", False
+        )
         from .migrations import apply_migrations, LATEST_VERSION
 
         version = data.get("schema_version", 0)

--- a/src/tests/test_decrypt_data_legacy_fallback.py
+++ b/src/tests/test_decrypt_data_legacy_fallback.py
@@ -23,6 +23,7 @@ def test_decrypt_data_password_fallback(tmp_path, monkeypatch):
     monkeypatch.setattr(
         enc_module, "prompt_existing_password", lambda *_a, **_k: TEST_PASSWORD
     )
+    monkeypatch.setattr("builtins.input", lambda *_a, **_k: "1")
 
     legacy_key = _fast_legacy_key(TEST_PASSWORD, iterations=50_000)
     legacy_mgr = EncryptionManager(legacy_key, tmp_path)

--- a/src/tests/test_legacy_migration_prompt.py
+++ b/src/tests/test_legacy_migration_prompt.py
@@ -1,0 +1,49 @@
+import base64
+import json
+from pathlib import Path
+
+from seedpass.core.encryption import (
+    EncryptionManager,
+    _derive_legacy_key_from_password,
+)
+
+
+def _setup_legacy_file(tmp_path: Path, password: str) -> Path:
+    legacy_key = _derive_legacy_key_from_password(password, iterations=50_000)
+    legacy_mgr = EncryptionManager(legacy_key, tmp_path)
+    data = {"entries": {"0": {"kind": "test"}}}
+    json_bytes = json.dumps(data, separators=(",", ":")).encode("utf-8")
+    legacy_encrypted = legacy_mgr.fernet.encrypt(json_bytes)
+    file_path = tmp_path / "seedpass_entries_db.json.enc"
+    file_path.write_bytes(legacy_encrypted)
+    return file_path
+
+
+def test_open_legacy_without_migrating(tmp_path, monkeypatch):
+    password = "secret"
+    _setup_legacy_file(tmp_path, password)
+    new_key = base64.urlsafe_b64encode(b"A" * 32)
+    mgr = EncryptionManager(new_key, tmp_path)
+    monkeypatch.setattr(
+        "seedpass.core.encryption.prompt_existing_password", lambda _: password
+    )
+    monkeypatch.setattr("builtins.input", lambda _: "1")
+    mgr.load_json_data()
+    content = (tmp_path / "seedpass_entries_db.json.enc").read_bytes()
+    assert not content.startswith(b"V2:")
+    assert mgr.last_migration_performed is False
+
+
+def test_migrate_legacy_and_sync(tmp_path, monkeypatch):
+    password = "secret"
+    _setup_legacy_file(tmp_path, password)
+    new_key = base64.urlsafe_b64encode(b"B" * 32)
+    mgr = EncryptionManager(new_key, tmp_path)
+    monkeypatch.setattr(
+        "seedpass.core.encryption.prompt_existing_password", lambda _: password
+    )
+    monkeypatch.setattr("builtins.input", lambda _: "2")
+    mgr.load_json_data()
+    content = (tmp_path / "seedpass_entries_db.json.enc").read_bytes()
+    assert content.startswith(b"V2:")
+    assert mgr.last_migration_performed is True

--- a/src/tests/test_nostr_legacy_decrypt_fallback.py
+++ b/src/tests/test_nostr_legacy_decrypt_fallback.py
@@ -25,6 +25,7 @@ def test_legacy_password_only_fallback(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(
         enc_module, "prompt_existing_password", lambda *_a, **_k: TEST_PASSWORD
     )
+    monkeypatch.setattr("builtins.input", lambda *_a, **_k: "2")
 
     vault, enc_mgr = create_vault(tmp_path)
     data = {"schema_version": 4, "entries": {}}


### PR DESCRIPTION
## Summary
- let users choose to open a legacy index or migrate and sync when decryption fails
- track legacy migration choice and flag vault for Nostr sync
- test legacy index opening and migration flows

## Testing
- `PYTHONPATH=src pytest src/tests/test_legacy_migration_prompt.py`


------
https://chatgpt.com/codex/tasks/task_b_688fe8cb67ac832b8b98c2e4ef95e8f5