### PR TITLE
Improve readability of seed setup prompts

### DIFF
--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -624,9 +624,11 @@ class PasswordManager:
         """
         try:
             choice = input(
-                "Do you want to (1) Paste in an existing seed in full "
-                "(2) Enter an existing seed one word at a time or "
-                "(3) Generate a new seed? (1/2/3): "
+                "Choose an option:\n"
+                "1. Paste in an existing seed in full\n"
+                "2. Enter an existing seed one word at a time\n"
+                "3. Generate a new seed\n"
+                "Enter choice (1/2/3): "
             ).strip()
             if choice == "1":
                 fingerprint = self.setup_existing_seed(method="paste")
@@ -981,9 +983,12 @@ class PasswordManager:
         self.notify("No existing seed found. Let's set up a new one!", level="WARNING")
 
         choice = input(
-            "Do you want to (1) Paste in an existing seed in full "
-            "(2) Enter an existing seed one word at a time, "
-            "(3) Generate a new seed, or (4) Restore from Nostr? (1/2/3/4): "
+            "Choose an option:\n"
+            "1. Paste in an existing seed in full\n"
+            "2. Enter an existing seed one word at a time\n"
+            "3. Generate a new seed\n"
+            "4. Restore from Nostr\n"
+            "Enter choice (1/2/3/4): "
         ).strip()
 
         if choice == "1":


### PR DESCRIPTION
## Summary
- Present seed profile creation choices in a numbered list
- List new-seed setup options one per line for clarity

## Testing
- `black src/seedpass/core/manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a683c92104832b9bdc53c42a4577fa