### PR TITLE
Enable padding for hex_to_bech32 conversion

### DIFF
--- a/src/nostr/coincurve_keys.py
+++ b/src/nostr/coincurve_keys.py
@@ -27,7 +27,8 @@ class Keys:
 
     @staticmethod
     def hex_to_bech32(key_str: str, prefix: str = "npub") -> str:
-        data = convertbits(bytes.fromhex(key_str), 8, 5)
+        # Pad to align with 5-bit groups as expected for Bech32 encoding
+        data = convertbits(bytes.fromhex(key_str), 8, 5, True)
         return bech32_encode(prefix, data)
 
     @staticmethod


### PR DESCRIPTION
## Summary
- pad convertbits output in `hex_to_bech32` so Bech32 encoding uses complete 5-bit groups

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6896237ba5dc832ba9402d28c4c616c2