### PR TITLE
Guard missing Nostr client in background sync

### DIFF
--- a/src/tests/test_background_error_reporting.py
+++ b/src/tests/test_background_error_reporting.py
@@ -12,6 +12,7 @@ def _make_pm():
     pm.notify = lambda msg, level="INFO": pm.notifications.put(
         manager_module.Notification(msg, level)
     )
+    pm.nostr_client = object()
     return pm
 
 

--- a/src/tests/test_unlock_sync.py
+++ b/src/tests/test_unlock_sync.py
@@ -17,6 +17,7 @@ def test_unlock_triggers_sync(monkeypatch, tmp_path):
     pm.setup_encryption_manager = lambda *a, **k: None
     pm.initialize_bip85 = lambda: None
     pm.initialize_managers = lambda: None
+    pm.nostr_client = object()
     called = {"sync": False}
 
     async def fake_sync(self):
@@ -62,6 +63,7 @@ def test_quick_unlock_background_sync(monkeypatch, tmp_path):
 def test_start_background_sync_running_loop(monkeypatch):
     pm = PasswordManager.__new__(PasswordManager)
     pm.offline_mode = False
+    pm.nostr_client = object()
     called = {"init": False, "sync": False}
 
     async def fake_attempt(self):


### PR DESCRIPTION
## Summary
- avoid background sync when no Nostr client is configured
- guard initial sync helpers for missing clients
- test settings menu exit without Nostr client to ensure no background errors

## Testing
- `black src/tests/test_background_error_reporting.py src/tests/test_unlock_sync.py src/tests/test_settings_menu.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6893fa490050832b9457b6aa41dbd3d9