### PR TITLE
chore: remove unused nostr utils module

### DIFF
--- a/src/nostr/utils.py
+++ b/src/nostr/utils.py
@@ -1,9 +1,0 @@
-"""Placeholder utilities for Nostr.
-
-This module is intentionally left minimal and will be expanded in future
-releases as the Nostr integration grows.
-"""
-
-# The module currently provides no functionality.
-# `pass` denotes the intentional absence of implementation.
-pass


### PR DESCRIPTION
## Summary
- remove placeholder Nostr utils module
- drop unused imports of nostr.utils

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b4deb7a9c832b928c6c9dac6d8030