### PR TITLE
Clarify best-effort memory zeroization

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,7 @@ You can also launch the GUI directly with `seedpass gui` or `seedpass-gui`.
 - **No PBKDF2 Salt Needed:** SeedPass deliberately omits an explicit PBKDF2 salt. Every password is derived from a unique 512-bit BIP-85 child seed, which already provides stronger per-password uniqueness than a conventional 128-bit salt.
 - **Checksum Verification:** Always verify the script's checksum to ensure its integrity and protect against unauthorized modifications.
 - **Potential Bugs and Limitations:** Be aware that the software may contain bugs and lacks certain features. Snapshot chunks are capped at 50 KB and the client rotates snapshots after enough delta events accumulate. The security of memory management and logs has not been thoroughly evaluated and may pose risks of leaking sensitive information.
+- **Best-Effort Memory Zeroization:** Sensitive data is wiped from memory when possible, but Python may retain copies of decrypted values.
 - **Multiple Seeds Management:** While managing multiple seeds adds flexibility, it also increases the responsibility to secure each seed and its associated password.
 - **No PBKDF2 Salt Required:** SeedPass deliberately omits an explicit PBKDF2 salt. Every password is derived from a unique 512-bit BIP-85 child seed, which already provides stronger per-password uniqueness than a conventional 128-bit salt.
 - **Default KDF Iterations:** New profiles start with 50,000 PBKDF2 iterations. Adjust this with `seedpass config set kdf_iterations`.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,0 +1,6 @@
+# SeedPass Specification
+
+## Memory Protection
+
+SeedPass encrypts sensitive values in memory and attempts to wipe them when no longer needed. This zeroization is best-effort only; Python's memory management may retain copies of decrypted data. Critical cryptographic operations may move to a Rust/WASM module in the future to provide stronger guarantees.
+

--- a/src/utils/memory_protection.py
+++ b/src/utils/memory_protection.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 import os
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
+# TODO: Replace this Python implementation with a Rust/WASM module for
+# critical cryptographic operations.
+
 
 class InMemorySecret:
-    """Store sensitive data encrypted in RAM using AES-GCM."""
+    """Store sensitive data encrypted in RAM using AES-GCM.
+
+    Zeroization is best-effort only; Python's memory management may retain
+    copies of the plaintext.
+    """
 
     def __init__(self, data: bytes) -> None:
         if not isinstance(data, (bytes, bytearray)):


### PR DESCRIPTION
## Summary
- document that in-memory zeroization is best-effort and Python may keep plaintext copies
- leave TODO for Rust/WASM module to handle critical crypto routines
- note memory zeroization caveat in docs and README

## Testing
- `black .`
- `pytest --ignore=docs`


------
https://chatgpt.com/codex/tasks/task_b_68a6624c2840832bbbe0dcebdbe920c9