### PR TITLE
refactor: move api state to app

### DIFF
--- a/src/seedpass/cli/api.py
+++ b/src/seedpass/cli/api.py
@@ -25,7 +25,7 @@ def api_stop(ctx: typer.Context, host: str = "127.0.0.1", port: int = 8000) -> N
     try:
         requests.post(
             f"http://{host}:{port}/api/v1/shutdown",
-            headers={"Authorization": f"Bearer {api_module._token}"},
+            headers={"Authorization": f"Bearer {api_module.app.state.token_hash}"},
             timeout=2,
         )
     except Exception as exc:  # pragma: no cover - best effort

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -51,8 +51,8 @@ def client(monkeypatch):
 
 def test_token_hashed(client):
     _, token = client
-    assert api._token != token
-    assert api._token == hashlib.sha256(token.encode()).hexdigest()
+    assert api.app.state.token_hash != token
+    assert api.app.state.token_hash == hashlib.sha256(token.encode()).hexdigest()
 
 
 def test_cors_and_auth(client):
@@ -158,7 +158,7 @@ def test_update_config(client):
     def set_timeout(val):
         called["val"] = val
 
-    api._pm.config_manager.set_inactivity_timeout = set_timeout
+    api.app.state.pm.config_manager.set_inactivity_timeout = set_timeout
     headers = {"Authorization": f"Bearer {token}", "Origin": "http://example.com"}
     res = cl.put(
         "/api/v1/config/inactivity_timeout",
@@ -174,8 +174,9 @@ def test_update_config(client):
 def test_update_config_quick_unlock(client):
     cl, token = client
     called = {}
-
-    api._pm.config_manager.set_quick_unlock = lambda v: called.setdefault("val", v)
+    api.app.state.pm.config_manager.set_quick_unlock = lambda v: called.setdefault(
+        "val", v
+    )
     headers = {"Authorization": f"Bearer {token}", "Origin": "http://example.com"}
     res = cl.put(
         "/api/v1/config/quick_unlock",
@@ -190,8 +191,7 @@ def test_update_config_quick_unlock(client):
 def test_change_password_route(client):
     cl, token = client
     called = {}
-
-    api._pm.change_password = lambda o, n: called.setdefault("called", (o, n))
+    api.app.state.pm.change_password = lambda o, n: called.setdefault("called", (o, n))
     headers = {"Authorization": f"Bearer {token}", "Origin": "http://example.com"}
     res = cl.post(
         "/api/v1/change-password",

--- a/src/tests/test_api_notifications.py
+++ b/src/tests/test_api_notifications.py
@@ -6,40 +6,42 @@ import seedpass.api as api
 
 def test_notifications_endpoint(client):
     cl, token = client
-    api._pm.notifications = queue.Queue()
-    api._pm.notifications.put(SimpleNamespace(message="m1", level="INFO"))
-    api._pm.notifications.put(SimpleNamespace(message="m2", level="WARNING"))
+    api.app.state.pm.notifications = queue.Queue()
+    api.app.state.pm.notifications.put(SimpleNamespace(message="m1", level="INFO"))
+    api.app.state.pm.notifications.put(SimpleNamespace(message="m2", level="WARNING"))
     res = cl.get("/api/v1/notifications", headers={"Authorization": f"Bearer {token}"})
     assert res.status_code == 200
     assert res.json() == [
         {"level": "INFO", "message": "m1"},
         {"level": "WARNING", "message": "m2"},
     ]
-    assert api._pm.notifications.empty()
+    assert api.app.state.pm.notifications.empty()
 
 
 def test_notifications_endpoint_clears_queue(client):
     cl, token = client
-    api._pm.notifications = queue.Queue()
-    api._pm.notifications.put(SimpleNamespace(message="hi", level="INFO"))
+    api.app.state.pm.notifications = queue.Queue()
+    api.app.state.pm.notifications.put(SimpleNamespace(message="hi", level="INFO"))
     res = cl.get("/api/v1/notifications", headers={"Authorization": f"Bearer {token}"})
     assert res.status_code == 200
     assert res.json() == [{"level": "INFO", "message": "hi"}]
-    assert api._pm.notifications.empty()
+    assert api.app.state.pm.notifications.empty()
     res = cl.get("/api/v1/notifications", headers={"Authorization": f"Bearer {token}"})
     assert res.json() == []
 
 
 def test_notifications_endpoint_does_not_clear_current(client):
     cl, token = client
-    api._pm.notifications = queue.Queue()
+    api.app.state.pm.notifications = queue.Queue()
     msg = SimpleNamespace(message="keep", level="INFO")
-    api._pm.notifications.put(msg)
-    api._pm._current_notification = msg
-    api._pm.get_current_notification = lambda: api._pm._current_notification
+    api.app.state.pm.notifications.put(msg)
+    api.app.state.pm._current_notification = msg
+    api.app.state.pm.get_current_notification = (
+        lambda: api.app.state.pm._current_notification
+    )
 
     res = cl.get("/api/v1/notifications", headers={"Authorization": f"Bearer {token}"})
     assert res.status_code == 200
     assert res.json() == [{"level": "INFO", "message": "keep"}]
-    assert api._pm.notifications.empty()
-    assert api._pm.get_current_notification() is msg
+    assert api.app.state.pm.notifications.empty()
+    assert api.app.state.pm.get_current_notification() is msg

--- a/src/tests/test_api_profile_stats.py
+++ b/src/tests/test_api_profile_stats.py
@@ -7,7 +7,7 @@ def test_profile_stats_endpoint(client):
     # monkeypatch set _pm.get_profile_stats after client fixture started
     import seedpass.api as api
 
-    api._pm.get_profile_stats = lambda: stats
+    api.app.state.pm.get_profile_stats = lambda: stats
     res = cl.get("/api/v1/stats", headers={"Authorization": f"Bearer {token}"})
     assert res.status_code == 200
     assert res.json() == stats


### PR DESCRIPTION
## Summary
- migrate API globals to `app.state` and request-scoped dependencies
- adjust helper functions and CLI to use new state management
- update API tests for dependency injection

## Testing
- `pytest src/tests/test_api*.py`


------
https://chatgpt.com/codex/tasks/task_b_68928ce84e54832b867e2fc9e4da674d