### PR TITLE
Run daily agent scheduler (docs-code-investigator)

### DIFF
--- a/src/seedpass/tui_v2/app.py
+++ b/src/seedpass/tui_v2/app.py
@@ -676,15 +676,11 @@ def launch_tui2(
             if kind_l in {"password", "stored_password"}:
                 context = "Entry ▣ v Reveal ▣ g QR ▣ e Edit ▣ a Archive"
             elif kind_l in {"seed", "managed_account"}:
-                context = (
-                    "Entry ▣ v Reveal (confirm) ▣ g QR ▣ e Edit ▣ a Archive"
-                )
+                context = "Entry ▣ v Reveal (confirm) ▣ g QR ▣ e Edit ▣ a Archive"
             elif kind_l == "totp":
                 context = "Entry ▣ 6 2FA Board ▣ v Reveal ▣ g QR ▣ a Archive"
             elif kind_l in {"ssh", "pgp"}:
-                context = (
-                    "Entry ▣ v Reveal (confirm) ▣ a Archive ▣ copy/export-field"
-                )
+                context = "Entry ▣ v Reveal (confirm) ▣ a Archive ▣ copy/export-field"
             elif kind_l == "nostr":
                 context = "Entry ▣ v Reveal ▣ g QR (public/private) ▣ a Archive"
             elif kind_l in {"document", "note"}:

--- a/src/tests/test_nostr_resilience_failure_modes.py
+++ b/src/tests/test_nostr_resilience_failure_modes.py
@@ -61,7 +61,9 @@ def test_sync_vault_async_sets_default_error_when_publish_returns_none() -> None
     assert pm.is_dirty is False
 
 
-def test_sync_index_from_nostr_async_notifies_last_error_when_snapshot_missing() -> None:
+def test_sync_index_from_nostr_async_notifies_last_error_when_snapshot_missing() -> (
+    None
+):
     notifications: list[tuple[str, str]] = []
 
     async def _no_snapshot():

--- a/torch/task-logs/daily/2026-03-02T22-19-00Z__docs-code-investigator__completed.md
+++ b/torch/task-logs/daily/2026-03-02T22-19-00Z__docs-code-investigator__completed.md
@@ -1,0 +1,7 @@
+---
+agent: docs-code-investigator
+platform: linux
+---
+
+Status: Success
+Learnings: MEMORY_STORED


### PR DESCRIPTION
Executed the daily agent scheduler process according to `src/prompts/scheduler-flow.md`.
Found `torch/src/prompts/scheduler-flow.md`, operating in host-repo mode.
Acquired lock for `docs-code-investigator`, produced memory artifacts, published completion, and wrote the final task log `_completed.md` for success.

---
*PR created automatically by Jules for task [12334015491229234985](https://jules.google.com/task/12334015491229234985) started by @PR0M3TH3AN*