### PR TITLE
test: add key-value and managed account entry tests

### DIFF
--- a/src/tests/test_key_value_entry.py
+++ b/src/tests/test_key_value_entry.py
@@ -37,10 +37,30 @@ def test_add_and_modify_key_value():
             "tags": [],
         }
 
+        # Appears in listing
+        assert em.list_entries() == [(idx, "API entry", None, None, False)]
+
+        # Modify key and value
         em.modify_entry(idx, key="api_key2", value="def456")
         updated = em.retrieve_entry(idx)
         assert updated["key"] == "api_key2"
         assert updated["value"] == "def456"
 
+        # Archive and ensure it disappears from the default listing
+        em.archive_entry(idx)
+        archived = em.retrieve_entry(idx)
+        assert archived["archived"] is True
+        assert em.list_entries() == []
+        assert em.list_entries(include_archived=True) == [
+            (idx, "API entry", None, None, True)
+        ]
+
+        # Restore and ensure it reappears
+        em.restore_entry(idx)
+        restored = em.retrieve_entry(idx)
+        assert restored["archived"] is False
+        assert em.list_entries() == [(idx, "API entry", None, None, False)]
+
+        # Values are not searchable
         results = em.search_entries("def456")
         assert results == []


### PR DESCRIPTION
## Summary
- expand key-value entry tests for listing, modification, and archive handling
- cover managed account listing, retrieval, determinism, and archive workflows

## Testing
- `pytest -q`
- `pytest src/tests/test_key_value_entry.py src/tests/test_managed_account_entry.py -q`
- `pre-commit run --files src/tests/test_key_value_entry.py src/tests/test_managed_account_entry.py`


------
https://chatgpt.com/codex/tasks/task_b_68a3b5fec764832ba2176aa7a2bb3325