### PR TITLE
Ensure config manager initialized for secret mode toggling

### DIFF
--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -539,7 +539,7 @@ class PasswordManager:
             )
 
             # Ensure managers are initialized for the newly created profile
-            if self.config_manager is None:
+            if getattr(self, "config_manager", None) is None:
                 self.initialize_managers()
 
         except Exception as e:
@@ -965,7 +965,7 @@ class PasswordManager:
             sys.exit(1)
 
         # Some seed loading paths may not initialize managers; ensure they exist
-        if self.config_manager is None:
+        if getattr(self, "config_manager", None) is None:
             self.initialize_managers()
 
     def setup_existing_seed(

--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -538,6 +538,10 @@ class PasswordManager:
                 )
             )
 
+            # Ensure managers are initialized for the newly created profile
+            if self.config_manager is None:
+                self.initialize_managers()
+
         except Exception as e:
             logger.error(f"Error adding new seed profile: {e}", exc_info=True)
             print(colored(f"Error: Failed to add new seed profile: {e}", "red"))
@@ -959,6 +963,10 @@ class PasswordManager:
         else:
             print(colored("Invalid choice. Exiting.", "red"))
             sys.exit(1)
+
+        # Some seed loading paths may not initialize managers; ensure they exist
+        if self.config_manager is None:
+            self.initialize_managers()
 
     def setup_existing_seed(
         self,

--- a/src/tests/test_secret_mode_profile_creation.py
+++ b/src/tests/test_secret_mode_profile_creation.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+
+import pytest
+
+from main import handle_toggle_secret_mode
+from seedpass.core.manager import PasswordManager
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+from utils.fingerprint import generate_fingerprint
+
+
+def test_add_new_fingerprint_initializes_managers(monkeypatch, tmp_path):
+    pm = PasswordManager.__new__(PasswordManager)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pm.initialize_fingerprint_manager()
+    called = {}
+
+    def fake_setup_existing_seed(method="paste"):
+        pm.current_fingerprint = "fp1"
+        pm.fingerprint_manager.current_fingerprint = "fp1"
+        pm.fingerprint_dir = tmp_path / "fp1"
+        pm.fingerprint_dir.mkdir()
+        return "fp1"
+
+    monkeypatch.setattr(pm, "setup_existing_seed", fake_setup_existing_seed)
+    monkeypatch.setattr(
+        pm, "initialize_managers", lambda: called.setdefault("init", True)
+    )
+    monkeypatch.setattr("builtins.input", lambda *a: "1")
+    pm.config_manager = None
+    pm.add_new_fingerprint()
+    assert called.get("init") is True
+
+
+def test_toggle_secret_mode_after_profile_creation(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.vault = vault
+        pm.encryption_manager = enc_mgr
+        pm.fingerprint_dir = tmp_path
+        pm.current_fingerprint = generate_fingerprint(TEST_SEED)
+        pm.secret_mode_enabled = False
+        pm.clipboard_clear_delay = 45
+        pm.config_manager = None
+
+        inputs = iter(["y", "10"])
+        monkeypatch.setattr("builtins.input", lambda *a: next(inputs))
+        handle_toggle_secret_mode(pm)
+
+        assert pm.secret_mode_enabled is True
+        assert pm.clipboard_clear_delay == 10
+        assert pm.config_manager is not None
+        cfg = pm.config_manager.load_config(require_pin=False)
+        assert cfg["secret_mode_enabled"] is True
+        assert cfg["clipboard_clear_delay"] == 10


### PR DESCRIPTION
## Summary
- Initialize dependent managers after creating a new seed profile when missing
- Lazily create a ConfigManager in `handle_toggle_secret_mode`
- Add tests covering manager initialization and secret mode toggling right after profile creation

## Testing
- `pytest src/tests/test_secret_mode_profile_creation.py`


------
https://chatgpt.com/codex/tasks/task_b_6893e22be958832b996cc2bca09d16b0