### PR TITLE
Use bcrypt-hashed API tokens

### DIFF
--- a/docs/docs/content/01-getting-started/01-advanced_cli.md
+++ b/docs/docs/content/01-getting-started/01-advanced_cli.md
@@ -127,7 +127,7 @@ Run or stop the local HTTP API.
 | Action | Command | Examples |
 | :--- | :--- | :--- |
 | Start the API | `api start` | `seedpass api start --host 0.0.0.0 --port 8000` |
-| Stop the API | `api stop` | `seedpass api stop` |
+| Stop the API | `api stop --token TOKEN` | `seedpass api stop --token <token>` |
 
 ---
 
@@ -214,7 +214,7 @@ Set the `SEEDPASS_CORS_ORIGINS` environment variable to a comma‑separated list
 SEEDPASS_CORS_ORIGINS=http://localhost:3000 seedpass api start
 ```
 
-Shut down the server with `seedpass api stop`.
+Shut down the server with `seedpass api stop --token <token>`.
 
 ---
 

--- a/src/seedpass/cli/api.py
+++ b/src/seedpass/cli/api.py
@@ -13,19 +13,25 @@ app = typer.Typer(help="Run the API server")
 def api_start(ctx: typer.Context, host: str = "127.0.0.1", port: int = 8000) -> None:
     """Start the SeedPass API server."""
     token = api_module.start_server(ctx.obj.get("fingerprint"))
-    typer.echo(f"API token: {token}")
+    typer.echo(
+        f"API token: {token}\nWARNING: Store this token securely; it cannot be recovered."
+    )
     uvicorn.run(api_module.app, host=host, port=port)
 
 
 @app.command("stop")
-def api_stop(ctx: typer.Context, host: str = "127.0.0.1", port: int = 8000) -> None:
+def api_stop(
+    token: str = typer.Option(..., help="API token"),
+    host: str = "127.0.0.1",
+    port: int = 8000,
+) -> None:
     """Stop the SeedPass API server."""
     import requests
 
     try:
         requests.post(
             f"http://{host}:{port}/api/v1/shutdown",
-            headers={"Authorization": f"Bearer {api_module.app.state.token_hash}"},
+            headers={"Authorization": f"Bearer {token}"},
             timeout=2,
         )
     except Exception as exc:  # pragma: no cover - best effort

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -4,7 +4,7 @@ import sys
 
 import pytest
 from httpx import ASGITransport, AsyncClient
-import hashlib
+import bcrypt
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -54,7 +54,7 @@ async def client(monkeypatch):
 async def test_token_hashed(client):
     _, token = client
     assert api.app.state.token_hash != token
-    assert api.app.state.token_hash == hashlib.sha256(token.encode()).hexdigest()
+    assert bcrypt.checkpw(token.encode(), api.app.state.token_hash)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Generate a random API token and store only a bcrypt hash on the server
- Verify API requests with bcrypt and adjust CLI to use the raw token
- Update docs and tests for new token handling

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a657f1c16c832b84e87bebea1b80e3