### PR TITLE
feat: add local backup restore during seed setup

### DIFF
--- a/src/seedpass/core/backup.py
+++ b/src/seedpass/core/backup.py
@@ -145,6 +145,28 @@ class BackupManager:
                 )
             )
 
+    def restore_from_backup(self, backup_path: str) -> None:
+        """Restore the index file from a user-specified backup path."""
+        try:
+            src = Path(backup_path)
+            if not src.exists():
+                logger.error(f"Backup file '{src}' does not exist.")
+                print(colored(f"Error: Backup file '{src}' does not exist.", "red"))
+                return
+            shutil.copy2(src, self.index_file)
+            os.chmod(self.index_file, 0o600)
+            logger.info(f"Index file restored from backup '{src}'.")
+            print(colored(f"[+] Index file restored from backup '{src}'.", "green"))
+        except Exception as e:
+            logger.error(
+                f"Failed to restore from backup '{backup_path}': {e}", exc_info=True
+            )
+            print(
+                colored(
+                    f"Error: Failed to restore from backup '{backup_path}': {e}", "red"
+                )
+            )
+
     def list_backups(self) -> None:
         try:
             backup_files = sorted(

--- a/src/seedpass/core/manager.py
+++ b/src/seedpass/core/manager.py
@@ -988,7 +988,8 @@ class PasswordManager:
             "2. Enter an existing seed one word at a time\n"
             "3. Generate a new seed\n"
             "4. Restore from Nostr\n"
-            "Enter choice (1/2/3/4): "
+            "5. Restore from local backup\n"
+            "Enter choice (1/2/3/4/5): "
         ).strip()
 
         if choice == "1":
@@ -1000,6 +1001,15 @@ class PasswordManager:
         elif choice == "4":
             seed_phrase = masked_input("Enter your 12-word BIP-85 seed: ").strip()
             self.restore_from_nostr_with_guidance(seed_phrase)
+            return
+        elif choice == "5":
+            backup_path = input("Enter backup file path: ").strip()
+            if not getattr(self, "fingerprint_manager", None):
+                self.initialize_fingerprint_manager()
+            seed_phrase = masked_input("Enter your 12-word BIP-85 seed: ").strip()
+            fp = self._finalize_existing_seed(seed_phrase)
+            if fp:
+                self.backup_manager.restore_from_backup(backup_path)
             return
         else:
             print(colored("Invalid choice. Exiting.", "red"))


### PR DESCRIPTION
## Summary
- allow new seed setup to restore from a local backup
- implement `BackupManager.restore_from_backup`
- add regression tests for local backup restore option

## Testing
- `pytest src/tests/test_restore_from_nostr_setup.py::test_handle_new_seed_setup_restore_from_local_backup -q`
- `pytest src/tests/test_restore_from_nostr_setup.py::test_handle_new_seed_setup_restore_from_nostr -q`


------
https://chatgpt.com/codex/tasks/task_b_68a86f11cda8832ba325844c33c0312a