### PR TITLE
docs: document optional GUI install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ SeedPass now uses the `portalocker` library for cross-platform file locking. No 
   - [2. Create a Virtual Environment](#2-create-a-virtual-environment)
   - [3. Activate the Virtual Environment](#3-activate-the-virtual-environment)
   - [4. Install Dependencies](#4-install-dependencies)
+  - [Optional GUI](#optional-gui)
 - [Usage](#usage)
   - [Running the Application](#running-the-application)
   - [Managing Multiple Seeds](#managing-multiple-seeds)
@@ -220,6 +221,42 @@ sudo apt install xclip
 ```
 
 After installing `xclip`, restart SeedPass to enable clipboard support.
+
+### Optional GUI
+
+SeedPass ships with a GTK-based desktop interface that requires additional system
+libraries. Install the packages for your platform before adding the Python GUI
+dependencies.
+
+- **Debian/Ubuntu**
+  ```bash
+  sudo apt install libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkit2gtk-4.0-dev
+  ```
+- **Fedora**
+  ```bash
+  sudo dnf install gobject-introspection-devel cairo-devel pango-devel webkit2gtk4.0-devel
+  ```
+- **Arch Linux**
+  ```bash
+  sudo pacman -S gobject-introspection cairo pango webkit2gtk
+  ```
+- **macOS (Homebrew)**
+  ```bash
+  brew install pygobject3 gtk+3 adwaita-icon-theme librsvg webkitgtk
+  ```
+
+With the system requirements in place, install the Python GUI extras:
+
+```bash
+pip install .[gui]
+```
+
+CLI-only users can skip these steps and install just the core package for a
+lightweight setup:
+
+```bash
+pip install .
+```
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ After installing `xclip`, restart SeedPass to enable clipboard support.
 
 ### Optional GUI
 
-SeedPass ships with a GTK-based desktop interface that requires additional system
-libraries. Install the packages for your platform before adding the Python GUI
-dependencies.
+SeedPass ships with a GTK-based desktop interface that is still in development
+and not currently functional. Install the packages for your platform before
+adding the Python GUI dependencies.
 
 - **Debian/Ubuntu**
   ```bash


### PR DESCRIPTION
## Summary
- document OS-level packages for the optional GTK GUI
- describe installing GUI extras via `pip install .[gui]`
- note CLI-only users can install with `pip install .`

## Testing
- `python3 -m venv venv`
- `pip install --require-hashes -r requirements.lock`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6894e05c2448832b9ab283ba0e6f382b