### PR TITLE
Avoid redundant fingerprint decryption

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -191,6 +191,13 @@ def handle_switch_fingerprint(password_manager: PasswordManager):
             return
 
         selected_fingerprint = fingerprints[int(choice) - 1]
+        if selected_fingerprint == password_manager.current_fingerprint:
+            print(
+                colored(
+                    f"Seed profile {selected_fingerprint} is already active.", "yellow"
+                )
+            )
+            return
         if password_manager.select_fingerprint(selected_fingerprint):
             print(colored(f"Switched to seed profile {selected_fingerprint}.", "green"))
         else:

--- a/src/tests/test_handle_switch_fingerprint.py
+++ b/src/tests/test_handle_switch_fingerprint.py
@@ -1,0 +1,32 @@
+from main import handle_switch_fingerprint
+
+
+def test_handle_switch_fingerprint_active_profile(monkeypatch, capsys):
+    class DummyFingerprintManager:
+        def __init__(self):
+            self.fingerprints = ["fp1", "fp2"]
+
+        def list_fingerprints(self):
+            return self.fingerprints
+
+        def display_name(self, fp):
+            return fp
+
+    class DummyPM:
+        def __init__(self):
+            self.fingerprint_manager = DummyFingerprintManager()
+            self.current_fingerprint = "fp1"
+            self.decrypted = False
+
+        def select_fingerprint(self, fingerprint):
+            self.decrypted = True
+            return True
+
+    pm = DummyPM()
+    monkeypatch.setattr("builtins.input", lambda _: "1")
+
+    handle_switch_fingerprint(pm)
+
+    captured = capsys.readouterr()
+    assert "already active" in captured.out.lower()
+    assert pm.decrypted is False


### PR DESCRIPTION
## Summary
- prevent switching to the currently active seed profile
- test that selecting active profile does not trigger decryption

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6894041eb00c832bb34a3e8cfc73d7ca