### PR TITLE
refactor: rename entropy length parameter

### DIFF
--- a/src/nostr/key_manager.py
+++ b/src/nostr/key_manager.py
@@ -85,7 +85,7 @@ class KeyManager:
             # Derive entropy for Nostr key (32 bytes)
             entropy_bytes = self.bip85.derive_entropy(
                 index=index,
-                bytes_len=32,
+                entropy_bytes=32,
                 app_no=NOSTR_KEY_APP_ID,
             )
 
@@ -102,7 +102,7 @@ class KeyManager:
         """Derive Nostr keys using the legacy application ID."""
         try:
             entropy = self.bip85.derive_entropy(
-                index=0, bytes_len=32, app_no=LEGACY_NOSTR_KEY_APP_ID
+                index=0, entropy_bytes=32, app_no=LEGACY_NOSTR_KEY_APP_ID
             )
             return Keys(priv_k=entropy.hex())
         except Exception as e:

--- a/src/seedpass/core/entry_management.py
+++ b/src/seedpass/core/entry_management.py
@@ -461,7 +461,7 @@ class EntryManager:
 
         seed_bytes = Bip39SeedGenerator(parent_seed).Generate()
         bip85 = BIP85(seed_bytes)
-        entropy = bip85.derive_entropy(index=index, bytes_len=32)
+        entropy = bip85.derive_entropy(index=index, entropy_bytes=32)
         keys = Keys(priv_k=entropy.hex())
         npub = Keys.hex_to_bech32(keys.public_key_hex(), "npub")
         nsec = Keys.hex_to_bech32(keys.private_key_hex(), "nsec")
@@ -539,7 +539,7 @@ class EntryManager:
         bip85 = BIP85(seed_bytes)
 
         key_idx = int(entry.get("index", index))
-        entropy = bip85.derive_entropy(index=key_idx, bytes_len=32)
+        entropy = bip85.derive_entropy(index=key_idx, entropy_bytes=32)
         keys = Keys(priv_k=entropy.hex())
         npub = Keys.hex_to_bech32(keys.public_key_hex(), "npub")
         nsec = Keys.hex_to_bech32(keys.private_key_hex(), "nsec")

--- a/src/seedpass/core/password_generation.py
+++ b/src/seedpass/core/password_generation.py
@@ -126,7 +126,7 @@ class PasswordGenerator:
 
     def _derive_password_entropy(self, index: int) -> bytes:
         """Derive deterministic entropy for password generation."""
