### PR TITLE
Add test fixtures for manager and vault

### DIFF
--- a/src/tests/test_custom_fields_display.py
+++ b/src/tests/test_custom_fields_display.py
@@ -1,53 +1,30 @@
 import sys
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from types import SimpleNamespace
-
-from helpers import create_vault, TEST_SEED, TEST_PASSWORD
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from seedpass.core.entry_management import EntryManager
-from seedpass.core.backup import BackupManager
-from seedpass.core.manager import PasswordManager, EncryptionMode
-from seedpass.core.config_manager import ConfigManager
 
+def test_retrieve_entry_shows_custom_fields(monkeypatch, capsys, password_manager):
+    pm = password_manager
+    pm.password_generator = SimpleNamespace(generate_password=lambda l, i: "pw")
+    pm.nostr_client = SimpleNamespace()
 
-def test_retrieve_entry_shows_custom_fields(monkeypatch, capsys):
-    with TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
-        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
-        cfg_mgr = ConfigManager(vault, tmp_path)
-        backup_mgr = BackupManager(tmp_path, cfg_mgr)
-        entry_mgr = EntryManager(vault, backup_mgr)
+    pm.entry_manager.add_entry(
+        "example",
+        8,
+        custom_fields=[
+            {"label": "visible", "value": "shown", "is_hidden": False},
+            {"label": "token", "value": "secret", "is_hidden": True},
+        ],
+    )
 
-        pm = PasswordManager.__new__(PasswordManager)
-        pm.encryption_mode = EncryptionMode.SEED_ONLY
-        pm.encryption_manager = enc_mgr
-        pm.vault = vault
-        pm.entry_manager = entry_mgr
-        pm.backup_manager = backup_mgr
-        pm.password_generator = SimpleNamespace(generate_password=lambda l, i: "pw")
-        pm.parent_seed = TEST_SEED
-        pm.nostr_client = SimpleNamespace()
-        pm.fingerprint_dir = tmp_path
-        pm.secret_mode_enabled = False
+    inputs = iter(["0", "y", "", ""])
+    monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
 
-        entry_mgr.add_entry(
-            "example",
-            8,
-            custom_fields=[
-                {"label": "visible", "value": "shown", "is_hidden": False},
-                {"label": "token", "value": "secret", "is_hidden": True},
-            ],
-        )
-
-        inputs = iter(["0", "y", "", ""])
-        monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
-
-        pm.handle_retrieve_entry()
-        out = capsys.readouterr().out
-        assert "Additional Fields:" in out
-        assert "visible: shown" in out
-        assert "token" in out
-        assert "secret" in out
+    pm.handle_retrieve_entry()
+    out = capsys.readouterr().out
+    assert "Additional Fields:" in out
+    assert "visible: shown" in out
+    assert "token" in out
+    assert "secret" in out

--- a/src/tests/test_manager_display_totp_codes.py
+++ b/src/tests/test_manager_display_totp_codes.py
@@ -1,15 +1,9 @@
 import sys
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
-from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+from helpers import TEST_SEED
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-
-from seedpass.core.entry_management import EntryManager
-from seedpass.core.backup import BackupManager
-from seedpass.core.manager import PasswordManager, EncryptionMode
-from seedpass.core.config_manager import ConfigManager
 
 
 class FakeNostrClient:
@@ -21,81 +15,45 @@ class FakeNostrClient:
         return None, "abcd"
 
 
-def test_handle_display_totp_codes(monkeypatch, capsys):
-    with TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
-        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
-        cfg_mgr = ConfigManager(vault, tmp_path)
-        backup_mgr = BackupManager(tmp_path, cfg_mgr)
-        entry_mgr = EntryManager(vault, backup_mgr)
+def test_handle_display_totp_codes(monkeypatch, capsys, password_manager):
+    pm = password_manager
+    pm.nostr_client = FakeNostrClient()
 
-        pm = PasswordManager.__new__(PasswordManager)
-        pm.encryption_mode = EncryptionMode.SEED_ONLY
-        pm.encryption_manager = enc_mgr
-        pm.vault = vault
-        pm.entry_manager = entry_mgr
-        pm.backup_manager = backup_mgr
-        pm.parent_seed = TEST_SEED
-        pm.nostr_client = FakeNostrClient()
-        pm.fingerprint_dir = tmp_path
-        pm.is_dirty = False
-        pm.secret_mode_enabled = False
+    pm.entry_manager.add_totp("Example", TEST_SEED)
 
-        entry_mgr.add_totp("Example", TEST_SEED)
+    monkeypatch.setattr(pm.entry_manager, "get_totp_code", lambda *a, **k: "123456")
+    monkeypatch.setattr(pm.entry_manager, "get_totp_time_remaining", lambda *a, **k: 30)
 
