### PR TITLE
Handle migration flag during manager init

### DIFF
--- a/src/tests/test_nostr_sdk_workflow.py
+++ b/src/tests/test_nostr_sdk_workflow.py
@@ -4,7 +4,6 @@ import threading
 import time
 from websocket import create_connection
 
-import asyncio
 import websockets
 from nostr.key_manager import KeyManager
 from nostr_sdk import nostr_sdk as sdk


### PR DESCRIPTION
## Summary
- use migration flag from `vault.load_index` to decide when to prompt for sync
- test schema-migration detection triggers sync
- clean up duplicate imports in nostr SDK workflow test

## Testing
- `black src/seedpass/core/manager.py src/tests/test_legacy_migration.py src/tests/test_nostr_sdk_workflow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6890cb2c7f48832b9820de8c77950322