### PR TITLE
docs: add deterministic artifact guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,11 @@ This project is written in **Python**. Follow these instructions when working wi
 
 Following these practices helps keep the code base consistent and secure.
 
+## Deterministic Artifact Generation
+
+- All generated artifacts (passwords, keys, TOTP secrets, etc.) must be fully deterministic across runs and platforms.
+- Randomness is only permitted for security primitives (e.g., encryption nonces, in-memory keys) and must never influence derived artifacts.
+
 ## Legacy Index Migration
 
 - Always provide a migration path for index archives and import/export routines.


### PR DESCRIPTION
## Summary
- document that generated artifacts like passwords and TOTP secrets must be deterministic
- clarify randomness is only allowed for security primitives and must not affect derived data

## Testing
- `pip install --require-hashes -r requirements.lock`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68a644118a88832b9b1a18f76fee52ac