### PR TITLE
Add module docstring to package init

### DIFF
--- a/src/seedpass/__init__.py
+++ b/src/seedpass/__init__.py
@@ -1,0 +1,3 @@
+"""SeedPass package initialization."""
+
+# Optionally re-export selected symbols here.


### PR DESCRIPTION
## Summary
- replace raw GitHub placeholder with a proper module docstring in `src/seedpass/__init__.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689605e1bb44832ba26bd01b92f93683