### PR TITLE
Ensure add_new_fingerprint exits after seed setup

### DIFF
--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -529,6 +529,9 @@ class PasswordManager:
                 print(colored("Invalid choice. Exiting.", "red"))
                 sys.exit(1)
 
+            if not fingerprint:
+                return None
+
             # Set current_fingerprint in FingerprintManager only
             self.fingerprint_manager.current_fingerprint = fingerprint
             print(
@@ -541,6 +544,8 @@ class PasswordManager:
             # Ensure managers are initialized for the newly created profile
             if getattr(self, "config_manager", None) is None:
                 self.initialize_managers()
+
+            return fingerprint
 
         except Exception as e:
             logger.error(f"Error adding new seed profile: {e}", exc_info=True)
@@ -1000,8 +1005,8 @@ class PasswordManager:
                 logging.error("Invalid BIP-85 seed phrase. Exiting.")
                 print(colored("Error: Invalid BIP-85 seed phrase.", "red"))
                 sys.exit(1)
-
-            return self._finalize_existing_seed(parent_seed, password=password)
+            fingerprint = self._finalize_existing_seed(parent_seed, password=password)
+            return fingerprint
         except KeyboardInterrupt:
             logging.info("Operation cancelled by user.")
             self.notify("Operation cancelled by user.", level="WARNING")

--- a/src/tests/test_add_new_fingerprint_words.py
+++ b/src/tests/test_add_new_fingerprint_words.py
@@ -1,0 +1,35 @@
+import builtins
+from types import SimpleNamespace
+
+import seedpass.core.manager as manager_module
+from helpers import TEST_SEED
+
+
+def test_add_new_fingerprint_word_entry_exits(monkeypatch):
+    pm = manager_module.PasswordManager.__new__(manager_module.PasswordManager)
+    pm.fingerprint_manager = SimpleNamespace(current_fingerprint=None)
+    pm.initialize_managers = lambda: None
+
+    calls = {"count": 0}
+    original_setup = manager_module.PasswordManager.setup_existing_seed
+
+    def setup_wrapper(self, *a, **k):
+        calls["count"] += 1
+        return original_setup(self, *a, **k)
+
+    monkeypatch.setattr(
+        manager_module.PasswordManager, "setup_existing_seed", setup_wrapper
+    )
+    monkeypatch.setattr(manager_module, "prompt_seed_words", lambda *a, **k: TEST_SEED)
+    monkeypatch.setattr(
+        manager_module.PasswordManager,
+        "_finalize_existing_seed",
+        lambda self, seed, password=None: "fp",
+    )
+    monkeypatch.setattr(builtins, "input", lambda *_a, **_k: "2")
+
+    result = pm.add_new_fingerprint()
+
+    assert result == "fp"
+    assert calls["count"] == 1
+    assert pm.fingerprint_manager.current_fingerprint == "fp"


### PR DESCRIPTION
## Summary
- Avoid re-invoking seed setup and return new fingerprint from `add_new_fingerprint`
- Propagate fingerprint from `_finalize_existing_seed`
- Add regression test for entering existing seed one word at a time

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68940dd8c26c832b89b8a2cd7880811c