### PR TITLE
Use nostr_sdk Event and update handler tests

### DIFF
--- a/src/nostr/event_handler.py
+++ b/src/nostr/event_handler.py
@@ -3,14 +3,7 @@
 import time
 import logging
 
-try:
-    from monstr.event.event import Event
-except ImportError:  # pragma: no cover - optional dependency
-
-    class Event:  # minimal placeholder for type hints when monstr is absent
-        id: str
-        created_at: int
-        content: str
+from nostr_sdk import Event
 
 
 # Instantiate the logger
@@ -26,26 +19,15 @@ class EventHandler:
         pass  # Initialize if needed
 
     def handle_new_event(self, evt: Event):
-        """
-        Processes incoming events by logging their details.
+        """Process and log details from a Nostr event."""
 
-        :param evt: The received Event object.
-        """
         try:
-            # Assuming evt.created_at is always an integer Unix timestamp
-            if isinstance(evt.created_at, int):
-                created_at_str = time.strftime(
-                    "%Y-%m-%d %H:%M:%S", time.gmtime(evt.created_at)
-                )
-            else:
-                # Handle unexpected types gracefully
-                created_at_str = str(evt.created_at)
+            created_at = evt.created_at().as_secs()
+            created_at_str = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(created_at))
+            event_id = evt.id().to_hex()
 
-            # Log the event details without extra newlines
             logger.info(
-                f"[New Event] ID: {evt.id} | Created At: {created_at_str} | Content: {evt.content}"
+                f"[New Event] ID: {event_id} | Created At: {created_at_str} | Content: {evt.content()}"
             )
         except Exception as e:
             logger.error(f"Error handling new event: {e}", exc_info=True)
-            # Optionally, handle the exception without re-raising
-            # For example, continue processing other events

--- a/src/tests/test_event_handler.py
+++ b/src/tests/test_event_handler.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import sys
 from pathlib import Path
@@ -6,31 +7,31 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from nostr import event_handler
-
-
-class SimpleEvent:
-    def __init__(self, id: str, created_at: int, content: str) -> None:
-        self.id = id
-        self.created_at = created_at
-        self.content = content
+from nostr_sdk import EventBuilder, Keys
 
 
 def test_handle_new_event_logs(caplog):
     handler = event_handler.EventHandler()
-    evt = SimpleEvent("1", 0, "hello")
+    keys = Keys.generate()
+    evt = EventBuilder.text_note("hello").sign_with_keys(keys)
 
     caplog.set_level(logging.INFO, logger=event_handler.logger.name)
     handler.handle_new_event(evt)
 
+    event_id = evt.id().to_hex()
+    created_at = evt.created_at().as_secs()
+    created_at_str = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(created_at))
+
     assert (
-        "[New Event] ID: 1 | Created At: 1970-01-01 00:00:00 | Content: hello"
+        f"[New Event] ID: {event_id} | Created At: {created_at_str} | Content: hello"
         in caplog.text
     )
 
 
 def test_handle_new_event_error(monkeypatch, caplog):
     handler = event_handler.EventHandler()
-    evt = SimpleEvent("2", 0, "boom")
+    keys = Keys.generate()
+    evt = EventBuilder.text_note("boom").sign_with_keys(keys)
 
     def raise_info(*args, **kwargs):
         raise RuntimeError("fail")


### PR DESCRIPTION
## Summary
- refactor `EventHandler` to rely on `nostr_sdk.Event` and log event details via the SDK API
- extend `test_event_handler` to build and sign real Nostr events
- verified requirements list includes `nostr-sdk` with no `monstr` dependency

## Testing
- `pytest src/tests/test_event_handler.py`


------
https://chatgpt.com/codex/tasks/task_b_689a453e61d8832b857f41305f807552