### PR TITLE
Add nonce tracking and V3 encryption format

### DIFF
--- a/src/tests/test_legacy_migration.py
+++ b/src/tests/test_legacy_migration.py
@@ -83,7 +83,7 @@ def test_failed_migration_restores_legacy(monkeypatch, tmp_path: Path):
     assert not vault.migrated_from_legacy
 
 
-def test_migrated_index_has_v2_prefix(monkeypatch, tmp_path: Path):
+def test_migrated_index_has_v3_prefix(monkeypatch, tmp_path: Path):
     vault, _ = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
 
     key = derive_index_key(TEST_SEED)
@@ -101,7 +101,7 @@ def test_migrated_index_has_v2_prefix(monkeypatch, tmp_path: Path):
 
     new_file = tmp_path / "seedpass_entries_db.json.enc"
     payload = json.loads(new_file.read_text())
-    assert base64.b64decode(payload["ct"]).startswith(b"V2:")
+    assert base64.b64decode(payload["ct"]).startswith(b"V3|")
     assert vault.migrated_from_legacy
 
 

--- a/src/tests/test_legacy_migration_iterations.py
+++ b/src/tests/test_legacy_migration_iterations.py
@@ -67,4 +67,4 @@ def test_migrate_iterations(tmp_path, monkeypatch, iterations):
     assert cfg.get_kdf_iterations() == iterations
 
     payload = json.loads((tmp_path / "seedpass_entries_db.json.enc").read_text())
-    assert base64.b64decode(payload["ct"]).startswith(b"V2:")
+    assert base64.b64decode(payload["ct"]).startswith(b"V3|")

--- a/src/tests/test_legacy_migration_prompt.py
+++ b/src/tests/test_legacy_migration_prompt.py
@@ -51,5 +51,5 @@ def test_migrate_legacy_sets_flag(tmp_path, monkeypatch):
     monkeypatch.setattr("builtins.input", lambda _: "2")
     vault.load_index()
     payload = json.loads((tmp_path / "seedpass_entries_db.json.enc").read_text())
-    assert base64.b64decode(payload["ct"]).startswith(b"V2:")
+    assert base64.b64decode(payload["ct"]).startswith(b"V3|")
     assert vault.encryption_manager.last_migration_performed is True

--- a/src/tests/test_legacy_migration_second_session.py
+++ b/src/tests/test_legacy_migration_second_session.py
@@ -36,7 +36,7 @@ def test_legacy_migration_second_session(monkeypatch, tmp_path: Path) -> None:
     vault.load_index()
     new_file = fp_dir / "seedpass_entries_db.json.enc"
     payload = json.loads(new_file.read_text())
-    assert base64.b64decode(payload["ct"]).startswith(b"V2:")
+    assert base64.b64decode(payload["ct"]).startswith(b"V3|")
 
     new_enc_mgr = EncryptionManager(key, fp_dir)
     new_vault = Vault(new_enc_mgr, fp_dir)
@@ -62,4 +62,4 @@ def test_legacy_migration_second_session(monkeypatch, tmp_path: Path) -> None:
 
     pm.initialize_managers()
     payload = json.loads(new_file.read_text())
-    assert base64.b64decode(payload["ct"]).startswith(b"V2:")
+    assert base64.b64decode(payload["ct"]).startswith(b"V3|")

--- a/src/tests/test_nonce_uniqueness.py
+++ b/src/tests/test_nonce_uniqueness.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from helpers import TEST_SEED
+from utils.key_derivation import derive_index_key
+from seedpass.core.encryption import EncryptionManager
+
+
+def test_nonce_uniqueness(tmp_path: Path) -> None:
+    key = derive_index_key(TEST_SEED)
+    manager = EncryptionManager(key, tmp_path)
+    plaintext = b"repeat"
+    nonces = set()
+    for _ in range(10):
+        payload = manager.encrypt_data(plaintext)
+        assert payload.startswith(b"V3|")
+        nonce = payload[3:15]
+        assert nonce not in nonces
+        nonces.add(nonce)
+    assert len(nonces) == 10

--- a/src/tests/test_seed_migration.py
+++ b/src/tests/test_seed_migration.py
@@ -31,4 +31,4 @@ def test_parent_seed_migrates_from_fernet(tmp_path: Path) -> None:
     assert new_file.exists()
     assert new_file.read_bytes() != encrypted
     payload = json.loads(new_file.read_text())
-    assert base64.b64decode(payload["ct"]).startswith(b"V2:")
+    assert base64.b64decode(payload["ct"]).startswith(b"V3|")


### PR DESCRIPTION
## Summary
- emit V3 payloads with fresh nonces and CRC tracking
- support both V3 and legacy V2 ciphertexts during decryption
- verify nonce uniqueness and update tests for new prefix

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a65bf98bc8832bab59744225757d3b