### PR TITLE
Handle empty profile cleanup

### DIFF
--- a/src/tests/test_auto_sync.py
+++ b/src/tests/test_auto_sync.py
@@ -15,6 +15,7 @@ def test_auto_sync_triggers_post(monkeypatch):
         is_dirty=True,
         last_update=time.time() - 0.2,
         last_activity=time.time(),
+        current_fingerprint="fp",
         nostr_client=SimpleNamespace(close_client_pool=lambda: None),
         handle_add_password=lambda: None,
         handle_retrieve_entry=lambda: None,

--- a/src/tests/test_profile_deletion_sync.py
+++ b/src/tests/test_profile_deletion_sync.py
@@ -1,0 +1,55 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import main
+from utils.fingerprint_manager import FingerprintManager
+from tests.helpers import TEST_SEED
+
+
+def test_profile_deletion_stops_sync(monkeypatch, tmp_path):
+    fm = FingerprintManager(tmp_path)
+    fp = fm.add_fingerprint(TEST_SEED)
+
+    calls = {"post": 0, "cleanup": 0}
+
+    def fake_post(_pm):
+        calls["post"] += 1
+
+    monkeypatch.setattr(main, "handle_post_to_nostr", fake_post)
+    monkeypatch.setattr("builtins.input", lambda *_: "1")
+    monkeypatch.setattr(main, "confirm_action", lambda *_: True)
+
+    pm = SimpleNamespace(
+        fingerprint_manager=fm,
+        current_fingerprint=fp,
+        is_dirty=False,
+        last_update=time.time(),
+        last_activity=time.time(),
+        nostr_client=SimpleNamespace(close_client_pool=lambda: None),
+        handle_add_password=lambda: None,
+        handle_retrieve_entry=lambda: None,
+        handle_modify_entry=lambda: None,
+        update_activity=lambda: None,
+        lock_vault=lambda: None,
+        unlock_vault=lambda: None,
+        start_background_sync=lambda: None,
+        start_background_relay_check=lambda: None,
+        cleanup=lambda: calls.__setitem__("cleanup", calls["cleanup"] + 1),
+    )
+
+    main.handle_post_to_nostr(pm)
+    assert calls["post"] == 1
+
+    with pytest.raises(SystemExit):
+        main.handle_remove_fingerprint(pm)
+
+    assert calls["post"] == 1
+    assert calls["cleanup"] == 1
+    pm.current_fingerprint = fm.current_fingerprint
+    assert pm.current_fingerprint is None
+    assert pm.is_dirty is False

--- a/src/utils/fingerprint_manager.py
+++ b/src/utils/fingerprint_manager.py
@@ -5,7 +5,7 @@ import json
 import logging
 import traceback
 from pathlib import Path
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import shutil  # Ensure shutil is imported if used within the class
 
@@ -138,12 +138,15 @@ class FingerprintManager:
             logger.error("Fingerprint generation failed.")
             return None
 
-    def remove_fingerprint(self, fingerprint: str) -> bool:
-        """
-        Removes a fingerprint and its associated directory.
+    def remove_fingerprint(
+        self, fingerprint: str, on_last_removed: Optional[Callable[[], None]] = None
+    ) -> bool:
+        """Remove a fingerprint and its associated directory.
 
         Parameters:
             fingerprint (str): The fingerprint to remove.
+            on_last_removed (Callable | None): Callback invoked when the last
+                fingerprint is deleted.
 
         Returns:
             bool: True if removed successfully, False otherwise.
@@ -167,6 +170,8 @@ class FingerprintManager:
                             shutil.rmtree(child)
                     fingerprint_dir.rmdir()
                 logger.info(f"Fingerprint {fingerprint} removed successfully.")
+                if not self.fingerprints and on_last_removed:
+                    on_last_removed()
                 return True
             except Exception as e:
                 logger.error(


### PR DESCRIPTION
## Summary
- Avoid Nostr sync when no active profile and reset dirty flag when switching profiles
- Support cleanup callback in FingerprintManager and exit when last profile removed
- Regression test for removing profile after Nostr backup

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6892292ea8a8832b9de760a059febf33