### PR TITLE
Track vault lock state with explicit lock flag

### DIFF
--- a/src/seedpass/errors.py
+++ b/src/seedpass/errors.py
@@ -1,0 +1,4 @@
+class VaultLockedError(Exception):
+    """Raised when an operation requires an unlocked vault."""
+
+    pass

--- a/src/tests/test_vault_lock_flag.py
+++ b/src/tests/test_vault_lock_flag.py
@@ -1,0 +1,52 @@
+import pytest
+from types import SimpleNamespace
+
+from seedpass.core.manager import PasswordManager
+from seedpass.errors import VaultLockedError
+
+
+class DummyEntryManager:
+    def __init__(self):
+        self.cleared = False
+
+    def clear_cache(self):
+        self.cleared = True
+
+
+def test_lock_vault_sets_flag_and_keeps_objects():
+    pm = PasswordManager.__new__(PasswordManager)
+    em = DummyEntryManager()
+    pm.entry_manager = em
+    pm.is_locked = False
+    pm.locked = False
+    pm.lock_vault()
+    assert pm.is_locked
+    assert pm.locked
+    assert pm.entry_manager is em
+    assert em.cleared
+
+
+def test_entry_service_requires_unlocked():
+    pm = PasswordManager.__new__(PasswordManager)
+    service = SimpleNamespace()
+    pm._entry_service = service
+    pm.is_locked = True
+    with pytest.raises(VaultLockedError):
+        _ = pm.entry_service
+    pm.is_locked = False
+    assert pm.entry_service is service
+
+
+def test_unlock_vault_clears_locked_flag(tmp_path):
+    pm = PasswordManager.__new__(PasswordManager)
+    pm.fingerprint_dir = tmp_path
+    pm.parent_seed = "seed"
+    pm.setup_encryption_manager = lambda *a, **k: None
+    pm.initialize_bip85 = lambda: None
+    pm.initialize_managers = lambda: None
+    pm.update_activity = lambda: None
+    pm.is_locked = True
+    pm.locked = True
+    pm.unlock_vault("pw")
+    assert not pm.is_locked
+    assert not pm.locked


### PR DESCRIPTION
## Summary
- introduce `VaultLockedError` and shared errors module
- add `is_locked` flag, retain managers when locking, and guard critical methods
- test locked/unlocked behavior and access restrictions

## Testing
- `python -m black src/seedpass/core/manager.py src/tests/test_vault_lock_flag.py src/seedpass/errors.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689a9758a968832b9633da3d90d1bb48