### PR TITLE
Use SeedPassError instead of sys.exit

### DIFF
--- a/src/seedpass/cli/__init__.py
+++ b/src/seedpass/cli/__init__.py
@@ -9,6 +9,7 @@ from typing import Optional
 import typer
 
 from .common import _get_services
+from seedpass.core.errors import SeedPassError
 
 app = typer.Typer(
     help="SeedPass command line interface",
@@ -47,6 +48,15 @@ app.add_typer(config.app, name="config")
 app.add_typer(fingerprint.app, name="fingerprint")
 app.add_typer(util.app, name="util")
 app.add_typer(api.app, name="api")
+
+
+def run() -> None:
+    """Invoke the CLI, handling SeedPass errors gracefully."""
+    try:
+        app()
+    except SeedPassError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from exc
 
 
 def _gui_backend_available() -> bool:
@@ -173,4 +183,4 @@ def gui(
 
 
 if __name__ == "__main__":  # pragma: no cover
-    app()
+    run()

--- a/src/seedpass/core/entry_management.py
+++ b/src/seedpass/core/entry_management.py
@@ -25,7 +25,6 @@ except Exception:  # pragma: no cover - fallback when orjson is missing
     USE_ORJSON = False
 import logging
 import hashlib
-import sys
 import shutil
 import time
 from typing import Optional, Tuple, Dict, Any, List
@@ -48,6 +47,7 @@ from utils.key_validation import (
 
 from .vault import Vault
 from .backup import BackupManager
+from .errors import SeedPassError
 
 
 # Instantiate the logger
@@ -148,7 +148,7 @@ class EntryManager:
         except Exception as e:
             logger.error(f"Error determining next index: {e}", exc_info=True)
             print(colored(f"Error determining next index: {e}", "red"))
-            sys.exit(1)
+            raise SeedPassError(f"Error determining next index: {e}") from e
 
     def add_entry(
         self,
@@ -238,7 +238,7 @@ class EntryManager:
         except Exception as e:
             logger.error(f"Failed to add entry: {e}", exc_info=True)
             print(colored(f"Error: Failed to add entry: {e}", "red"))
-            sys.exit(1)
+            raise SeedPassError(f"Failed to add entry: {e}") from e
 
     def get_next_totp_index(self) -> int:
         """Return the next available derivation index for TOTP secrets."""

--- a/src/seedpass/core/errors.py
+++ b/src/seedpass/core/errors.py
@@ -1,0 +1,21 @@
+"""Custom exceptions for SeedPass core modules.
+
+This module defines :class:`SeedPassError`, a base exception used across the
+core modules. Library code should raise this error instead of terminating the
+process with ``sys.exit`` so that callers can handle failures gracefully.
+
+When raised inside the CLI, :class:`SeedPassError` behaves like a Click
+exception, displaying a friendly message and exiting with code ``1``.
+"""
+
+from click import ClickException
+
+
+class SeedPassError(ClickException):
+    """Base exception for SeedPass-related errors."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+__all__ = ["SeedPassError"]

--- a/src/seedpass/errors.py
+++ b/src/seedpass/errors.py
@@ -1,4 +1,13 @@
-class VaultLockedError(Exception):
+"""Compatibility layer for historic exception types."""
+
+from .core.errors import SeedPassError
+
+
+class VaultLockedError(SeedPassError):
     """Raised when an operation requires an unlocked vault."""
 
-    pass
+    def __init__(self, message: str = "Vault is locked") -> None:
+        super().__init__(message)
+
+
+__all__ = ["VaultLockedError", "SeedPassError"]

--- a/src/tests/test_legacy_migration.py
+++ b/src/tests/test_legacy_migration.py
@@ -14,6 +14,7 @@ import gzip
 
 from seedpass.core.manager import PasswordManager, EncryptionMode
 from seedpass.core.vault import Vault
+from seedpass.core.errors import SeedPassError
 
 
 def test_legacy_index_migrates(monkeypatch, tmp_path: Path):
@@ -386,7 +387,7 @@ def test_declined_migration_no_sync_prompt(monkeypatch, tmp_path: Path):
 
     monkeypatch.setattr("seedpass.core.manager.confirm_action", fake_confirm)
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SeedPassError):
         pm.initialize_managers()
 
     assert calls["confirm"] == 0
@@ -425,7 +426,7 @@ def test_failed_migration_no_sync_prompt(monkeypatch, tmp_path: Path):
 
     monkeypatch.setattr("seedpass.core.manager.confirm_action", fake_confirm)
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SeedPassError):
         pm.initialize_managers()
 
     assert calls["confirm"] == 0

--- a/src/tests/test_seed_word_by_word_flow.py
+++ b/src/tests/test_seed_word_by_word_flow.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import pytest
 
 import seedpass.core.manager as manager_module
+from seedpass.core.errors import SeedPassError
 from helpers import TEST_SEED
 from utils import seed_prompt
 
@@ -86,7 +87,7 @@ def test_add_new_fingerprint_words_flow_invalid_phrase(monkeypatch):
     monkeypatch.setattr(seed_prompt, "clear_screen", lambda *_a, **_k: None)
     monkeypatch.setattr(builtins, "input", lambda *_: next(inputs))
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SeedPassError):
         pm.add_new_fingerprint()
 
     assert pm.fingerprint_manager.current_fingerprint is None


### PR DESCRIPTION
## Summary
- introduce SeedPassError for controlled error handling
- raise SeedPassError in core modules instead of calling sys.exit
- wrap CLI entry point to display errors and exit cleanly
- adjust tests to expect SeedPassError

## Testing
- `black src/seedpass/core/errors.py src/seedpass/errors.py src/seedpass/core/entry_management.py src/seedpass/core/manager.py src/seedpass/cli/__init__.py src/tests/test_seed_word_by_word_flow.py src/tests/test_legacy_migration.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a87516a20c832ba8b933131d2f958d