### PR TITLE
Initialize config manager lazily for offline mode

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -846,8 +846,18 @@ def handle_toggle_offline_mode(pm: PasswordManager) -> None:
     """Enable or disable offline mode."""
     cfg = pm.config_manager
     if cfg is None:
-        print(colored("Configuration manager unavailable.", "red"))
-        return
+        vault = getattr(pm, "vault", None)
+        fingerprint_dir = getattr(pm, "fingerprint_dir", None)
+        if vault is not None and fingerprint_dir is not None:
+            try:
+                cfg = pm.config_manager = ConfigManager(vault, fingerprint_dir)
+            except Exception as exc:
+                logging.error(f"Failed to initialize ConfigManager: {exc}")
+                print(colored("Configuration manager unavailable.", "red"))
+                return
+        else:
+            print(colored("Configuration manager unavailable.", "red"))
+            return
     try:
         enabled = cfg.get_offline_mode()
     except Exception as exc:

--- a/src/tests/test_offline_mode_profile_creation.py
+++ b/src/tests/test_offline_mode_profile_creation.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from main import handle_toggle_offline_mode
+from seedpass.core.manager import PasswordManager
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+from utils.fingerprint import generate_fingerprint
+
+
+def test_toggle_offline_mode_after_profile_creation(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.vault = vault
+        pm.encryption_manager = enc_mgr
+        pm.fingerprint_dir = tmp_path
+        pm.current_fingerprint = generate_fingerprint(TEST_SEED)
+        pm.offline_mode = False
+        pm.config_manager = None
+
+        inputs = iter(["y"])
+        monkeypatch.setattr("builtins.input", lambda *a: next(inputs))
+        handle_toggle_offline_mode(pm)
+
+        assert pm.offline_mode is True
+        assert pm.config_manager is not None
+        cfg = pm.config_manager.load_config(require_pin=False)
+        assert cfg["offline_mode"] is True


### PR DESCRIPTION
## Summary
- Lazily create configuration manager when toggling offline mode
- Add regression test ensuring offline mode toggle works right after profile creation

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install --require-hashes -r requirements.lock`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6893e8d95e54832bb532f97c84ddb3e4