### PR TITLE
docs: note installer dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ The Windows installer will attempt to install Git automatically if it is not alr
 
 **Note:** If this fallback fails, install Python 3.12 manually or install the [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) and rerun the installer.
 
+#### Installer Dependency Checks
+
+The installer verifies that core build tooling—C/C++ build tools, Rust, CMake, and the imaging/GTK libraries—are available before completing. Pass `--no-gui` to skip installing GUI packages. On Linux, ensure `xclip` or `wl-clipboard` is installed for clipboard support.
+
 #### Windows Nostr Sync Troubleshooting
 
 When backing up or restoring from Nostr on Windows, a few issues are common:

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -120,6 +120,11 @@ isn't on your PATH. If these tools are unavailable you'll see a link to download
 the installer now attempts to download Python 3.12 automatically so you don't have to compile packages from source.
 
 **Note:** If this fallback fails, install Python 3.12 manually or install the [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) and rerun the installer.
+
+#### Installer Dependency Checks
+
+The installer verifies that core build tooling—C/C++ build tools, Rust, CMake, and the imaging/GTK libraries—are available before completing. Pass `--no-gui` to skip installing GUI packages. On Linux, ensure `xclip` or `wl-clipboard` is installed for clipboard support.
+
 ### Uninstall
 
 Run the matching uninstaller if you need to remove a previous installation or clean up an old `seedpass` command:


### PR DESCRIPTION
## Summary
- highlight that the installer ensures C/C++ build tools, Rust, CMake, and imaging/GTK libraries are installed
- document `--no-gui` option and Linux clipboard helpers

## Testing
- `mkdocs build` *(fails: Config file 'mkdocs.yml' does not exist)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3a539d0cc832b81ea07918414b198