### PR TITLE
fix: remove stale password_manager directory

### DIFF
--- a/src/saved_config.yaml
+++ b/src/saved_config.yaml
@@ -3,4 +3,3 @@ selected_directories:
 - utils/
 - nostr/
 - local_bip85/
-- password_manager/


### PR DESCRIPTION
## Summary
- remove outdated `password_manager/` entry from `saved_config.yaml` so selected directories reflect the actual project layout

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install --require-hashes -r requirements.lock`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689616ec7574832b90cacb943f6e0edc