### PR TITLE
Prompt migration sync after Nostr index update

### DIFF
--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -1300,8 +1300,49 @@ class PasswordManager:
                             updated = True
                             current = delta
                             migrated = migrated or mig
-            if migrated and not getattr(self, "offline_mode", False):
-                self.start_background_vault_sync()
+            if migrated:
+                print(colored("Local database migration successful.", "green"))
+                if self.encryption_manager is not None:
+                    self.encryption_manager.last_migration_performed = False
+                if not getattr(self, "offline_mode", False):
+                    if confirm_action(
+                        "Do you want to sync the migrated profile to Nostr now?"
+                    ):
+                        try:
+                            result = await self.sync_vault_async()
+                            if result:
+                                print(
+                                    colored(
+                                        "Profile synchronized to Nostr successfully.",
+                                        "green",
+                                    )
+                                )
+                            else:
+                                print(
+                                    colored(
+                                        "Error: Failed to sync profile to Nostr.",
+                                        "red",
+                                    )
+                                )
+                        except Exception as sync_err:
+                            logger.error(
+                                "Failed to sync profile to Nostr after migration: %s",
+                                sync_err,
+                                exc_info=True,
+                            )
+                            print(
+                                colored(
+                                    "Error: Failed to sync profile to Nostr.",
+                                    "red",
+                                )
+                            )
+                    else:
+                        print(
+                            colored(
+                                "You can sync the migrated profile later from the main menu.",
+                                "yellow",
+                            )
+                        )
             if updated:
                 logger.info("Local database synchronized from Nostr.")
         except Exception as e:

--- a/src/tests/test_legacy_migration.py
+++ b/src/tests/test_legacy_migration.py
@@ -155,9 +155,13 @@ def test_legacy_nostr_payload_triggers_sync(monkeypatch, tmp_path: Path):
     pm.offline_mode = False
 
     calls = {"sync": 0}
-    pm.start_background_vault_sync = lambda *a, **k: calls.__setitem__(
-        "sync", calls["sync"] + 1
-    )
+
+    async def fake_sync_vault_async(*_a, **_k):
+        calls["sync"] += 1
+        return True
+
+    pm.sync_vault_async = fake_sync_vault_async
+    monkeypatch.setattr("seedpass.core.manager.confirm_action", lambda *_a, **_k: True)
 
     asyncio.run(pm.sync_index_from_nostr_async())
     assert calls["sync"] == 1


### PR DESCRIPTION
## Summary
- prompt user to sync vault after migrating Nostr index instead of auto background sync
- reset migration flag and report sync results during manual confirmation
- update legacy migration test to mock sync and confirmation

## Testing
- `black src/seedpass/core/manager.py src/tests/test_legacy_migration.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6890b54adf54832b8ba06345527e6784