### PR TITLE
Default offline mode and docs clarify online sync opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Recent releases derive passwords and other artifacts using a fully deterministic
 
 **⚠️ First Run Warning**
 
-Use a dedicated BIP-39 seed phrase exclusively for SeedPass. Offline Mode is **ON by default**, keeping all Nostr syncing disabled until you explicitly opt in.
+Use a dedicated BIP-39 seed phrase exclusively for SeedPass. Offline Mode is **ON by default**, keeping all Nostr syncing disabled until you explicitly opt in. To synchronize with Nostr, disable offline mode through the Settings menu or by running `seedpass config toggle-offline` and choosing to turn syncing on.
 
 ---
 ### Supported OS

--- a/docs/docs/content/01-getting-started/01-advanced_cli.md
+++ b/docs/docs/content/01-getting-started/01-advanced_cli.md
@@ -78,7 +78,7 @@ Manage the entire vault for a profile.
 
 ### Nostr Commands
 
-Interact with the Nostr network for backup and synchronization.
+Interact with the Nostr network for backup and synchronization. Offline mode is enabled by default, so disable it with `seedpass config toggle-offline` before using these commands.
 
 | Action | Command | Examples |
 | :--- | :--- | :--- |

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -83,7 +83,7 @@ maintainable while enabling a consistent experience on multiple platforms.
 - **Change Master Password:** Rotate your encryption password at any time.
 - **Checksum Verification Utilities:** Verify or regenerate the script checksum.
 - **Relay Management:** List, add, remove or reset configured Nostr relays.
-- **Offline Mode:** Disable network sync to work entirely locally.
+- **Offline Mode (default):** SeedPass runs without network sync until you explicitly enable it.
 
 ## Prerequisites
 
@@ -472,7 +472,7 @@ Back in the Settings menu you can:
   whether both the encrypted database and the script itself pass checksum
   validation.
 * Choose `14` to toggle Secret Mode and set the clipboard clear delay.
-* Select `15` to toggle Offline Mode and work locally without contacting Nostr.
+* Select `15` to toggle Offline Mode. SeedPass starts offline; disable it here to enable Nostr syncing.
 * Choose `16` to toggle Quick Unlock so subsequent actions skip the password prompt. Startup delay is unchanged.
 * Select `17` to return to the main menu.
 
@@ -566,7 +566,7 @@ Mutation testing is disabled in the GitHub workflow due to reliability issues an
 - **Multiple Seeds Management:** While managing multiple seeds adds flexibility, it also increases the responsibility to secure each seed and its associated password.
 - **No PBKDF2 Salt Required:** SeedPass deliberately omits an explicit PBKDF2 salt. Every password is derived from a unique 512-bit BIP-85 child seed, which already provides stronger per-password uniqueness than a conventional 128-bit salt.
 - **Default KDF Iterations:** New profiles start with 50,000 PBKDF2 iterations. Use `seedpass config set kdf_iterations` to change this.
-- **Offline Mode:** Disable Nostr sync to keep all operations local until you re-enable networking.
+- **Offline Mode (default):** Nostr sync is disabled until you explicitly enable it via the Settings menu or `seedpass config toggle-offline`.
   - **Quick Unlock:** Store a hashed copy of your password so future actions skip the prompt. Startup delay no longer changes. Use with caution on shared systems.
 
 ## Contributing

--- a/docs/nostr_setup.md
+++ b/docs/nostr_setup.md
@@ -1,6 +1,6 @@
 # Nostr Setup
 
-This guide explains how SeedPass uses the Nostr protocol for encrypted vault backups and how to configure relays.
+This guide explains how SeedPass uses the Nostr protocol for encrypted vault backups and how to configure relays. SeedPass starts in offline mode, so you must explicitly disable it before any network synchronization. Run `seedpass config toggle-offline` or use the Settings menu to enable online syncing.
 
 ## Relay Configuration
 

--- a/src/seedpass/core/config_manager.py
+++ b/src/seedpass/core/config_manager.py
@@ -243,7 +243,7 @@ class ConfigManager:
     def get_offline_mode(self) -> bool:
         """Retrieve the offline mode setting."""
         config = self.load_config(require_pin=False)
-        return bool(config.get("offline_mode", False))
+        return bool(config.get("offline_mode", True))
 
     def set_clipboard_clear_delay(self, delay: int) -> None:
         """Persist clipboard clear timeout in seconds."""

--- a/src/tests/test_cli_doc_examples.py
+++ b/src/tests/test_cli_doc_examples.py
@@ -77,7 +77,7 @@ class DummyPM:
             set_offline_mode=lambda v: None,
             get_secret_mode_enabled=lambda: True,
             get_clipboard_clear_delay=lambda: 30,
-            get_offline_mode=lambda: False,
+            get_offline_mode=lambda: True,
         )
         self.secret_mode_enabled = True
         self.clipboard_clear_delay = 30

--- a/src/tests/test_cli_toggle_offline_mode.py
+++ b/src/tests/test_cli_toggle_offline_mode.py
@@ -7,7 +7,7 @@ from seedpass.cli import common as cli_common
 runner = CliRunner()
 
 
-def _make_pm(called, enabled=False):
+def _make_pm(called, enabled=True):
     cfg = SimpleNamespace(
         get_offline_mode=lambda: enabled,
         set_offline_mode=lambda v: called.setdefault("enabled", v),
@@ -24,10 +24,10 @@ def test_toggle_offline_updates(monkeypatch):
     called = {}
     pm = _make_pm(called)
     monkeypatch.setattr(cli_common, "PasswordManager", lambda: pm)
-    result = runner.invoke(app, ["config", "toggle-offline"], input="y\n")
+    result = runner.invoke(app, ["config", "toggle-offline"], input="n\n")
     assert result.exit_code == 0
-    assert called == {"enabled": True}
-    assert "Offline mode enabled." in result.stdout
+    assert called == {"enabled": False}
+    assert "Offline mode disabled." in result.stdout
 
 
 def test_toggle_offline_keep(monkeypatch):


### PR DESCRIPTION
## Summary
- Default `ConfigManager.get_offline_mode` to True
- Update CLI tests for offline-first behavior
- Document that Nostr sync requires disabling offline mode

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a78078fcf4832b9c4257891989e7d0