### PR TITLE
Clean up legacy index files after migration

### DIFF
--- a/src/seedpass/core/vault.py
+++ b/src/seedpass/core/vault.py
@@ -67,6 +67,17 @@ class Vault:
                 legacy_checksum.rename(
                     self.fingerprint_dir / "seedpass_entries_db_checksum.txt"
                 )
+
+            # Remove any leftover legacy files to avoid triggering migration again
+            for stray in self.fingerprint_dir.glob("seedpass_passwords_db*.enc"):
+                try:
+                    stray.unlink()
+                except FileNotFoundError:
+                    pass
+            stray_checksum = self.fingerprint_dir / "seedpass_passwords_db_checksum.txt"
+            if stray_checksum.exists():
+                stray_checksum.unlink()
+
             self.migrated_from_legacy = True
             print(
                 colored(


### PR DESCRIPTION
## Summary
- remove stray legacy `seedpass_passwords_db*.enc` files after migrating vault index
- add regression test ensuring legacy files are cleaned up when loading twice

## Testing
- `pytest src/tests/test_legacy_migration.py -q`


------
https://chatgpt.com/codex/tasks/task_b_688fffa60728832b94a273fd466c25eb