### PR TITLE
refactor: import GUI entrypoint from package

### DIFF
--- a/src/seedpass_gui/__main__.py
+++ b/src/seedpass_gui/__main__.py
@@ -1,4 +1,4 @@
-from .app import main
+from . import main
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- adjust seedpass_gui __main__ to import `main` from package to use centralized entrypoint

## Testing
- `python - <<'PY'
import sys
sys.path.append('src')
from unittest.mock import MagicMock
import seedpass_gui
seedpass_gui.build = MagicMock(return_value=MagicMock(main_loop=lambda: print('main loop called')))
import runpy
runpy.run_module('seedpass_gui', run_name='__main__')
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689647176a5c832ba97891cc558174bf