### PR TITLE
Clean up logging in local BIP85 init

### DIFF
--- a/src/local_bip85/__init__.py
+++ b/src/local_bip85/__init__.py
@@ -9,7 +9,7 @@ try:
 
     logger.info("BIP85 module imported successfully.")
 except Exception as e:
-    logger.error("Failed to import BIP85 module: %s", e, exc_info=True)
+    logger.error(f"Failed to import BIP85 module: {e}", exc_info=True)
     BIP85 = None
 
 __all__ = ["BIP85"] if BIP85 is not None else []


### PR DESCRIPTION
## Summary
- streamline BIP85 import logging and use direct logger calls

## Testing
- `pip install --require-hashes -r requirements.lock`
- `black src/local_bip85/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68962d4142b8832b93377dcf61de7ac8