### PR TITLE
feat: make GUI install optional on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ See `docs/ARCHITECTURE.md` and [Nostr Setup](docs/nostr_setup.md) for details.
 ### Quick Installer
 
 Use the automated installer to download SeedPass and its dependencies in one step.
-The scripts also install the correct BeeWare backend for your platform automatically.
+The scripts can also install the BeeWare backend for your platform when requested (use `-IncludeGui` on Windows).
 If the GTK `gi` bindings are missing, the installer attempts to install the
 necessary system packages using `apt`, `yum`, `pacman`, or Homebrew.
 
@@ -135,6 +135,10 @@ Make sure the command ends right after `-b beta` with **no trailing parenthesis*
 **Windows (PowerShell):**
 ```powershell
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; $scriptContent = (New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/PR0M3TH3AN/SeedPass/main/scripts/install.ps1'); & ([scriptblock]::create($scriptContent))
+```
+*Install with the optional GUI:*
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; $scriptContent = (New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/PR0M3TH3AN/SeedPass/main/scripts/install.ps1'); & ([scriptblock]::create($scriptContent)) -IncludeGui
 ```
 Before running the script, install **Python 3.11** or **3.12** from [python.org](https://www.python.org/downloads/windows/) and tick **"Add Python to PATH"**. You should also install the [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the **C++ build tools** workload so dependencies compile correctly.  
 The Windows installer will attempt to install Git automatically if it is not already available. It also tries to install Python 3 using `winget`, `choco`, or `scoop` when Python is missing and recognizes the `py` launcher if `python` isn't on your PATH. If these tools are unavailable you'll see a link to download Python directly from <https://www.python.org/downloads/windows/>. When Python 3.13 or newer is detected without the Microsoft C++ build tools, the installer now attempts to download Python 3.12 automatically so you don't have to compile packages from source.


### PR DESCRIPTION
## Summary
- add `-IncludeGui` parameter to Windows installer to control BeeWare backend installation
- skip `toga-winforms` unless GUI is requested and warn instead of aborting on build-tool errors
- document optional GUI installation in README

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6894dbfb873c832b9b6a4c1a4cba8ebb