### PR TITLE
Track migrations and trigger sync

### DIFF
--- a/src/seedpass/core/encryption.py
+++ b/src/seedpass/core/encryption.py
@@ -332,6 +332,9 @@ class EncryptionManager:
         if relative_path is None:
             relative_path = Path("seedpass_entries_db.json.enc")
 
+        is_legacy = not encrypted_data.startswith(b"V2:")
+        self.last_migration_performed = False
+
         def _process(decrypted: bytes) -> dict:
             if USE_ORJSON:
                 data = json_lib.loads(decrypted)
@@ -361,6 +364,7 @@ class EncryptionManager:
             self.update_checksum(relative_path)
             logger.info("Index file from Nostr was processed and saved successfully.")
             print(colored("Index file updated from Nostr successfully.", "green"))
+            self.last_migration_performed = is_legacy
             return True
         except InvalidToken as e:
             try:
@@ -382,6 +386,7 @@ class EncryptionManager:
                         "yellow",
                     )
                 )
+                self.last_migration_performed = True
                 return True
             except Exception as e2:
                 if strict:

--- a/src/tests/test_legacy_migration.py
+++ b/src/tests/test_legacy_migration.py
@@ -159,3 +159,38 @@ def test_legacy_nostr_payload_triggers_sync(monkeypatch, tmp_path: Path):
     asyncio.run(pm.sync_index_from_nostr_async())
     assert calls["sync"] == 1
     assert pm.vault.load_index() == data
+
+
+def test_legacy_index_reinit_triggers_sync_once(monkeypatch, tmp_path: Path):
+    vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+
+    key = derive_index_key(TEST_SEED)
+    data = {"schema_version": 4, "entries": {}}
+    enc = Fernet(key).encrypt(json.dumps(data).encode())
+    legacy_file = tmp_path / "seedpass_passwords_db.json.enc"
+    legacy_file.write_bytes(enc)
+
+    monkeypatch.setattr("builtins.input", lambda *_a, **_k: "y")
+
+    pm = PasswordManager.__new__(PasswordManager)
+    pm.encryption_mode = EncryptionMode.SEED_ONLY
+    pm.encryption_manager = enc_mgr
+    pm.vault = Vault(enc_mgr, tmp_path)
+    pm.parent_seed = TEST_SEED
+    pm.fingerprint_dir = tmp_path
+    pm.current_fingerprint = tmp_path.name
+    pm.bip85 = SimpleNamespace()
+
+    monkeypatch.setattr(
+        "seedpass.core.manager.NostrClient", lambda *a, **k: SimpleNamespace()
+    )
+
+    calls = {"sync": 0}
+    pm.start_background_vault_sync = lambda *a, **k: calls.__setitem__(
+        "sync", calls["sync"] + 1
+    )
+
+    pm.initialize_managers()
+    pm.initialize_managers()
+
+    assert calls["sync"] == 1


### PR DESCRIPTION
## Summary
- track legacy migrations when decrypting Nostr payloads
- expose migration flag from vault helpers and use it during manager init
- add regression test ensuring sync runs once on legacy reinit

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6890013981a8832b9f86728004b9a0cb