### PR TITLE
Handle immediate Enter in stats view

### DIFF
--- a/src/tests/test_stats_screen.py
+++ b/src/tests/test_stats_screen.py
@@ -88,3 +88,21 @@ def test_stats_display_resets_after_exit(monkeypatch, capsys):
     main._display_live_stats(pm)
     out = capsys.readouterr().out
     assert out.count("stats") == 2
+
+
+def test_stats_screen_breaks_on_enter(monkeypatch):
+    calls = {"display": 0}
+
+    def display():
+        calls["display"] += 1
+        print("stats")
+
+    pm = _make_pm()
+    pm.display_stats = display
+
+    monkeypatch.setattr(main, "get_notification_text", lambda *_: "")
+    monkeypatch.setattr(main, "timed_input", lambda *_args, **_kwargs: "")
+
+    main._display_live_stats(pm, interval=0.01)
+
+    assert calls["display"] == 1


### PR DESCRIPTION
## Summary
- Flush pending stdin and check for queued input in `_display_live_stats` so pressing Enter exits the stats screen immediately
- Add regression test to ensure a single Enter returns control without extra iterations

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6892395727f4832ba76713f959349a7d