-        monkeypatch.setattr(pm.entry_manager, "get_totp_code", lambda *a, **k: "123456")
-        monkeypatch.setattr(
-            pm.entry_manager, "get_totp_time_remaining", lambda *a, **k: 30
-        )
+    # interrupt the loop after first iteration
+    monkeypatch.setattr(
+        "seedpass.core.manager.timed_input",
+        lambda *a, **k: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
 
-        # interrupt the loop after first iteration
-        monkeypatch.setattr(
-            "seedpass.core.manager.timed_input",
-            lambda *a, **k: (_ for _ in ()).throw(KeyboardInterrupt()),
-        )
-
-        pm.handle_display_totp_codes()
-        out = capsys.readouterr().out
-        assert "Generated 2FA Codes" in out
-        assert "[0] Example" in out
-        assert "123456" in out
+    pm.handle_display_totp_codes()
+    out = capsys.readouterr().out
+    assert "Generated 2FA Codes" in out
+    assert "[0] Example" in out
+    assert "123456" in out
 
 
-def test_display_totp_codes_excludes_archived(monkeypatch, capsys):
-    with TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
-        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
-        cfg_mgr = ConfigManager(vault, tmp_path)
-        backup_mgr = BackupManager(tmp_path, cfg_mgr)
-        entry_mgr = EntryManager(vault, backup_mgr)
+def test_display_totp_codes_excludes_archived(monkeypatch, capsys, password_manager):
+    pm = password_manager
+    pm.nostr_client = FakeNostrClient()
 
-        pm = PasswordManager.__new__(PasswordManager)
-        pm.encryption_mode = EncryptionMode.SEED_ONLY
-        pm.encryption_manager = enc_mgr
-        pm.vault = vault
-        pm.entry_manager = entry_mgr
-        pm.backup_manager = backup_mgr
-        pm.parent_seed = TEST_SEED
-        pm.nostr_client = FakeNostrClient()
-        pm.fingerprint_dir = tmp_path
-        pm.is_dirty = False
-        pm.secret_mode_enabled = False
+    pm.entry_manager.add_totp("Visible", TEST_SEED)
+    pm.entry_manager.add_totp("Hidden", TEST_SEED)
+    pm.entry_manager.modify_entry(1, archived=True)
 
-        entry_mgr.add_totp("Visible", TEST_SEED)
-        entry_mgr.add_totp("Hidden", TEST_SEED)
-        entry_mgr.modify_entry(1, archived=True)
+    monkeypatch.setattr(pm.entry_manager, "get_totp_code", lambda *a, **k: "123456")
+    monkeypatch.setattr(pm.entry_manager, "get_totp_time_remaining", lambda *a, **k: 30)
 
-        monkeypatch.setattr(pm.entry_manager, "get_totp_code", lambda *a, **k: "123456")
-        monkeypatch.setattr(
-            pm.entry_manager, "get_totp_time_remaining", lambda *a, **k: 30
-        )
+    monkeypatch.setattr(
+        "seedpass.core.manager.timed_input",
+        lambda *a, **k: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
 
-        monkeypatch.setattr(
-            "seedpass.core.manager.timed_input",
-            lambda *a, **k: (_ for _ in ()).throw(KeyboardInterrupt()),
-        )
-
-        pm.handle_display_totp_codes()
-        out = capsys.readouterr().out
-        assert "Visible" in out
-        assert "Hidden" not in out
+    pm.handle_display_totp_codes()
+    out = capsys.readouterr().out
+    assert "Visible" in out
+    assert "Hidden" not in out

--- a/src/tests/test_retrieve_pause_sensitive_entries.py
+++ b/src/tests/test_retrieve_pause_sensitive_entries.py
@@ -1,15 +1,9 @@
 import sys
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
-from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+from helpers import TEST_SEED
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-
-from seedpass.core.entry_management import EntryManager
-from seedpass.core.backup import BackupManager
-from seedpass.core.manager import PasswordManager, EncryptionMode
-from seedpass.core.config_manager import ConfigManager
 
 import pytest
 
@@ -23,36 +17,23 @@ import pytest
         (lambda mgr: mgr.add_nostr_key("nostr", TEST_SEED), False),
     ],
 )
-def test_pause_before_entry_actions(monkeypatch, adder, needs_confirm):
-    with TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
-        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
-        cfg_mgr = ConfigManager(vault, tmp_path)
-        backup_mgr = BackupManager(tmp_path, cfg_mgr)
-        entry_mgr = EntryManager(vault, backup_mgr)
+def test_pause_before_entry_actions(
+    monkeypatch, adder, needs_confirm, password_manager
+):
+    pm = password_manager
 
-        pm = PasswordManager.__new__(PasswordManager)
-        pm.encryption_mode = EncryptionMode.SEED_ONLY
-        pm.encryption_manager = enc_mgr
-        pm.vault = vault
-        pm.entry_manager = entry_mgr
-        pm.backup_manager = backup_mgr
-        pm.parent_seed = TEST_SEED
-        pm.fingerprint_dir = tmp_path
-        pm.secret_mode_enabled = False
+    index = adder(pm.entry_manager)
 
-        index = adder(entry_mgr)
-
-        pause_calls = []
+    pause_calls = []
+    monkeypatch.setattr(
+        "seedpass.core.manager.pause", lambda *a, **k: pause_calls.append(True)
+    )
+    monkeypatch.setattr(pm, "_entry_actions_menu", lambda *a, **k: None)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: str(index))
+    if needs_confirm:
         monkeypatch.setattr(
-            "seedpass.core.manager.pause", lambda *a, **k: pause_calls.append(True)
+            "seedpass.core.manager.confirm_action", lambda *a, **k: True
         )
-        monkeypatch.setattr(pm, "_entry_actions_menu", lambda *a, **k: None)
-        monkeypatch.setattr("builtins.input", lambda *a, **k: str(index))
-        if needs_confirm:
-            monkeypatch.setattr(
-                "seedpass.core.manager.confirm_action", lambda *a, **k: True
-            )
 
-        pm.handle_retrieve_entry()
-        assert len(pause_calls) == 1
+    pm.handle_retrieve_entry()
+    assert len(pause_calls) == 1


### PR DESCRIPTION
## Summary
- add `vault` and `password_manager` fixtures for standard test initialization
- refactor various tests to leverage new fixtures and drop manual setup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6892b3767818832bb739a883779dd8bc