### PR TITLE
Initialize quick unlock config on demand

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -819,8 +819,18 @@ def handle_toggle_quick_unlock(pm: PasswordManager) -> None:
     """Enable or disable Quick Unlock."""
     cfg = pm.config_manager
     if cfg is None:
-        print(colored("Configuration manager unavailable.", "red"))
-        return
+        vault = getattr(pm, "vault", None)
+        fingerprint_dir = getattr(pm, "fingerprint_dir", None)
+        if vault is not None and fingerprint_dir is not None:
+            try:
+                cfg = pm.config_manager = ConfigManager(vault, fingerprint_dir)
+            except Exception as exc:
+                logging.error(f"Failed to initialize ConfigManager: {exc}")
+                print(colored("Configuration manager unavailable.", "red"))
+                return
+        else:
+            print(colored("Configuration manager unavailable.", "red"))
+            return
     try:
         enabled = cfg.get_quick_unlock()
     except Exception as exc:

--- a/src/tests/test_quick_unlock_profile_creation.py
+++ b/src/tests/test_quick_unlock_profile_creation.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from main import handle_toggle_quick_unlock
+from seedpass.core.manager import PasswordManager
+from helpers import create_vault, TEST_SEED, TEST_PASSWORD
+from utils.fingerprint import generate_fingerprint
+
+
+def test_toggle_quick_unlock_after_profile_creation(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        pm = PasswordManager.__new__(PasswordManager)
+        pm.vault = vault
+        pm.encryption_manager = enc_mgr
+        pm.fingerprint_dir = tmp_path
+        pm.current_fingerprint = generate_fingerprint(TEST_SEED)
+        pm.config_manager = None
+
+        inputs = iter(["y"])
+        monkeypatch.setattr("builtins.input", lambda *a: next(inputs))
+        handle_toggle_quick_unlock(pm)
+
+        assert pm.config_manager is not None
+        cfg = pm.config_manager.load_config(require_pin=False)
+        assert cfg["quick_unlock_enabled"] is True


### PR DESCRIPTION
## Summary
- Lazily initialize `ConfigManager` in `handle_toggle_quick_unlock` to mirror other toggles
- Add regression test enabling quick unlock immediately after profile creation

## Testing
- `pytest src/tests/test_secret_mode_profile_creation.py::test_toggle_secret_mode_after_profile_creation src/tests/test_quick_unlock_profile_creation.py::test_toggle_quick_unlock_after_profile_creation -q`


------
https://chatgpt.com/codex/tasks/task_b_6893ebe4a614832bb7cd1cdc30684e16