### PR TITLE
Convert Nostr client operations to async

### DIFF
--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -4355,7 +4355,7 @@ class PasswordManager:
                     manifest, event_id = pub_snap(encrypted)
             else:
                 # Fallback for tests using simplified stubs
-                event_id = self.nostr_client.publish_json_to_nostr(encrypted)
+                event_id = await self.nostr_client.publish_json_to_nostr(encrypted)
             self.is_dirty = False
             if event_id is None:
                 return None


### PR DESCRIPTION
## Summary
- Refactor Nostr connection methods to async and remove internal asyncio.run usage
- Await new async methods in manager sync flow
- Add regression test verifying async methods work inside a running event loop

## Testing
- `pip install --require-hashes -r requirements.lock`
- `black .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689800f58ffc832b8ac902e2c5689084