### PR TITLE
Fix inconsistent Nostr sync notifications

### DIFF
--- a/src/seedpass/core/encryption.py
+++ b/src/seedpass/core/encryption.py
@@ -399,7 +399,6 @@ class EncryptionManager:
             self.save_json_data(data, relative_path)  # This always saves in V2 format
             self.update_checksum(relative_path)
             logger.info("Index file from Nostr was processed and saved successfully.")
-            print(colored("Index file updated from Nostr successfully.", "green"))
             self.last_migration_performed = is_legacy
             return True
         except InvalidToken as e:

--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -1380,6 +1380,7 @@ class PasswordManager:
                         )
             if updated:
                 logger.info("Local database synchronized from Nostr.")
+                self.notify("Index file updated from Nostr successfully.")
         except Exception as e:
             logger.warning(
                 "Unable to sync index from Nostr relays %s: %s",
@@ -1540,6 +1541,7 @@ class PasswordManager:
                     if migrated and not getattr(self, "offline_mode", False):
                         self.start_background_vault_sync()
                     logger.info("Initialized local database from Nostr.")
+                    self.notify("Index file updated from Nostr successfully.")
         except Exception as e:  # pragma: no cover - network errors
             logger.warning(f"Unable to sync index from Nostr: {e}")
         finally:
@@ -4154,7 +4156,6 @@ class PasswordManager:
         try:
             self.vault.decrypt_and_save_index_from_nostr(encrypted_data, merge=True)
             logging.info("Index file updated from Nostr successfully.")
-            print(colored("Index file updated from Nostr successfully.", "green"))
         except Exception as e:
             logging.error(
                 f"Failed to decrypt and save data from Nostr: {e}", exc_info=True


### PR DESCRIPTION
## Summary
- avoid printing Nostr sync success from low-level helpers
- notify when Nostr sync actually updates the index

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68924eb60f08832b9cb2ce91e1e78dad