### PR TITLE
Refine legacy migration prompt

### DIFF
--- a/src/seedpass/core/encryption.py
+++ b/src/seedpass/core/encryption.py
@@ -148,13 +148,15 @@ class EncryptionManager:
             resp = input(
                 "\nChoose an option:\n"
                 "1. Open legacy index without migrating\n"
-                "2. Migrate to new format and sync to Nostr\n"
+                "2. Migrate to new format.\n"
                 "Selection [1/2]: "
             ).strip()
             if resp == "1":
                 self._legacy_migrate_flag = False
+                self.last_migration_performed = False
             elif resp == "2":
                 self._legacy_migrate_flag = True
+                self.last_migration_performed = True
             else:
                 raise InvalidToken(
                     "User declined legacy decryption or provided invalid choice."


### PR DESCRIPTION
## Summary
- Simplify legacy migration prompt and remove Nostr sync language
- Track migration choice via `_legacy_migrate_flag` and `last_migration_performed`

## Testing
- `pip install --require-hashes -r requirements.lock`
- `black src/seedpass/core/encryption.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6890a89f747c832ba9b2bcda98f6a35e