### PR TITLE
Handle configuration decryption errors gracefully

### DIFF
--- a/src/seedpass/core/encryption.py
+++ b/src/seedpass/core/encryption.py
@@ -409,11 +409,13 @@ class EncryptionManager:
             if return_kdf:
                 return data, kdf
             return data
-        except (InvalidToken, InvalidTag, JSONDecodeError) as e:
-            logger.error(
-                f"FATAL: Could not decrypt or parse data from {file_path}: {e}",
-                exc_info=True,
-            )
+        except (InvalidToken, InvalidTag) as e:
+            msg = f"Failed to decrypt or parse data from {file_path}: {e}"
+            logger.error(msg)
+            raise InvalidToken(msg) from e
+        except JSONDecodeError as e:
+            msg = f"Failed to parse JSON data from {file_path}: {e}"
+            logger.error(msg)
             raise
 
     def get_encrypted_index(self) -> Optional[bytes]:

--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -4420,6 +4420,15 @@ class PasswordManager:
             else:
                 logging.warning("Password verification failed.")
             return is_correct
+        except InvalidToken as e:
+            logging.error(f"Failed to decrypt config: {e}")
+            print(
+                colored(
+                    "Error: Could not decrypt configuration. The password may be incorrect or the file may be corrupted.",
+                    "red",
+                )
+            )
+            return False
         except Exception as e:
             logging.error(f"Error verifying password: {e}", exc_info=True)
             print(colored(f"Error: Failed to verify password: {e}", "red"))


### PR DESCRIPTION
## Summary
- improve config file decryption error handling
- provide user-facing message when password decryption fails

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a678e37204832bb871982ab99fb483