-        entropy = self.bip85.derive_entropy(index=index, bytes_len=64, app_no=32)
+        entropy = self.bip85.derive_entropy(index=index, entropy_bytes=64, app_no=32)
         logger.debug("Entropy derived for password generation.")
 
         hkdf = HKDF(
@@ -433,7 +433,7 @@ class PasswordGenerator:
 
 def derive_ssh_key(bip85: BIP85, idx: int) -> bytes:
     """Derive 32 bytes of entropy suitable for an SSH key."""
-    return bip85.derive_entropy(index=idx, bytes_len=32, app_no=32)
+    return bip85.derive_entropy(index=idx, entropy_bytes=32, app_no=32)
 
 
 def derive_ssh_key_pair(parent_seed: str, index: int) -> tuple[str, str]:
@@ -499,7 +499,7 @@ def derive_pgp_key(
     import hashlib
     import datetime
 
-    entropy = bip85.derive_entropy(index=idx, bytes_len=32, app_no=32)
+    entropy = bip85.derive_entropy(index=idx, entropy_bytes=32, app_no=32)
     created = datetime.datetime(2000, 1, 1, tzinfo=datetime.timezone.utc)
 
     if key_type.lower() == "rsa":

--- a/src/tests/test_api_new_endpoints.py
+++ b/src/tests/test_api_new_endpoints.py
@@ -501,8 +501,10 @@ async def test_generate_password_no_special_chars(client):
             return b"\x00" * 32
 
     class DummyBIP85:
-        def derive_entropy(self, index: int, bytes_len: int, app_no: int = 32) -> bytes:
-            return bytes(range(bytes_len))
+        def derive_entropy(
+            self, index: int, entropy_bytes: int, app_no: int = 32
+        ) -> bytes:
+            return bytes(range(entropy_bytes))
 
     api.app.state.pm.password_generator = PasswordGenerator(
         DummyEnc(), "seed", DummyBIP85()
@@ -529,8 +531,10 @@ async def test_generate_password_allowed_chars(client):
             return b"\x00" * 32
 
     class DummyBIP85:
-        def derive_entropy(self, index: int, bytes_len: int, app_no: int = 32) -> bytes:
-            return bytes((index + i) % 256 for i in range(bytes_len))
+        def derive_entropy(
+            self, index: int, entropy_bytes: int, app_no: int = 32
+        ) -> bytes:
+            return bytes((index + i) % 256 for i in range(entropy_bytes))
 
     api.app.state.pm.password_generator = PasswordGenerator(
         DummyEnc(), "seed", DummyBIP85()

--- a/src/tests/test_bip85_derivation_path.py
+++ b/src/tests/test_bip85_derivation_path.py
@@ -1,0 +1,52 @@
+from local_bip85.bip85 import BIP85
+
+
+class DummyChild:
+    def PrivateKey(self):
+        return self
+
+    def Raw(self):
+        return self
+
+    def ToBytes(self):
+        return b"\x00" * 32
+
+
+class DummyCtx:
+    def __init__(self):
+        self.last_path = None
+
+    def DerivePath(self, path: str):
+        self.last_path = path
+        return DummyChild()
+
+
+def test_derivation_paths_for_entropy_lengths():
+    bip85 = BIP85(b"\x00" * 64)
+    ctx = DummyCtx()
+    bip85.bip32_ctx = ctx
+
+    vectors = [
+        (16, 12),
+        (24, 18),
+        (32, 24),
+    ]
+
+    for entropy_bytes, word_count in vectors:
+        bip85.derive_entropy(
+            index=0,
+            entropy_bytes=entropy_bytes,
+            app_no=39,
+            word_count=word_count,
+        )
+        assert ctx.last_path == f"m/83696968'/39'/0'/{word_count}'/0'"
+
+
+def test_default_word_count_from_entropy_bytes():
+    bip85 = BIP85(b"\x00" * 64)
+    ctx = DummyCtx()
+    bip85.bip32_ctx = ctx
+
+    bip85.derive_entropy(index=5, entropy_bytes=20, app_no=39)
+
+    assert ctx.last_path == "m/83696968'/39'/0'/20'/5'"

--- a/src/tests/test_entry_policy_override.py
+++ b/src/tests/test_entry_policy_override.py
@@ -21,8 +21,8 @@ class DummyEnc:
 
 
 class DummyBIP85:
-    def derive_entropy(self, index: int, bytes_len: int, app_no: int = 32) -> bytes:
-        return bytes((index + i) % 256 for i in range(bytes_len))
+    def derive_entropy(self, index: int, entropy_bytes: int, app_no: int = 32) -> bytes:
+        return bytes((index + i) % 256 for i in range(entropy_bytes))
 
 
 def make_manager(tmp_path: Path) -> PasswordManager:

--- a/src/tests/test_password_generation_policy.py
+++ b/src/tests/test_password_generation_policy.py
@@ -13,8 +13,8 @@ class DummyEnc:
 
 
 class DummyBIP85:
-    def derive_entropy(self, index: int, bytes_len: int, app_no: int = 32) -> bytes:
-        return bytes((index + i) % 256 for i in range(bytes_len))
+    def derive_entropy(self, index: int, entropy_bytes: int, app_no: int = 32) -> bytes:
+        return bytes((index + i) % 256 for i in range(entropy_bytes))
 
 
 def make_generator(policy=None):

--- a/src/tests/test_password_helpers.py
+++ b/src/tests/test_password_helpers.py
@@ -8,8 +8,8 @@ class DummyEnc:
 
 
 class DummyBIP85:
-    def derive_entropy(self, index: int, bytes_len: int, app_no: int = 32) -> bytes:
-        return bytes((index + i) % 256 for i in range(bytes_len))
+    def derive_entropy(self, index: int, entropy_bytes: int, app_no: int = 32) -> bytes:
+        return bytes((index + i) % 256 for i in range(entropy_bytes))
 
 
 def make_generator():

--- a/src/tests/test_password_length_constraints.py
+++ b/src/tests/test_password_length_constraints.py
@@ -14,8 +14,8 @@ class DummyEnc:
 
 
 class DummyBIP85:
-    def derive_entropy(self, index: int, bytes_len: int, app_no: int = 32) -> bytes:
-        return bytes((index + i) % 256 for i in range(bytes_len))
+    def derive_entropy(self, index: int, entropy_bytes: int, app_no: int = 32) -> bytes:
+        return bytes((index + i) % 256 for i in range(entropy_bytes))
 
 
 def make_generator():

--- a/src/tests/test_password_properties.py
+++ b/src/tests/test_password_properties.py
@@ -15,8 +15,8 @@ class DummyEnc:
 
 
 class DummyBIP85:
-    def derive_entropy(self, index: int, bytes_len: int, app_no: int = 32) -> bytes:
-        return bytes((index + i) % 256 for i in range(bytes_len))
+    def derive_entropy(self, index: int, entropy_bytes: int, app_no: int = 32) -> bytes:
+        return bytes((index + i) % 256 for i in range(entropy_bytes))
 
 
 def make_generator():

--- a/src/tests/test_password_shuffle_consistency.py
+++ b/src/tests/test_password_shuffle_consistency.py
@@ -12,8 +12,8 @@ class DummyEnc:
 
 
 class DummyBIP85:
-    def derive_entropy(self, index: int, bytes_len: int, app_no: int = 32) -> bytes:
-        return bytes((index + i) % 256 for i in range(bytes_len))
+    def derive_entropy(self, index: int, entropy_bytes: int, app_no: int = 32) -> bytes:
+        return bytes((index + i) % 256 for i in range(entropy_bytes))
 
 
 def make_generator():

--- a/src/tests/test_password_special_chars.py
+++ b/src/tests/test_password_special_chars.py
@@ -15,8 +15,8 @@ class DummyEnc:
 
 
 class DummyBIP85:
-    def derive_entropy(self, index: int, bytes_len: int, app_no: int = 32) -> bytes:
-        return bytes((index + i) % 256 for i in range(bytes_len))
+    def derive_entropy(self, index: int, entropy_bytes: int, app_no: int = 32) -> bytes:
+        return bytes((index + i) % 256 for i in range(entropy_bytes))
 
 
 def make_generator(policy=None):

--- a/src/tests/test_password_special_modes.py
+++ b/src/tests/test_password_special_modes.py
@@ -14,8 +14,8 @@ class DummyEnc:
 
 
 class DummyBIP85:
-    def derive_entropy(self, index: int, bytes_len: int, app_no: int = 32) -> bytes:
-        return bytes((index + i) % 256 for i in range(bytes_len))
+    def derive_entropy(self, index: int, entropy_bytes: int, app_no: int = 32) -> bytes:
+        return bytes((index + i) % 256 for i in range(entropy_bytes))
 
 
 def make_generator(policy=None):

--- a/tests/perf/test_bip85_cache.py
+++ b/tests/perf/test_bip85_cache.py
@@ -9,10 +9,10 @@ class SlowBIP85:
     def __init__(self):
         self.calls = 0
 
-    def derive_entropy(self, index: int, bytes_len: int, app_no: int = 39) -> bytes:
+    def derive_entropy(self, index: int, entropy_bytes: int, app_no: int = 39) -> bytes:
         self.calls += 1
         time.sleep(0.01)
-        return b"\x00" * bytes_len
+        return b"\x00" * entropy_bytes
 
 
 def _setup_manager(bip85: SlowBIP85) -> PasswordManager:
@@ -21,10 +21,12 @@ def _setup_manager(bip85: SlowBIP85) -> PasswordManager:
     pm.bip85 = bip85
     orig = bip85.derive_entropy
 
-    def cached(index: int, bytes_len: int, app_no: int = 39) -> bytes:
+    def cached(index: int, entropy_bytes: int, app_no: int = 39) -> bytes:
         key = (app_no, index)
         if key not in pm._bip85_cache:
-            pm._bip85_cache[key] = orig(index=index, bytes_len=bytes_len, app_no=app_no)
+            pm._bip85_cache[key] = orig(
+                index=index, entropy_bytes=entropy_bytes, app_no=app_no
+            )
         return pm._bip85_cache[key]
 
     bip85.derive_entropy = cached


### PR DESCRIPTION
## Summary
- rename `bytes_len` to `entropy_bytes` and internal `words_len` to `word_count`
- document relationship between `entropy_bytes`, `word_count`, and the derivation path
- add tests covering derivation path generation for multiple entropy sizes

## Testing
- `pytest src/tests/test_bip85_derivation_path.py src/tests/test_password_helpers.py src/tests/test_password_generation_policy.py src/tests/test_password_special_chars.py -q`
- `pytest src/tests/test_password_special_modes.py src/tests/test_password_shuffle_consistency.py src/tests/test_entry_policy_override.py src/tests/test_password_properties.py src/tests/test_password_length_constraints.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689b4030cbfc832bb3dcc80d4938c788