### PR TITLE
Add option to export and import database without encryption

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1309,6 +1309,11 @@ def main(argv: list[str] | None = None, *, fingerprint: str | None = None) -> in
 
     exp = sub.add_parser("export")
     exp.add_argument("--file")
+    exp.add_argument(
+        "--unencrypted",
+        action="store_true",
+        help="Export without encryption",
+    )
 
     imp = sub.add_parser("import")
     imp.add_argument("--file")
@@ -1380,7 +1385,9 @@ def main(argv: list[str] | None = None, *, fingerprint: str | None = None) -> in
         password_manager.deterministic_totp = True
 
     if args.command == "export":
-        password_manager.handle_export_database(Path(args.file))
+        password_manager.handle_export_database(
+            Path(args.file), encrypt=not args.unencrypted
+        )
         return 0
     if args.command == "import":
         password_manager.handle_import_database(Path(args.file))

--- a/src/tests/test_api_new_endpoints.py
+++ b/src/tests/test_api_new_endpoints.py
@@ -378,7 +378,7 @@ async def test_vault_export_endpoint(client, tmp_path):
     out = tmp_path / "out.json"
     out.write_text("data")
 
-    api.app.state.pm.handle_export_database = lambda: out
+    api.app.state.pm.handle_export_database = lambda *a, **k: out
 
     headers = {
         "Authorization": f"Bearer {token}",

--- a/src/tests/test_audit_logger.py
+++ b/src/tests/test_audit_logger.py
@@ -36,6 +36,7 @@ def test_audit_logger_records_events(monkeypatch, tmp_path):
     monkeypatch.setattr(manager_module, "export_backup", lambda *a, **k: dest)
     pm.vault = object()
     pm.backup_manager = object()
+    monkeypatch.setattr("seedpass.core.manager.confirm_action", lambda *_a, **_k: True)
     pm.handle_export_database(dest)
 
     confirms = iter([True, False])

--- a/src/tests/test_cli_doc_examples.py
+++ b/src/tests/test_cli_doc_examples.py
@@ -42,7 +42,7 @@ class DummyPM:
         )
         self.parent_seed = "seed"
         self.handle_display_totp_codes = lambda: None
-        self.handle_export_database = lambda path: None
+        self.handle_export_database = lambda path, **kwargs: None
         self.handle_import_database = lambda path: None
         self.change_password = lambda *a, **kw: None
         self.lock_vault = lambda: None


### PR DESCRIPTION
## Summary
- Allow portable backups to be written and restored without encryption
- Prompt for new master password when importing unencrypted backups
- Add `--unencrypted` flag to CLI export command and cover with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a66bc144f0832ba2f67f3ded25c10c