### PR TITLE
Clarify placeholder utilities and clean imports

### DIFF
--- a/src/local_bip85/bip85.py
+++ b/src/local_bip85/bip85.py
@@ -18,7 +18,6 @@ import hashlib
 import hmac
 import logging
 import os
-import traceback
 from colorama import Fore
 
 from bip_utils import Bip32Slip10Secp256k1, Bip39MnemonicGenerator, Bip39Languages

--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,6 @@ from tomli import TOMLDecodeError
 from colorama import init as colorama_init
 from termcolor import colored
 from utils.color_scheme import color_text
-import traceback
 import importlib
 
 from seedpass.core.manager import PasswordManager

--- a/src/nostr/event_handler.py
+++ b/src/nostr/event_handler.py
@@ -2,7 +2,6 @@
 
 import time
 import logging
-import traceback
 
 try:
     from monstr.event.event import Event

--- a/src/nostr/key_manager.py
+++ b/src/nostr/key_manager.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import logging
-import traceback
 from bech32 import bech32_encode, convertbits
 
 from local_bip85.bip85 import BIP85

--- a/src/nostr/utils.py
+++ b/src/nostr/utils.py
@@ -1,8 +1,9 @@
-# nostr/utils.py
+"""Placeholder utilities for Nostr.
 
-import logging
+This module is intentionally left minimal and will be expanded in future
+releases as the Nostr integration grows.
+"""
 
-
-# Example utility function (if any specific to nostr package)
-def some_helper_function():
-    pass  # Implement as needed
+# The module currently provides no functionality.
+# `pass` denotes the intentional absence of implementation.
+pass

--- a/src/seedpass/core/backup.py
+++ b/src/seedpass/core/backup.py
@@ -15,7 +15,6 @@ import logging
 import os
 import shutil
 import time
-import traceback
 from pathlib import Path
 from termcolor import colored
 

--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -86,7 +86,6 @@ from constants import (
     initialize_app,
 )
 
-import traceback
 import asyncio
 import gzip
 import bcrypt

--- a/src/seedpass/core/password_generation.py
+++ b/src/seedpass/core/password_generation.py
@@ -23,7 +23,6 @@ import logging
 import hashlib
 import string
 import hmac
-import traceback
 import base64
 from typing import Optional
 from dataclasses import dataclass

--- a/src/utils/checksum.py
+++ b/src/utils/checksum.py
@@ -15,7 +15,6 @@ import logging
 import sys
 import os
 import json
-import traceback
 from typing import Optional, Any
 
 from termcolor import colored

--- a/src/utils/color_scheme.py
+++ b/src/utils/color_scheme.py
@@ -32,5 +32,5 @@ def color_text(text: str, category: str = "default") -> str:
     color = _COLOR_MAP.get(category, "white")
     if color == "orange":
         return _apply_orange(text)
-    attrs = ["bold"] if category in {"info", "warning", "error"} else None
+    attrs = ["bold"] if category in {"info", "warning", "error"} else []
     return colored(text, color, attrs=attrs)

--- a/src/utils/fingerprint.py
+++ b/src/utils/fingerprint.py
@@ -10,7 +10,6 @@ facilitating organized and secure storage.
 
 import hashlib
 import logging
-import traceback
 from typing import Optional
 
 # Instantiate the logger

--- a/src/utils/fingerprint_manager.py
+++ b/src/utils/fingerprint_manager.py
@@ -3,7 +3,6 @@
 import os
 import json
 import logging
-import traceback
 from pathlib import Path
 from typing import Callable, List, Optional
 

--- a/src/utils/key_derivation.py
+++ b/src/utils/key_derivation.py
@@ -19,7 +19,6 @@ import hashlib
 import base64
 import unicodedata
 import logging
-import traceback
 import hmac
 import time
 from enum import Enum


### PR DESCRIPTION
## Summary
- Document nostr utils placeholder module
- Default color_scheme attrs to empty list for clarity
- Drop unused `traceback` imports across modules

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install --require-hashes -r requirements.lock`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6896519d0e4c832bb052b25caf9bb149