### PR TITLE
feat: support random and deterministic TOTP secrets

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1295,6 +1295,11 @@ def main(argv: list[str] | None = None, *, fingerprint: str | None = None) -> in
         help="Disable clipboard support and print secrets",
     )
     parser.add_argument(
+        "--deterministic-totp",
+        action="store_true",
+        help="Derive TOTP secrets deterministically",
+    )
+    parser.add_argument(
         "--max-prompt-attempts",
         type=int,
         default=None,
@@ -1371,6 +1376,8 @@ def main(argv: list[str] | None = None, *, fingerprint: str | None = None) -> in
 
     if args.no_clipboard:
         password_manager.secret_mode_enabled = False
+    if args.deterministic_totp:
+        password_manager.deterministic_totp = True
 
     if args.command == "export":
         password_manager.handle_export_database(Path(args.file))

--- a/src/seedpass/api.py
+++ b/src/seedpass/api.py
@@ -214,13 +214,14 @@ async def create_entry(
         uri = await run_in_threadpool(
             pm.entry_manager.add_totp,
             entry.get("label"),
-            pm.parent_seed,
+            pm.KEY_TOTP_DET if entry.get("deterministic", False) else None,
             secret=entry.get("secret"),
             index=entry.get("index"),
             period=int(entry.get("period", 30)),
             digits=int(entry.get("digits", 6)),
             notes=entry.get("notes", ""),
             archived=entry.get("archived", False),
+            deterministic=entry.get("deterministic", False),
         )
         return {"id": index, "uri": uri}
 

--- a/src/seedpass/cli/__init__.py
+++ b/src/seedpass/cli/__init__.py
@@ -30,6 +30,13 @@ no_clipboard_option = typer.Option(
     is_flag=True,
 )
 
+deterministic_totp_option = typer.Option(
+    False,
+    "--deterministic-totp",
+    help="Derive TOTP secrets deterministically",
+    is_flag=True,
+)
+
 # Sub command groups
 from . import entry, vault, nostr, config, fingerprint, util, api
 
@@ -55,12 +62,17 @@ def main(
     ctx: typer.Context,
     fingerprint: Optional[str] = fingerprint_option,
     no_clipboard: bool = no_clipboard_option,
+    deterministic_totp: bool = deterministic_totp_option,
 ) -> None:
     """SeedPass CLI entry point.
 
     When called without a subcommand this launches the interactive TUI.
     """
-    ctx.obj = {"fingerprint": fingerprint, "no_clipboard": no_clipboard}
+    ctx.obj = {
+        "fingerprint": fingerprint,
+        "no_clipboard": no_clipboard,
+        "deterministic_totp": deterministic_totp,
+    }
     if ctx.invoked_subcommand is None:
         tui = importlib.import_module("main")
         raise typer.Exit(tui.main(fingerprint=fingerprint))

--- a/src/seedpass/cli/common.py
+++ b/src/seedpass/cli/common.py
@@ -29,6 +29,8 @@ def _get_pm(ctx: typer.Context) -> PasswordManager:
         pm = PasswordManager(fingerprint=fp)
     if ctx.obj.get("no_clipboard"):
         pm.secret_mode_enabled = False
+    if ctx.obj.get("deterministic_totp"):
+        pm.deterministic_totp = True
     return pm
 
 

--- a/src/seedpass/cli/entry.py
+++ b/src/seedpass/cli/entry.py
@@ -177,6 +177,9 @@ def entry_add_totp(
     secret: Optional[str] = typer.Option(None, "--secret", help="Import secret"),
     period: int = typer.Option(30, "--period", help="TOTP period in seconds"),
     digits: int = typer.Option(6, "--digits", help="Number of TOTP digits"),
+    deterministic_totp: bool = typer.Option(
+        False, "--deterministic-totp", help="Derive secret deterministically"
+    ),
 ) -> None:
     """Add a TOTP entry and output the otpauth URI."""
     service = _get_entry_service(ctx)
@@ -186,6 +189,7 @@ def entry_add_totp(
         secret=secret,
         period=period,
         digits=digits,
+        deterministic=deterministic_totp,
     )
     typer.echo(uri)
 

--- a/src/seedpass/core/api.py
+++ b/src/seedpass/core/api.py
@@ -363,15 +363,18 @@ class EntryService:
         secret: str | None = None,
         period: int = 30,
         digits: int = 6,
+        deterministic: bool = False,
     ) -> str:
         with self._lock:
+            key = self._manager.KEY_TOTP_DET if deterministic else None
             uri = self._manager.entry_manager.add_totp(
                 label,
-                self._manager.parent_seed,
+                key,
                 index=index,
                 secret=secret,
                 period=period,
                 digits=digits,
+                deterministic=deterministic,
             )
             self._manager.start_background_vault_sync()
             return uri

--- a/src/seedpass/core/totp.py
+++ b/src/seedpass/core/totp.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import time
+import base64
 from typing import Union
 from urllib.parse import quote
 from urllib.parse import urlparse, parse_qs, unquote
@@ -13,6 +15,11 @@ import qrcode
 import pyotp
 
 from utils import key_derivation
+
+
+def random_totp_secret(length: int = 20) -> str:
+    """Return a random Base32 encoded TOTP secret."""
+    return base64.b32encode(os.urandom(length)).decode("ascii").rstrip("=")
 
 
 class TotpManager:

--- a/src/tests/test_api_new_endpoints.py
+++ b/src/tests/test_api_new_endpoints.py
@@ -53,6 +53,7 @@ async def test_create_and_modify_totp_entry(client):
         "digits": 8,
         "notes": "n",
         "archived": False,
+        "deterministic": False,
     }
 
     res = await cl.put(

--- a/src/tests/test_cli_doc_examples.py
+++ b/src/tests/test_cli_doc_examples.py
@@ -25,7 +25,7 @@ class DummyPM:
             retrieve_entry=lambda idx: {"type": EntryType.PASSWORD.value, "length": 8},
             get_totp_code=lambda idx, seed: "123456",
             add_entry=lambda label, length, username, url, **kwargs: 1,
-            add_totp=lambda label, seed, index=None, secret=None, period=30, digits=6: "totp://",
+            add_totp=lambda label, seed, index=None, secret=None, period=30, digits=6, deterministic=False: "totp://",
             add_ssh_key=lambda label, seed, index=None, notes="": 2,
             add_pgp_key=lambda label, seed, index=None, key_type="ed25519", user_id="", notes="": 3,
             add_nostr_key=lambda label, seed, index=None, notes="": 4,

--- a/src/tests/test_cli_entry_add_commands.py
+++ b/src/tests/test_cli_entry_add_commands.py
@@ -65,8 +65,14 @@ runner = CliRunner()
                 "--digits",
                 "7",
             ],
-            ("Label", "seed"),
-            {"index": 1, "secret": "abc", "period": 45, "digits": 7},
+            ("Label", None),
+            {
+                "index": 1,
+                "secret": "abc",
+                "period": 45,
+                "digits": 7,
+                "deterministic": False,
+            },
             "otpauth://uri",
         ),
         (

--- a/src/tests/test_gui_headless.py
+++ b/src/tests/test_gui_headless.py
@@ -33,7 +33,9 @@ class FakeEntries:
         self.added.append(("password", label, length, username, url))
         return 1
 
-    def add_totp(self, label):
+    def add_totp(
+        self, label, deterministic=False, index=None, secret=None, period=30, digits=6
+    ):
         self.added.append(("totp", label))
         return 1
 

--- a/src/tests/test_manager_add_totp.py
+++ b/src/tests/test_manager_add_totp.py
@@ -60,15 +60,11 @@ def test_handle_add_totp(monkeypatch, capsys):
         out = capsys.readouterr().out
 
         entry = entry_mgr.retrieve_entry(0)
-        assert entry == {
-            "type": "totp",
-            "kind": "totp",
-            "label": "Example",
-            "index": 0,
-            "period": 30,
-            "digits": 6,
-            "archived": False,
-            "notes": "",
-            "tags": [],
-        }
+        assert entry["type"] == "totp"
+        assert entry["kind"] == "totp"
+        assert entry["label"] == "Example"
+        assert entry["deterministic"] is False
+        assert "index" not in entry
+        assert "secret" in entry
+        assert len(entry["secret"]) >= 16
         assert "ID 0" in out

--- a/src/tests/test_manager_display_totp_codes.py
+++ b/src/tests/test_manager_display_totp_codes.py
@@ -32,7 +32,7 @@ def test_handle_display_totp_codes(monkeypatch, capsys, password_manager):
 
     pm.handle_display_totp_codes()
     out = capsys.readouterr().out
-    assert "Generated 2FA Codes" in out
+    assert "Imported 2FA Codes" in out
     assert "[0] Example" in out
     assert "123456" in out
 


### PR DESCRIPTION
## Summary
- add `random_totp_secret` helper for generating Base32 TOTP keys
- support random and deterministic TOTP entries with a `deterministic` flag
- expose `--deterministic-totp` option in CLI/TUI and update API export/retrieval

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a64a0ad5e4832ba0745c1e111cb26f